### PR TITLE
fix(middleware): use world-readable permissions for payload files

### DIFF
--- a/internal/middleware/jqschema.go
+++ b/internal/middleware/jqschema.go
@@ -129,12 +129,12 @@ func savePayload(baseDir, sessionID, queryID string, payload []byte) (string, er
 	logger.LogDebug("payload", "Creating payload directory: baseDir=%s, session=%s, query=%s, fullPath=%s",
 		baseDir, sessionID, queryID, dir)
 
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		logger.LogError("payload", "Failed to create payload directory: path=%s, error=%v", dir, err)
 		return "", fmt.Errorf("failed to create payload directory: %w", err)
 	}
 
-	logger.LogDebug("payload", "Successfully created payload directory: path=%s, permissions=0700", dir)
+	logger.LogDebug("payload", "Successfully created payload directory: path=%s, permissions=0755", dir)
 
 	// Save payload to file with restrictive permissions (owner read/write only)
 	filePath := filepath.Join(dir, "payload.json")
@@ -143,13 +143,13 @@ func savePayload(baseDir, sessionID, queryID string, payload []byte) (string, er
 	logger.LogInfo("payload", "Writing large payload to filesystem: path=%s, size=%d bytes (%.2f KB, %.2f MB)",
 		filePath, payloadSize, float64(payloadSize)/1024, float64(payloadSize)/(1024*1024))
 
-	if err := os.WriteFile(filePath, payload, 0600); err != nil {
+	if err := os.WriteFile(filePath, payload, 0644); err != nil {
 		logger.LogError("payload", "Failed to write payload file: path=%s, size=%d bytes, error=%v",
 			filePath, payloadSize, err)
 		return "", fmt.Errorf("failed to write payload file: %w", err)
 	}
 
-	logger.LogInfo("payload", "Successfully saved large payload to filesystem: path=%s, size=%d bytes, permissions=0600",
+	logger.LogInfo("payload", "Successfully saved large payload to filesystem: path=%s, size=%d bytes, permissions=0644",
 		filePath, payloadSize)
 
 	// Verify file was written correctly

--- a/internal/middleware/jqschema_test.go
+++ b/internal/middleware/jqschema_test.go
@@ -496,12 +496,12 @@ func TestPayloadStorage_FilePermissions(t *testing.T) {
 	dirPath := filepath.Dir(filePath)
 	dirInfo, err := os.Stat(dirPath)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0700), dirInfo.Mode().Perm(), "Directory should have 0700 permissions")
+	assert.Equal(t, os.FileMode(0755), dirInfo.Mode().Perm(), "Directory should have 0755 permissions")
 
 	// Check file permissions
 	fileInfo, err := os.Stat(filePath)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0600), fileInfo.Mode().Perm(), "File should have 0600 permissions")
+	assert.Equal(t, os.FileMode(0644), fileInfo.Mode().Perm(), "File should have 0644 permissions")
 }
 
 // TestPayloadStorage_DefaultSessionID verifies behavior when session ID is empty

--- a/internal/server/unified.go
+++ b/internal/server/unified.go
@@ -811,8 +811,8 @@ func (us *UnifiedServer) ensureSessionDirectory(sessionID string) error {
 		return fmt.Errorf("failed to check session directory: %w", err)
 	}
 
-	// Directory doesn't exist, create it with restrictive permissions (owner-only access)
-	if err := os.MkdirAll(sessionDir, 0700); err != nil {
+	// Directory doesn't exist, create it with world-readable permissions (for agent access)
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
 		return fmt.Errorf("failed to create session directory: %w", err)
 	}
 

--- a/internal/server/unified_test.go
+++ b/internal/server/unified_test.go
@@ -549,8 +549,8 @@ func TestUnifiedServer_EnsureSessionDirectory(t *testing.T) {
 	require.NoError(t, err, "Session directory should exist")
 	assert.True(t, info.IsDir(), "Session path should be a directory")
 
-	// Verify directory has correct permissions (0700)
-	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "Session directory should have 0700 permissions")
+	// Verify directory has correct permissions (0755 - world-readable for agent access)
+	assert.Equal(t, os.FileMode(0755), info.Mode().Perm(), "Session directory should have 0755 permissions")
 
 	// Test that calling ensureSessionDirectory again doesn't fail (idempotent)
 	err = us.ensureSessionDirectory(sessionID)


### PR DESCRIPTION
- Change directory permissions from 0700 to 0755
- Change file permissions from 0600 to 0644
- Allows agents running in containers to read payload files