### PR TITLE
refactor: Improve PayloadMetadata schema and fix flaky playwright test

### DIFF
--- a/internal/middleware/README.md
+++ b/internal/middleware/README.md
@@ -51,10 +51,10 @@ The middleware is automatically applied to all backend MCP server tools (except 
 **Transformed response:**
 ```json
 {
-  "queryID": "a1b2c3d4e5f6...",
+  "agentInstructions": "The payload was too large for an MCP response. The payloadSchema approximates the structure of the full payload. The full response can be accessed through the local file system at the payloadPath.",
   "payloadPath": "/tmp/gh-awmg/tools-calls/a1b2c3d4e5f6.../payload.json",
-  "preview": "{\"total_count\":1000,\"items\":[{\"login\":\"user1\",\"id\":123,\"verified\":true}...",
-  "schema": {
+  "payloadPreview": "{\"total_count\":1000,\"items\":[{\"login\":\"user1\",\"id\":123,\"verified\":true}...",
+  "payloadSchema": {
     "total_count": "number",
     "items": [
       {
@@ -64,8 +64,7 @@ The middleware is automatically applied to all backend MCP server tools (except 
       }
     ]
   },
-  "originalSize": 234,
-  "truncated": false
+  "originalSize": 234
 }
 ```
 

--- a/internal/middleware/jqschema.go
+++ b/internal/middleware/jqschema.go
@@ -19,18 +19,17 @@ var logMiddleware = logger.New("middleware:jqschema")
 
 // PayloadTruncatedInstructions is the message returned to clients when a payload
 // has been truncated and saved to the filesystem
-const PayloadTruncatedInstructions = "The payload was too large for an MCP response. The full response can be accessed through the local file system at the payloadPath."
+const PayloadTruncatedInstructions = "The payload was too large for an MCP response. The payloadSchema approximates the structure of the full payload. The full response can be accessed through the local file system at the payloadPath."
 
 // PayloadMetadata represents the metadata response returned when a payload is too large
 // and has been saved to the filesystem
 type PayloadMetadata struct {
-	QueryID      string      `json:"queryID"`
-	PayloadPath  string      `json:"payloadPath"`
-	Preview      string      `json:"preview"`
-	Schema       interface{} `json:"schema"`
-	OriginalSize int         `json:"originalSize"`
-	Truncated    bool        `json:"truncated"`
-	Instructions string      `json:"instructions"`
+	AgentInstructions string      `json:"agentInstructions"`
+	PayloadPath       string      `json:"payloadPath"`
+	PayloadPreview    string      `json:"payloadPreview"`
+	PayloadSchema     interface{} `json:"payloadSchema"`
+	OriginalSize      int         `json:"originalSize"`
+	QueryID           string      `json:"-"` // Internal use only, not serialized to clients
 }
 
 // jqSchemaFilter is the jq filter that transforms JSON to schema
@@ -303,13 +302,12 @@ func WrapToolHandler(
 
 		// Create rewritten response using the PayloadMetadata struct
 		rewrittenResponse := PayloadMetadata{
-			QueryID:      queryID,
-			PayloadPath:  filePath,
-			Preview:      preview,
-			Schema:       schemaObj,
-			OriginalSize: len(payloadJSON),
-			Truncated:    truncated,
-			Instructions: PayloadTruncatedInstructions,
+			AgentInstructions: PayloadTruncatedInstructions,
+			PayloadPath:       filePath,
+			PayloadPreview:    preview,
+			PayloadSchema:     schemaObj,
+			OriginalSize:      len(payloadJSON),
+			QueryID:           queryID,
 		}
 
 		logMiddleware.Printf("Rewritten response: tool=%s, queryID=%s, sessionID=%s, originalSize=%d, truncated=%v",

--- a/internal/middleware/jqschema_integration_test.go
+++ b/internal/middleware/jqschema_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -90,39 +91,24 @@ func TestMiddlewareIntegration(t *testing.T) {
 	err = json.Unmarshal([]byte(textContent.Text), &contentMap)
 	require.NoError(t, err, "Content should be valid JSON")
 
-	// Verify all required fields exist in Content
-	assert.Contains(t, contentMap, "queryID", "Content should contain queryID")
+	// Verify all required fields exist in Content (queryID is excluded from JSON via json:"-")
 	assert.Contains(t, contentMap, "payloadPath", "Content should contain payloadPath")
-	assert.Contains(t, contentMap, "preview", "Content should contain preview")
-	assert.Contains(t, contentMap, "schema", "Content should contain schema")
+	assert.Contains(t, contentMap, "payloadPreview", "Content should contain payloadPreview")
+	assert.Contains(t, contentMap, "payloadSchema", "Content should contain payloadSchema")
 	assert.Contains(t, contentMap, "originalSize", "Content should contain originalSize")
-	assert.Contains(t, contentMap, "truncated", "Content should contain truncated")
-
-	// Verify queryID format in Content
-	queryIDFromContent := contentMap["queryID"].(string)
-	assert.Len(t, queryIDFromContent, 32, "QueryID should be 32 hex characters")
+	assert.NotContains(t, contentMap, "queryID", "Content should NOT contain queryID (excluded from JSON)")
 
 	// Verify response structure in data return value (for internal use)
-	dataMap := integrationPayloadMetadataToMap(t, data)
-
-	// Check all required fields exist
-	assert.Contains(t, dataMap, "queryID")
-	assert.Contains(t, dataMap, "payloadPath")
-	assert.Contains(t, dataMap, "preview")
-	assert.Contains(t, dataMap, "schema")
-	assert.Contains(t, dataMap, "originalSize")
-	assert.Contains(t, dataMap, "truncated")
-
-	// Verify queryID format
-	queryID := dataMap["queryID"].(string)
-	assert.Len(t, queryID, 32, "QueryID should be 32 hex characters")
+	// Access QueryID directly from the struct since it's excluded from JSON
+	pm, ok := data.(PayloadMetadata)
+	require.True(t, ok, "data should be PayloadMetadata")
+	assert.Len(t, pm.QueryID, 32, "QueryID should be 32 hex characters")
 
 	// Verify payload was saved
-	payloadPath := dataMap["payloadPath"].(string)
-	assert.FileExists(t, payloadPath, "Payload file should exist")
+	assert.FileExists(t, pm.PayloadPath, "Payload file should exist")
 
 	// Verify payload content
-	payloadContent, err := os.ReadFile(payloadPath)
+	payloadContent, err := os.ReadFile(pm.PayloadPath)
 	require.NoError(t, err, "Should read payload file")
 
 	var originalData map[string]interface{}
@@ -134,11 +120,10 @@ func TestMiddlewareIntegration(t *testing.T) {
 	assert.NotNil(t, originalData["items"])
 
 	// Verify schema structure
-	schemaObj := dataMap["schema"]
-	assert.NotNil(t, schemaObj, "Schema should not be nil")
+	assert.NotNil(t, pm.PayloadSchema, "Schema should not be nil")
 
 	// Convert schema to JSON string for inspection
-	schemaJSON, err := json.Marshal(schemaObj)
+	schemaJSON, err := json.Marshal(pm.PayloadSchema)
 	require.NoError(t, err, "Schema should be marshallable")
 
 	var schema map[string]interface{}
@@ -180,12 +165,8 @@ func TestMiddlewareIntegration(t *testing.T) {
 	assert.Equal(t, "string", ownerSchema["login"])
 	assert.Equal(t, "number", ownerSchema["id"])
 
-	// Verify truncation flag
-	assert.False(t, dataMap["truncated"].(bool), "Should not be truncated for small payloads")
-
 	// Verify originalSize
-	originalSize := int(dataMap["originalSize"].(float64))
-	assert.Greater(t, originalSize, 0, "Original size should be positive")
+	assert.Greater(t, pm.OriginalSize, 0, "Original size should be positive")
 }
 
 // TestMiddlewareWithLargePayload tests truncation behavior
@@ -226,25 +207,19 @@ func TestMiddlewareWithLargePayload(t *testing.T) {
 	err = json.Unmarshal([]byte(textContent.Text), &contentMap)
 	require.NoError(t, err, "Content should be valid JSON")
 
-	// Verify truncation in Content field
-	truncatedInContent := contentMap["truncated"].(bool)
-	previewInContent := contentMap["preview"].(string)
-
-	if truncatedInContent {
+	// Verify preview truncation in Content field (preview ends with ... when truncated)
+	previewInContent := contentMap["payloadPreview"].(string)
+	if strings.HasSuffix(previewInContent, "...") {
 		assert.True(t, len(previewInContent) <= 503, "Preview in Content should be truncated")
-		assert.Contains(t, previewInContent, "...", "Truncated preview in Content should end with ...")
 	}
 
 	// Also check data return value
 	dataMap := integrationPayloadMetadataToMap(t, data)
 
-	// Verify truncation occurred
-	truncated := dataMap["truncated"].(bool)
-	preview := dataMap["preview"].(string)
-
-	if truncated {
+	// Verify preview truncation (check if it ends with ...)
+	preview := dataMap["payloadPreview"].(string)
+	if strings.HasSuffix(preview, "...") {
 		assert.True(t, len(preview) <= 503, "Preview should be truncated")
-		assert.Contains(t, preview, "...", "Truncated preview should end with ...")
 	}
 
 	// Verify payload file has complete data
@@ -279,7 +254,7 @@ func TestMiddlewareDirectoryCreation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// Verify Content field
+	// Verify Content field (queryID is excluded from JSON)
 	require.NotEmpty(t, result.Content, "Result should have Content")
 	textContent, ok := result.Content[0].(*sdk.TextContent)
 	require.True(t, ok, "Content should be TextContent")
@@ -288,19 +263,18 @@ func TestMiddlewareDirectoryCreation(t *testing.T) {
 	err = json.Unmarshal([]byte(textContent.Text), &contentMap)
 	require.NoError(t, err, "Content should be valid JSON")
 
-	queryIDFromContent := contentMap["queryID"].(string)
+	// queryID should NOT be in the JSON response
+	assert.NotContains(t, contentMap, "queryID", "Content should NOT contain queryID (excluded from JSON)")
 
-	// Also check data return value
-	dataMap := integrationPayloadMetadataToMap(t, data)
-	queryID := dataMap["queryID"].(string)
-
-	// Both should match
-	assert.Equal(t, queryID, queryIDFromContent, "QueryID should match in both data and Content")
+	// Access QueryID directly from the struct for internal verification
+	pm, ok := data.(PayloadMetadata)
+	require.True(t, ok, "data should be PayloadMetadata")
+	queryID := pm.QueryID
 
 	// Verify directory structure with session ID
 	expectedDir := filepath.Join(baseDir, sessionID, queryID)
 	assert.DirExists(t, expectedDir, "Query directory should exist")
 
-	payloadPath := dataMap["payloadPath"].(string)
+	payloadPath := pm.PayloadPath
 	assert.Equal(t, filepath.Join(expectedDir, "payload.json"), payloadPath, "Payload path should match expected structure")
 }

--- a/internal/middleware/jqschema_test.go
+++ b/internal/middleware/jqschema_test.go
@@ -171,25 +171,17 @@ func TestWrapToolHandler(t *testing.T) {
 	require.NoError(t, err, "Content should be valid JSON")
 
 	// Verify transformed response in Content field
-	assert.Contains(t, contentMap, "queryID", "Content should contain queryID")
 	assert.Contains(t, contentMap, "payloadPath", "Content should contain payloadPath")
-	assert.Contains(t, contentMap, "preview", "Content should contain preview")
-	assert.Contains(t, contentMap, "schema", "Content should contain schema")
+	assert.Contains(t, contentMap, "payloadPreview", "Content should contain payloadPreview")
+	assert.Contains(t, contentMap, "payloadSchema", "Content should contain payloadSchema")
 	assert.Contains(t, contentMap, "originalSize", "Content should contain originalSize")
-	assert.Contains(t, contentMap, "truncated", "Content should contain truncated")
-
-	// Verify queryID is a valid hex string
-	queryID, ok := contentMap["queryID"].(string)
-	require.True(t, ok, "queryID should be a string")
-	assert.NotEmpty(t, queryID, "queryID should not be empty")
 
 	// Verify schema is present
-	schema := contentMap["schema"]
+	schema := contentMap["payloadSchema"]
 	assert.NotNil(t, schema, "Schema should not be nil")
 
 	// Also verify rewritten response in data return value (for internal use)
 	dataMap := payloadMetadataToMap(t, data)
-	assert.Contains(t, dataMap, "queryID", "Data should contain queryID")
 	assert.Contains(t, dataMap, "payloadPath", "Data should contain payloadPath")
 
 	// Clean up test directory
@@ -243,7 +235,7 @@ func TestWrapToolHandler_LongPayload(t *testing.T) {
 	}
 
 	wrapped := WrapToolHandler(mockHandler, "test_tool", baseDir, 100, testGetSessionID)
-	result, data, err := wrapped(context.Background(), &sdk.CallToolRequest{}, map[string]interface{}{})
+	result, _, err := wrapped(context.Background(), &sdk.CallToolRequest{}, map[string]interface{}{})
 
 	require.NoError(t, err, "Should not return error")
 	require.NotNil(t, result, "Result should not be nil")
@@ -258,15 +250,10 @@ func TestWrapToolHandler_LongPayload(t *testing.T) {
 	err = json.Unmarshal([]byte(textContent.Text), &contentMap)
 	require.NoError(t, err, "Content should be valid JSON")
 
-	// Verify truncation in Content field
-	assert.True(t, contentMap["truncated"].(bool), "Should indicate truncation in Content")
-	preview := contentMap["preview"].(string)
+	// Verify preview truncation in Content field
+	preview := contentMap["payloadPreview"].(string)
 	assert.LessOrEqual(t, len(preview), 503, "Preview should be truncated to ~500 chars + '...'")
 	assert.True(t, strings.HasSuffix(preview, "..."), "Preview should end with '...'")
-
-	// Also verify in data return value
-	dataMap := payloadMetadataToMap(t, data)
-	assert.True(t, dataMap["truncated"].(bool), "Should indicate truncation in data")
 }
 
 // TestPayloadStorage_SessionIsolation verifies that payloads are stored in session-specific directories
@@ -360,9 +347,6 @@ func TestPayloadStorage_LargePayloadPreserved(t *testing.T) {
 
 	dataMap := payloadMetadataToMap(t, data)
 
-	// Verify truncation occurred
-	assert.True(t, dataMap["truncated"].(bool), "Large payload should be truncated")
-
 	// Get the payload path
 	payloadPath := dataMap["payloadPath"].(string)
 	assert.FileExists(t, payloadPath, "Payload file should exist")
@@ -410,10 +394,11 @@ func TestPayloadStorage_DirectoryStructure(t *testing.T) {
 	_, data, err := wrapped(context.Background(), &sdk.CallToolRequest{}, map[string]interface{}{})
 	require.NoError(t, err)
 
-	dataMap := payloadMetadataToMap(t, data)
-
-	payloadPath := dataMap["payloadPath"].(string)
-	queryID := dataMap["queryID"].(string)
+	// Access QueryID directly from the struct (it's excluded from JSON via json:"-")
+	pm, ok := data.(PayloadMetadata)
+	require.True(t, ok, "data should be PayloadMetadata")
+	queryID := pm.QueryID
+	payloadPath := pm.PayloadPath
 
 	// Verify the expected directory structure
 	expectedDir := filepath.Join(baseDir, sessionID, queryID)
@@ -451,9 +436,11 @@ func TestPayloadStorage_MultipleRequestsSameSession(t *testing.T) {
 		_, data, err := wrapped(context.Background(), &sdk.CallToolRequest{}, map[string]interface{}{})
 		require.NoError(t, err)
 
-		dataMap := payloadMetadataToMap(t, data)
-		payloadPaths = append(payloadPaths, dataMap["payloadPath"].(string))
-		queryIDs = append(queryIDs, dataMap["queryID"].(string))
+		// Access QueryID directly from the struct (it's excluded from JSON via json:"-")
+		pm, ok := data.(PayloadMetadata)
+		require.True(t, ok, "data should be PayloadMetadata")
+		payloadPaths = append(payloadPaths, pm.PayloadPath)
+		queryIDs = append(queryIDs, pm.QueryID)
 	}
 
 	// Verify all payload paths are unique
@@ -637,7 +624,7 @@ func TestPayloadSizeThreshold_SmallPayload(t *testing.T) {
 	// Verify no PayloadMetadata fields are present
 	assert.NotContains(t, dataMap, "queryID", "Should not have queryID field")
 	assert.NotContains(t, dataMap, "payloadPath", "Should not have payloadPath field")
-	assert.NotContains(t, dataMap, "preview", "Should not have preview field")
+	assert.NotContains(t, dataMap, "payloadPreview", "Should not have payloadPreview field")
 
 	// Verify no files were created in the payload directory
 	entries, err := os.ReadDir(baseDir)
@@ -845,8 +832,8 @@ func TestThresholdBehavior_SmallPayloadsAsIs(t *testing.T) {
 			// Verify no PayloadMetadata fields
 			assert.NotContains(t, dataMap, "queryID", "Should not have queryID field")
 			assert.NotContains(t, dataMap, "payloadPath", "Should not have payloadPath field")
-			assert.NotContains(t, dataMap, "preview", "Should not have preview field")
-			assert.NotContains(t, dataMap, "schema", "Should not have schema field")
+			assert.NotContains(t, dataMap, "payloadPreview", "Should not have payloadPreview field")
+			assert.NotContains(t, dataMap, "payloadSchema", "Should not have payloadSchema field")
 
 			// Verify original data is preserved
 			payloadJSON, _ := json.Marshal(tt.payload)
@@ -924,8 +911,8 @@ func TestThresholdBehavior_LargePayloadsUsePayloadDir(t *testing.T) {
 			// Verify PayloadMetadata fields are present
 			assert.NotEmpty(t, pm.QueryID, "Should have queryID")
 			assert.NotEmpty(t, pm.PayloadPath, "Should have payloadPath")
-			assert.NotEmpty(t, pm.Preview, "Should have preview")
-			assert.NotNil(t, pm.Schema, "Should have schema")
+			assert.NotEmpty(t, pm.PayloadPreview, "Should have payloadPreview")
+			assert.NotNil(t, pm.PayloadSchema, "Should have payloadSchema")
 			assert.True(t, pm.OriginalSize > tt.threshold, "Original size should exceed threshold: %s", tt.comment)
 
 			// Verify file was created at the specified path

--- a/test/integration/binary_test.go
+++ b/test/integration/binary_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -596,6 +597,42 @@ func createTempConfig(t *testing.T, servers map[string]interface{}) string {
 	}
 
 	return tmpFile.Name()
+}
+
+// killProcessOnPort kills any process listening on the specified port
+// This helps prevent test interference from stale server processes
+func killProcessOnPort(t *testing.T, port string) {
+	t.Helper()
+
+	// Use lsof to find processes listening on the port (macOS/Linux)
+	cmd := exec.Command("lsof", "-ti", "tcp:"+port)
+	output, err := cmd.Output()
+	if err != nil {
+		// No process found on port, which is fine
+		return
+	}
+
+	// Kill each PID found
+	pids := strings.TrimSpace(string(output))
+	if pids == "" {
+		return
+	}
+
+	for _, pid := range strings.Split(pids, "\n") {
+		pid = strings.TrimSpace(pid)
+		if pid == "" {
+			continue
+		}
+		killCmd := exec.Command("kill", "-9", pid)
+		if err := killCmd.Run(); err != nil {
+			t.Logf("Warning: failed to kill process %s on port %s: %v", pid, port, err)
+		} else {
+			t.Logf("Killed stale process %s on port %s", pid, port)
+		}
+	}
+
+	// Give the OS a moment to release the port
+	time.Sleep(100 * time.Millisecond)
 }
 
 // waitForServer waits for the server to become available

--- a/test/integration/playwright_test.go
+++ b/test/integration/playwright_test.go
@@ -82,6 +82,10 @@ func TestPlaywrightMCPServer(t *testing.T) {
 	defer cancel()
 
 	port := "13100"
+
+	// Kill any stale processes on this port from previous test runs
+	killProcessOnPort(t, port)
+
 	cmd := exec.CommandContext(ctx, binaryPath,
 		"--config-stdin",
 		"--listen", "127.0.0.1:"+port,
@@ -421,10 +425,13 @@ CMD ["node", "mock-mcp-server.js"]
 	defer cancel()
 
 	port := "13101"
+
+	// Kill any stale processes on this port from previous test runs
+	killProcessOnPort(t, port)
+
 	cmd := exec.CommandContext(ctx, binaryPath,
 		"--config-stdin",
 		"--listen", "127.0.0.1:"+port,
-		"--unified",
 	)
 
 	cmd.Stdin = bytes.NewReader(configJSON)
@@ -441,10 +448,9 @@ CMD ["node", "mock-mcp-server.js"]
 		if cmd.Process != nil {
 			cmd.Process.Kill()
 		}
-		if t.Failed() {
-			t.Logf("STDOUT:\n%s", stdout.String())
-			t.Logf("STDERR:\n%s", stderr.String())
-		}
+		// Always log output for debugging
+		t.Logf("STDOUT:\n%s", stdout.String())
+		t.Logf("STDERR:\n%s", stderr.String())
 	}()
 
 	// Wait for server to start
@@ -481,7 +487,7 @@ CMD ["node", "mock-mcp-server.js"]
 			},
 		}
 
-		result := sendMCPRequest(t, serverURL+"/mcp", "test-mock-key", initReq)
+		result := sendMCPRequest(t, serverURL+"/mcp/mock-playwright", "test-mock-key", initReq)
 
 		// Verify initialize succeeded
 		if _, ok := result["error"]; ok {
@@ -496,7 +502,7 @@ CMD ["node", "mock-mcp-server.js"]
 			"params":  map[string]interface{}{},
 		}
 
-		result = sendMCPRequest(t, serverURL+"/mcp", "test-mock-key", listReq)
+		result = sendMCPRequest(t, serverURL+"/mcp/mock-playwright", "test-mock-key", listReq)
 
 		// The key test is that we didn't panic, not whether tools/list works perfectly
 		// Check if we got any tools registered (may be zero if backend connection failed)


### PR DESCRIPTION
PayloadMetadata changes:
- Rename 'instructions' to 'agentInstructions' and move to first field
- Rename 'preview' to 'payloadPreview'
- Rename 'schema' to 'payloadSchema'
- Remove 'truncated' field (redundant - can check if preview ends with '...')
- Keep QueryID for internal use with json:"-" (excluded from client response)
- Update agentInstructions text to explain payloadSchema approximates the payload

Test fixes:
- Fix TestPlaywrightWithLocalDockerfile to use routed mode instead of unified
- Add killProcessOnPort helper to prevent test interference from stale servers
- Update test assertions for renamed fields