### PR TITLE
fix: staticcheck linting error and schema normalization

### DIFF
--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -71,8 +71,27 @@ func NormalizeInputSchema(schema map[string]interface{}, toolName string) map[st
 
 	// Check if this is an object type schema
 	typeVal, hasType := schema["type"]
+
+	// If schema has no type but has properties, it's implicitly an object type
+	// The MCP SDK requires "type": "object" to be present, so add it
 	if !hasType {
-		return schema
+		_, hasProperties := schema["properties"]
+		if hasProperties {
+			logger.LogWarn("backend", "Tool schema normalized: %s - added 'type': 'object' to schema with properties", toolName)
+			// Create a copy of the schema to avoid modifying the original
+			normalized := make(map[string]interface{})
+			for k, v := range schema {
+				normalized[k] = v
+			}
+			normalized["type"] = "object"
+			return normalized
+		}
+		// Schema without type and without properties - assume it's an empty object schema
+		logger.LogWarn("backend", "Tool schema normalized: %s - schema missing type, assuming empty object schema", toolName)
+		return map[string]interface{}{
+			"type":       "object",
+			"properties": map[string]interface{}{},
+		}
 	}
 
 	typeStr, isString := typeVal.(string)

--- a/internal/mcp/types_test.go
+++ b/internal/mcp/types_test.go
@@ -22,7 +22,12 @@ func TestNormalizeInputSchema_NilSchema(t *testing.T) {
 func TestNormalizeInputSchema_EmptySchema(t *testing.T) {
 	schema := map[string]interface{}{}
 	result := NormalizeInputSchema(schema, "test-tool")
-	assert.Equal(t, schema, result, "Empty schema should be unchanged")
+	// Empty schema should be normalized to a valid object schema since SDK requires type: object
+	expected := map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{},
+	}
+	assert.Equal(t, expected, result, "Empty schema should be normalized to object schema")
 }
 
 func TestNormalizeInputSchema_NonObjectType(t *testing.T) {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -244,9 +244,10 @@ func TestHandleClose_MultipleRequests(t *testing.T) {
 	goneCount := 0
 
 	for _, rec := range responses {
-		if rec.Code == http.StatusOK {
+		switch rec.Code {
+		case http.StatusOK:
 			okCount++
-		} else if rec.Code == http.StatusGone {
+		case http.StatusGone:
 			goneCount++
 		}
 	}

--- a/internal/server/http_helpers.go
+++ b/internal/server/http_helpers.go
@@ -18,7 +18,7 @@ var logHelpers = logger.New("server:helpers")
 // and logs connection details. Returns empty string if validation fails.
 func extractAndValidateSession(r *http.Request) string {
 	logHelpers.Printf("Extracting session from request: remote=%s, path=%s", r.RemoteAddr, r.URL.Path)
-	
+
 	authHeader := r.Header.Get("Authorization")
 	sessionID := auth.ExtractSessionID(authHeader)
 
@@ -38,7 +38,7 @@ func extractAndValidateSession(r *http.Request) string {
 // The backendID parameter is optional and can be empty for unified mode.
 func logHTTPRequestBody(r *http.Request, sessionID, backendID string) {
 	logHelpers.Printf("Checking request body: method=%s, hasBody=%v, sessionID=%s", r.Method, r.Body != nil, sessionID)
-	
+
 	if r.Method != "POST" || r.Body == nil {
 		logHelpers.Printf("Skipping body logging: not a POST request or no body present")
 		return
@@ -70,7 +70,7 @@ func logHTTPRequestBody(r *http.Request, sessionID, backendID string) {
 // Returns the modified request with updated context.
 func injectSessionContext(r *http.Request, sessionID, backendID string) *http.Request {
 	logHelpers.Printf("Injecting session context: sessionID=%s, backendID=%s", sessionID, backendID)
-	
+
 	ctx := context.WithValue(r.Context(), SessionIDContextKey, sessionID)
 
 	if backendID != "" {

--- a/internal/server/register_tools_from_backend_test.go
+++ b/internal/server/register_tools_from_backend_test.go
@@ -491,7 +491,7 @@ func TestRegisterToolsFromBackend_ToolNaming(t *testing.T) {
 
 	tool := us.tools["my-server___my_tool"]
 	require.NotNil(tool, "Tool should be registered with prefixed name")
-	
+
 	// Verify naming convention
 	assert.Equal("my-server___my_tool", tool.Name, "Tool name should be prefixed with server ID")
 	assert.Equal("[my-server] Does something useful", tool.Description, "Description should include backend info")
@@ -584,11 +584,11 @@ func TestRegisterToolsFromBackend_SchemaNormalization(t *testing.T) {
 
 	tool := us.tools["schema-backend___schema_tool"]
 	require.NotNil(tool)
-	
+
 	// Verify schema was normalized (should have "type": "object" added)
 	schema := tool.InputSchema
 	require.NotNil(schema)
-	
+
 	schemaType, ok := schema["type"]
 	assert.True(ok, "Schema should have 'type' field after normalization")
 	assert.Equal("object", schemaType, "Schema type should be 'object'")


### PR DESCRIPTION
- Convert if/else chain to switch statement in handlers_test.go (QF1003)
- Fix NormalizeInputSchema to add 'type: object' when missing (required by go-sdk AddTool validation)
- Update types_test.go to expect normalized empty schemas