### PR TITLE
feat: capture and log container stderr when MCP connection fails

### DIFF
--- a/internal/mcp/connection.go
+++ b/internal/mcp/connection.go
@@ -190,6 +190,12 @@ func NewConnection(ctx context.Context, command string, args []string, env map[s
 		}
 	}
 
+	// Capture stderr to help diagnose container failures
+	// The SDK's CommandTransport only uses stdin/stdout for MCP protocol,
+	// so we can capture stderr separately for debugging
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
 	logger.LogInfo("backend", "Starting MCP backend server, command=%s, args=%v", command, sanitize.SanitizeArgs(expandedArgs))
 	log.Printf("Starting MCP server command: %s %v", command, sanitize.SanitizeArgs(expandedArgs))
 	transport := &sdk.CommandTransport{Command: cmd}
@@ -207,6 +213,16 @@ func NewConnection(ctx context.Context, command string, args []string, env map[s
 		log.Printf("   Command: %s", command)
 		log.Printf("   Args: %v", sanitize.SanitizeArgs(expandedArgs))
 		log.Printf("   Error: %v", err)
+
+		// Log captured stderr output from the container/process
+		stderrOutput := strings.TrimSpace(stderrBuf.String())
+		if stderrOutput != "" {
+			logger.LogErrorMd("backend", "MCP backend stderr output:\n%s", stderrOutput)
+			log.Printf("   📋 Container/Process stderr output:")
+			for _, line := range strings.Split(stderrOutput, "\n") {
+				log.Printf("      %s", line)
+			}
+		}
 
 		// Check if it's a command not found error
 		if strings.Contains(err.Error(), "executable file not found") ||


### PR DESCRIPTION
When a container/process fails to launch, the stderr output is now captured and logged to help diagnose issues. This is particularly useful for debugging container startup failures where the error message is written to stderr.

The SDK's CommandTransport only uses stdin/stdout for the MCP protocol, so we can safely capture stderr separately for debugging purposes.