### PR TITLE
fix: correct log helper test expectations

### DIFF
--- a/internal/launcher/log_helpers.go
+++ b/internal/launcher/log_helpers.go
@@ -41,6 +41,9 @@ func (l *Launcher) logLaunchStart(serverID, sessionID string, serverCfg *config.
 	}
 	log.Printf("[LAUNCHER] Command: %s", serverCfg.Command)
 	log.Printf("[LAUNCHER] Args: %v", sanitize.SanitizeArgs(serverCfg.Args))
+	if isDirectCommand {
+		log.Printf("[LAUNCHER] isDirectCommand=true")
+	}
 }
 
 // logEnvPassthrough checks and logs environment variable passthrough status
@@ -95,7 +98,11 @@ func (l *Launcher) logLaunchError(serverID, sessionID string, err error, serverC
 func (l *Launcher) logTimeoutError(serverID, sessionID string) {
 	logger.LogErrorWithServer(serverID, "backend", "MCP backend server startup timeout%s: server=%s%s, timeout=%v",
 		sessionSuffix(sessionID), serverID, sessionSuffix(sessionID), l.startupTimeout)
-	log.Printf("[LAUNCHER] ❌ Server startup timed out after %v", l.startupTimeout)
+	if sessionID != "" {
+		log.Printf("[LAUNCHER] ❌ Server '%s' (session: %s) startup timed out after %v", serverID, sessionID, l.startupTimeout)
+	} else {
+		log.Printf("[LAUNCHER] ❌ Server '%s' startup timed out after %v", serverID, l.startupTimeout)
+	}
 	log.Printf("[LAUNCHER] ⚠️  The server may be hanging or taking too long to initialize")
 	log.Printf("[LAUNCHER] ⚠️  Consider increasing 'startupTimeout' in gateway config if server needs more time")
 	if sessionID != "" {

--- a/internal/launcher/log_helpers_test.go
+++ b/internal/launcher/log_helpers_test.go
@@ -165,12 +165,12 @@ func TestLauncher_LogLaunchStart(t *testing.T) {
 			serverID:        "env-server",
 			sessionID:       "env-session",
 			command:         "docker",
-			args:            []string{"run", "-e", "API_KEY=***REDACTED***"},
+			args:            []string{"run", "-e", "API_KEY=secret-value-12345"},
 			isDirectCommand: false,
 			wantInLog: []string{
 				"env-server",
 				"env-session",
-				"***REDACTED***",
+				"secr...", // TruncateSecret shows first 4 chars + "..."
 			},
 		},
 	}
@@ -415,7 +415,7 @@ func TestLauncher_LogTimeoutError(t *testing.T) {
 			wantInLog: []string{
 				"slow-server",
 				"timed out",
-				"60s",
+				"1m0s", // Go formats 60s as 1m0s
 				"hanging",
 			},
 		},


### PR DESCRIPTION
- Add isDirectCommand=true to log output in logLaunchStart
- Include serverID and sessionID in logTimeoutError messages
- Fix test expectations for TruncateSecret output (secr... not ***REDACTED***)
- Fix test expectation for Go Duration format (1m0s not 60s)