### PR TITLE
fix: resolve build errors and lint warnings

### DIFF
--- a/internal/logger/slog_adapter_test.go
+++ b/internal/logger/slog_adapter_test.go
@@ -478,7 +478,7 @@ func TestSlogHandler_Handle_EdgeCases(t *testing.T) {
 		handler := NewSlogHandler(logger)
 
 		// Enabled should work with nil context (underscore param means it's ignored)
-		enabled := handler.Enabled(nil, slog.LevelInfo)
+		enabled := handler.Enabled(context.TODO(), slog.LevelInfo)
 		assert.Equal(logger.Enabled(), enabled)
 	})
 }

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -6,7 +6,7 @@ import (
 	"github.com/github/gh-aw-mcpg/internal/logger"
 )
 
-var log = logger.New("mcp:types")
+var logTypes = logger.New("mcp:types")
 
 // Request represents a JSON-RPC 2.0 request
 type Request struct {
@@ -61,12 +61,12 @@ type ContentItem struct {
 //     but is missing the required "properties" field, we add an empty properties
 //     object to make it valid per JSON Schema standards.
 func NormalizeInputSchema(schema map[string]interface{}, toolName string) map[string]interface{} {
-	log.Printf("Normalizing input schema for tool: %s", toolName)
-	
+	logTypes.Printf("Normalizing input schema for tool: %s", toolName)
+
 	// If backend didn't provide a schema, use a default empty object schema
 	// This allows the tool to be registered and clients will see it accepts any parameters
 	if schema == nil {
-		log.Printf("Tool %s has nil schema, applying default empty object schema", toolName)
+		logTypes.Printf("Tool %s has nil schema, applying default empty object schema", toolName)
 		logger.LogWarn("backend", "Tool schema normalized: %s - backend provided no inputSchema, using default empty object schema", toolName)
 		return map[string]interface{}{
 			"type":       "object",
@@ -77,13 +77,13 @@ func NormalizeInputSchema(schema map[string]interface{}, toolName string) map[st
 	// Check if this is an object type schema
 	typeVal, hasType := schema["type"]
 
-	log.Printf("Tool %s schema analysis: hasType=%v", toolName, hasType)
-	
+	logTypes.Printf("Tool %s schema analysis: hasType=%v", toolName, hasType)
+
 	// If schema has no type but has properties, it's implicitly an object type
 	// The MCP SDK requires "type": "object" to be present, so add it
 	if !hasType {
 		_, hasProperties := schema["properties"]
-		log.Printf("Tool %s has no type field, hasProperties=%v", toolName, hasProperties)
+		logTypes.Printf("Tool %s has no type field, hasProperties=%v", toolName, hasProperties)
 		if hasProperties {
 			logger.LogWarn("backend", "Tool schema normalized: %s - added 'type': 'object' to schema with properties", toolName)
 			// Create a copy of the schema to avoid modifying the original
@@ -92,11 +92,11 @@ func NormalizeInputSchema(schema map[string]interface{}, toolName string) map[st
 				normalized[k] = v
 			}
 			normalized["type"] = "object"
-			log.Printf("Tool %s schema normalized: added object type", toolName)
+			logTypes.Printf("Tool %s schema normalized: added object type", toolName)
 			return normalized
 		}
 		// Schema without type and without properties - assume it's an empty object schema
-		log.Printf("Tool %s has no type and no properties, using empty object schema", toolName)
+		logTypes.Printf("Tool %s has no type and no properties, using empty object schema", toolName)
 		logger.LogWarn("backend", "Tool schema normalized: %s - schema missing type, assuming empty object schema", toolName)
 		return map[string]interface{}{
 			"type":       "object",
@@ -106,7 +106,7 @@ func NormalizeInputSchema(schema map[string]interface{}, toolName string) map[st
 
 	typeStr, isString := typeVal.(string)
 	if !isString || typeStr != "object" {
-		log.Printf("Tool %s has non-object type or invalid type value, returning schema as-is", toolName)
+		logTypes.Printf("Tool %s has non-object type or invalid type value, returning schema as-is", toolName)
 		return schema
 	}
 
@@ -114,9 +114,9 @@ func NormalizeInputSchema(schema map[string]interface{}, toolName string) map[st
 	_, hasProperties := schema["properties"]
 	_, hasAdditionalProperties := schema["additionalProperties"]
 
-	log.Printf("Tool %s object type schema: hasProperties=%v, hasAdditionalProperties=%v", 
+	logTypes.Printf("Tool %s object type schema: hasProperties=%v, hasAdditionalProperties=%v",
 		toolName, hasProperties, hasAdditionalProperties)
-	
+
 	// If it's an object type but missing both properties and additionalProperties,
 	// add an empty properties object to make it valid
 	if !hasProperties && !hasAdditionalProperties {
@@ -129,10 +129,10 @@ func NormalizeInputSchema(schema map[string]interface{}, toolName string) map[st
 		}
 		normalized["properties"] = map[string]interface{}{}
 
-		log.Printf("Tool %s schema normalized: added empty properties field", toolName)
+		logTypes.Printf("Tool %s schema normalized: added empty properties field", toolName)
 		return normalized
 	}
 
-	log.Printf("Tool %s schema is valid, no normalization needed", toolName)
+	logTypes.Printf("Tool %s schema is valid, no normalization needed", toolName)
 	return schema
 }


### PR DESCRIPTION
- Rename 'log' to 'logTypes' in internal/mcp/types.go to avoid conflict with standard log package import in connection.go
- Fix SA1012 staticcheck warning in slog_adapter_test.go by replacing nil context with context.TODO()