### PR TITLE
fix: use Docker server's current API version instead of minimum

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -90,15 +90,25 @@ check_optional_env_vars() {
     fi
 }
 
-# Set DOCKER_API_VERSION based on architecture
+# Set DOCKER_API_VERSION based on Docker daemon's current API version
 set_docker_api_version() {
-    local arch=$(uname -m)
-    if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
-        export DOCKER_API_VERSION=1.43
+    # Get the server's current API version (what it actually supports)
+    local server_api=$(docker version --format '{{.Server.APIVersion}}' 2>/dev/null || echo "")
+    
+    if [ -n "$server_api" ]; then
+        # Use the server's current API version for full compatibility
+        export DOCKER_API_VERSION="$server_api"
+        log_info "Set DOCKER_API_VERSION=$DOCKER_API_VERSION (server current)"
     else
-        export DOCKER_API_VERSION=1.44
+        # Fallback: set based on architecture
+        local arch=$(uname -m)
+        if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
+            export DOCKER_API_VERSION=1.44
+        else
+            export DOCKER_API_VERSION=1.44
+        fi
+        log_info "Set DOCKER_API_VERSION=$DOCKER_API_VERSION for $arch (fallback)"
     fi
-    log_info "Set DOCKER_API_VERSION=$DOCKER_API_VERSION for $arch"
 }
 
 # Main execution

--- a/run_containerized.sh
+++ b/run_containerized.sh
@@ -227,13 +227,13 @@ validate_log_directory_mount() {
 
 # Set DOCKER_API_VERSION based on architecture and Docker daemon requirements
 set_docker_api_version() {
-    # First, check what the Docker daemon requires as minimum API version
-    local min_api=$(docker version --format '{{.Server.MinAPIVersion}}' 2>/dev/null || echo "")
+    # Get the server's current API version (what it actually supports)
+    local server_api=$(docker version --format '{{.Server.APIVersion}}' 2>/dev/null || echo "")
     
-    if [ -n "$min_api" ]; then
-        # Use the daemon's minimum API version to ensure compatibility
-        export DOCKER_API_VERSION="$min_api"
-        log_info "Set DOCKER_API_VERSION=$DOCKER_API_VERSION (daemon minimum)"
+    if [ -n "$server_api" ]; then
+        # Use the server's current API version for full compatibility
+        export DOCKER_API_VERSION="$server_api"
+        log_info "Set DOCKER_API_VERSION=$DOCKER_API_VERSION (server current)"
     else
         # Fallback: set based on architecture
         local arch=$(uname -m)


### PR DESCRIPTION
The scripts were setting DOCKER_API_VERSION to the server's minimum supported version, which could cause compatibility issues when the Docker client SDK requires a higher version.

Now auto-detects the server's current API version for full compatibility, with fallback to 1.44 if detection fails.