### PR TITLE
refactor: use tagged switch for status code comparison (QF1003)

### DIFF
--- a/internal/server/transport_test.go
+++ b/internal/server/transport_test.go
@@ -416,10 +416,11 @@ func TestCreateHTTPServerForMCP_Close(t *testing.T) {
 
 			// Verify response based on error expectation
 			if tt.wantError {
-				if tt.wantStatusCode == http.StatusMethodNotAllowed {
+				switch tt.wantStatusCode {
+				case http.StatusMethodNotAllowed:
 					// http.Error writes plain text for 405
 					assert.Contains(t, w.Body.String(), "Method not allowed")
-				} else if tt.wantStatusCode == http.StatusUnauthorized {
+				case http.StatusUnauthorized:
 					assert.Contains(t, w.Body.String(), "Unauthorized")
 				}
 			} else {


### PR DESCRIPTION
Convert if-else chain to switch statement for cleaner code per staticcheck QF1003 recommendation.