### PR TITLE
fix: resolve linting and test errors

### DIFF
--- a/internal/guard/registry.go
+++ b/internal/guard/registry.go
@@ -2,7 +2,6 @@ package guard
 
 import (
 	"fmt"
-	"log"
 	"sync"
 
 	"github.com/githubnext/gh-aw-mcpg/internal/logger"


### PR DESCRIPTION
- Remove unused 'log' import from guard/registry.go that conflicted with context.go's logger variable
- Update transport_test.go to use new responseWriter type API:
  - Use newResponseWriter() constructor instead of struct literal
  - Use StatusCode() and Body() methods instead of direct field access
  - Remove obsolete MultipleWrites_FirstWins test case
- Fix health endpoint test to expect 'servers' field (not 'protocolVersion')
- Fix MCP GET test to expect 400 (session required) instead of 405