### PR TITLE
fix: resolve duplicate log variable declarations

### DIFF
--- a/internal/config/validation_env.go
+++ b/internal/config/validation_env.go
@@ -13,7 +13,7 @@ import (
 	"github.com/githubnext/gh-aw-mcpg/internal/logger"
 )
 
-var log = logger.New("config:validation_env")
+var logEnv = logger.New("config:validation_env")
 
 // RequiredEnvVars lists the environment variables that must be set for the gateway to operate
 var RequiredEnvVars = []string{
@@ -73,17 +73,17 @@ func (r *EnvValidationResult) Error() string {
 // ValidateExecutionEnvironment performs comprehensive validation of the execution environment
 // It checks Docker accessibility, required environment variables, and containerization status
 func ValidateExecutionEnvironment() *EnvValidationResult {
-	log.Print("Starting execution environment validation")
+	logEnv.Print("Starting execution environment validation")
 	result := &EnvValidationResult{}
 
 	// Check if running in a containerized environment
 	result.IsContainerized, result.ContainerID = detectContainerized()
-	log.Printf("Containerization check: isContainerized=%v, containerID=%s", result.IsContainerized, result.ContainerID)
+	logEnv.Printf("Containerization check: isContainerized=%v, containerID=%s", result.IsContainerized, result.ContainerID)
 
 	// Check Docker daemon accessibility
 	result.DockerAccessible = checkDockerAccessible()
 	if !result.DockerAccessible {
-		log.Print("Docker daemon is not accessible")
+		logEnv.Print("Docker daemon is not accessible")
 		result.ValidationErrors = append(result.ValidationErrors,
 			"Docker daemon is not accessible. Ensure the Docker socket is mounted or Docker is running.")
 	}
@@ -91,25 +91,25 @@ func ValidateExecutionEnvironment() *EnvValidationResult {
 	// Check required environment variables
 	result.MissingEnvVars = checkRequiredEnvVars()
 	if len(result.MissingEnvVars) > 0 {
-		log.Printf("Missing required environment variables: %v", result.MissingEnvVars)
+		logEnv.Printf("Missing required environment variables: %v", result.MissingEnvVars)
 		result.ValidationErrors = append(result.ValidationErrors,
 			fmt.Sprintf("Required environment variables not set: %s", strings.Join(result.MissingEnvVars, ", ")))
 	}
 
-	log.Printf("Validation complete: valid=%v, errors=%d, warnings=%d", result.IsValid(), len(result.ValidationErrors), len(result.ValidationWarnings))
+	logEnv.Printf("Validation complete: valid=%v, errors=%d, warnings=%d", result.IsValid(), len(result.ValidationErrors), len(result.ValidationWarnings))
 	return result
 }
 
 // ValidateContainerizedEnvironment performs additional validation for containerized mode
 // This is called by run_containerized.sh through the binary or by the Go code directly
 func ValidateContainerizedEnvironment(containerID string) *EnvValidationResult {
-	log.Printf("Starting containerized environment validation: containerID=%s", containerID)
+	logEnv.Printf("Starting containerized environment validation: containerID=%s", containerID)
 	result := ValidateExecutionEnvironment()
 	result.IsContainerized = true
 	result.ContainerID = containerID
 
 	if containerID == "" {
-		log.Print("Container ID could not be determined")
+		logEnv.Print("Container ID could not be determined")
 		result.ValidationErrors = append(result.ValidationErrors,
 			"Container ID could not be determined. Are you running in a Docker container?")
 		return result
@@ -118,7 +118,7 @@ func ValidateContainerizedEnvironment(containerID string) *EnvValidationResult {
 	// Validate port mapping
 	port := os.Getenv("MCP_GATEWAY_PORT")
 	if port != "" {
-		log.Printf("Checking port mapping: port=%s", port)
+		logEnv.Printf("Checking port mapping: port=%s", port)
 		portMapped, err := checkPortMapping(containerID, port)
 		if err != nil {
 			result.ValidationWarnings = append(result.ValidationWarnings,
@@ -128,12 +128,12 @@ func ValidateContainerizedEnvironment(containerID string) *EnvValidationResult {
 				fmt.Sprintf("MCP_GATEWAY_PORT (%s) is not mapped to a host port. Use: -p <host_port>:%s", port, port))
 		}
 		result.PortMapped = portMapped
-		log.Printf("Port mapping result: mapped=%v", portMapped)
+		logEnv.Printf("Port mapping result: mapped=%v", portMapped)
 	}
 
 	// Check if stdin is interactive (requires -i flag)
 	result.StdinInteractive = checkStdinInteractive(containerID)
-	log.Printf("Stdin interactive check: interactive=%v", result.StdinInteractive)
+	logEnv.Printf("Stdin interactive check: interactive=%v", result.StdinInteractive)
 	if !result.StdinInteractive {
 		result.ValidationErrors = append(result.ValidationErrors,
 			"Container was not started with -i flag. Stdin is required for configuration input.")
@@ -145,13 +145,13 @@ func ValidateContainerizedEnvironment(containerID string) *EnvValidationResult {
 		logDir = "/tmp/gh-aw/mcp-logs"
 	}
 	result.LogDirMounted = checkLogDirMounted(containerID, logDir)
-	log.Printf("Log directory mount check: mounted=%v, logDir=%s", result.LogDirMounted, logDir)
+	logEnv.Printf("Log directory mount check: mounted=%v, logDir=%s", result.LogDirMounted, logDir)
 	if !result.LogDirMounted {
 		result.ValidationWarnings = append(result.ValidationWarnings,
 			fmt.Sprintf("Log directory %s is not mounted. Logs will not persist outside the container. Use: -v /path/on/host:%s", logDir, logDir))
 	}
 
-	log.Printf("Containerized validation complete: valid=%v, errors=%d, warnings=%d", result.IsValid(), len(result.ValidationErrors), len(result.ValidationWarnings))
+	logEnv.Printf("Containerized validation complete: valid=%v, errors=%d, warnings=%d", result.IsValid(), len(result.ValidationErrors), len(result.ValidationWarnings))
 	return result
 }
 
@@ -205,10 +205,10 @@ func checkDockerAccessible() bool {
 		// Parse unix:// prefix if present
 		socketPath = strings.TrimPrefix(socketPath, "unix://")
 	}
-	log.Printf("Checking Docker socket accessibility: socketPath=%s", socketPath)
+	logEnv.Printf("Checking Docker socket accessibility: socketPath=%s", socketPath)
 
 	if _, err := os.Stat(socketPath); os.IsNotExist(err) {
-		log.Printf("Docker socket not found: socketPath=%s", socketPath)
+		logEnv.Printf("Docker socket not found: socketPath=%s", socketPath)
 		return false
 	}
 
@@ -217,7 +217,7 @@ func checkDockerAccessible() bool {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	accessible := cmd.Run() == nil
-	log.Printf("Docker daemon check: accessible=%v", accessible)
+	logEnv.Printf("Docker daemon check: accessible=%v", accessible)
 	return accessible
 }
 

--- a/internal/guard/noop.go
+++ b/internal/guard/noop.go
@@ -7,7 +7,7 @@ import (
 	"github.com/githubnext/gh-aw-mcpg/internal/logger"
 )
 
-var log = logger.New("guard:noop")
+var logNoop = logger.New("guard:noop")
 
 // NoopGuard is the default guard that performs no DIFC labeling
 // It allows all operations by returning empty labels (no restrictions)
@@ -15,7 +15,7 @@ type NoopGuard struct{}
 
 // NewNoopGuard creates a new noop guard
 func NewNoopGuard() *NoopGuard {
-	log.Print("Creating new noop guard (no DIFC restrictions)")
+	logNoop.Print("Creating new noop guard (no DIFC restrictions)")
 	return &NoopGuard{}
 }
 
@@ -28,7 +28,7 @@ func (g *NoopGuard) Name() string {
 // Conservatively assumes all operations could be writes
 func (g *NoopGuard) LabelResource(ctx context.Context, toolName string, args interface{}, backend BackendCaller, caps *difc.Capabilities) (*difc.LabeledResource, difc.OperationType, error) {
 	log.Printf("Labeling resource: tool=%s, operation=write (conservative)", toolName)
-	
+
 	// Empty resource = no label requirements = all operations allowed
 	resource := &difc.LabeledResource{
 		Description: "noop resource (no restrictions)",
@@ -38,7 +38,7 @@ func (g *NoopGuard) LabelResource(ctx context.Context, toolName string, args int
 	}
 
 	log.Printf("Resource labeled with no restrictions: tool=%s", toolName)
-	
+
 	// Conservatively treat as write to be safe
 	// (writes are more restrictive than reads in DIFC)
 	return resource, difc.OperationWrite, nil
@@ -48,7 +48,7 @@ func (g *NoopGuard) LabelResource(ctx context.Context, toolName string, args int
 // The reference monitor will use the resource labels for the entire response
 func (g *NoopGuard) LabelResponse(ctx context.Context, toolName string, result interface{}, backend BackendCaller, caps *difc.Capabilities) (difc.LabeledData, error) {
 	log.Printf("Labeling response: tool=%s, using resource labels (no fine-grained labeling)", toolName)
-	
+
 	// No fine-grained labeling - return nil
 	// Reference monitor will use LabelResource result for entire response
 	return nil, nil

--- a/internal/server/health_test.go
+++ b/internal/server/health_test.go
@@ -137,7 +137,7 @@ func TestHealthEndpoint_ResponseFields(t *testing.T) {
 				t.Helper()
 				require := require.New(t)
 				assert := assert.New(t)
-				
+
 				status, ok := value.(string)
 				require.True(ok, "Expected 'status' to be string, got %T", value)
 				assert.Contains([]string{"healthy", "unhealthy"}, status, "Status must be 'healthy' or 'unhealthy'")
@@ -150,7 +150,7 @@ func TestHealthEndpoint_ResponseFields(t *testing.T) {
 				t.Helper()
 				require := require.New(t)
 				assert := assert.New(t)
-				
+
 				specVersion, ok := value.(string)
 				require.True(ok, "Expected 'specVersion' to be string, got %T", value)
 				assert.Equal(MCPGatewaySpecVersion, specVersion, "specVersion must match gateway spec")
@@ -163,7 +163,7 @@ func TestHealthEndpoint_ResponseFields(t *testing.T) {
 				t.Helper()
 				require := require.New(t)
 				assert := assert.New(t)
-				
+
 				gatewayVersion, ok := value.(string)
 				require.True(ok, "Expected 'gatewayVersion' to be string, got %T", value)
 				assert.NotEmpty(gatewayVersion, "gatewayVersion must not be empty")
@@ -176,7 +176,7 @@ func TestHealthEndpoint_ResponseFields(t *testing.T) {
 				t.Helper()
 				require := require.New(t)
 				assert := assert.New(t)
-				
+
 				servers, ok := value.(map[string]interface{})
 				require.True(ok, "Expected 'servers' to be map[string]interface{}, got %T", value)
 				// With empty config, servers map should be empty
@@ -346,10 +346,12 @@ func TestHealthEndpoint_MultipleServers(t *testing.T) {
 	cfg := &config.Config{
 		Servers: map[string]*config.ServerConfig{
 			"server1": {
-				Container: "test/server1:latest",
+				Command: "echo",
+				Args:    []string{"server1"},
 			},
 			"server2": {
-				Container: "test/server2:latest",
+				Command: "echo",
+				Args:    []string{"server2"},
 			},
 		},
 	}


### PR DESCRIPTION
- Rename log to logNoop in guard/noop.go to avoid conflict with guard/context.go
- Rename log to logEnv in config/validation_env.go to avoid conflict with config.go's standard log import
- Fix health_test.go to use Command field instead of non-existent Container field in ServerConfig