### PR TITLE
fix: 📚 Documentation Reconciliation Report - 2026-03-07

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,13 @@ Run both unit and integration tests:
 make test-all
 ```
 
+#### Serena MCP Tests (Optional)
+Run Serena MCP Server tests (requires Docker and network access):
+```bash
+make test-serena          # Direct connection tests
+make test-serena-gateway  # Tests routed via the MCP Gateway
+```
+
 ### Linting
 
 Run all linters (go vet, gofmt check, and golangci-lint):

--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ Both GitHub MCP and Serena MCP servers pass comprehensive test suites including 
 ```bash
 # Both servers use stdio transport via Docker containers
 docker run -i ghcr.io/github/github-mcp-server          # GitHub MCP
-docker run -i ghcr.io/github/serena-mcp-server     # Serena MCP
+docker run -i ghcr.io/github/serena-mcp-server:latest   # Serena MCP
 ```
 
 ### Using MCP Servers with the Gateway


### PR DESCRIPTION
## Summary
Closes #1652
Documentation was missing instructions for running Serena MCP Server tests, and the Docker image tag was inconsistent. This adds the missing test commands and makes the Serena MCP image tag explicit.

## Changes
- Added "Serena MCP Tests (Optional)" section to CONTRIBUTING.md with `make test-serena` and `make test-serena-gateway` commands
- Updated README.md to explicitly use `:latest` tag for the Serena MCP Docker image (`ghcr.io/github/serena-mcp-server:latest`)<analysis>
Looking at the diff, I need to identify what changes were made:

1. **CONTRIBUTING.md**: Added a new section "Serena MCP Tests (Optional)" with two make commands:
   - `make test-serena` - Direct connection tests
   - `make test-serena-gateway` - Tests routed via the MCP Gateway

2. **README.md**: Changed the Docker image tag for Serena MCP server from no explicit tag to `:latest`:
   - Before: `ghcr.io/github/serena-mcp-server`
   - After: `ghcr.io/github/serena-mcp-server:latest`

This is a documentation fix that:
- Adds missing test instructions for Serena MCP
- Makes the Docker image tag explicit for consistency
</analysis>

## Summary
Closes #1652
Documentation was missing instructions for running Serena MCP Server tests, and the Docker image tag was inconsistent. This adds the missing test commands and makes the Serena MCP image tag explicit.

## Changes
- Added "Serena MCP Tests (Optional)" section to CONTRIBUTING.md with `make test-serena` and `make test-serena-gateway` commands
- Updated README.md to explicitly use `:latest` tag for the Serena MCP Docker image (`ghcr.io/github/serena-mcp-server:latest`)<analysis>
Looking at the diff, I need to identify what changes were made:

1. **CONTRIBUTING.md**: Added a new section "Serena MCP Tests (Optional)" with two make commands:
   - `make test-serena` - Direct connection tests
   - `make test-serena-gateway` - Tests routed via the MCP Gateway

2. **README.md**: Changed the Docker image tag for Serena MCP server from no explicit tag to `:latest`:
   - Before: `ghcr.io/github/serena-mcp-server`
   - After: `ghcr.io/github/serena-mcp-server:latest`

This is a documentation fix that:
- Adds missing test instructions for Serena MCP
- Makes the Docker image tag explicit for consistency
</analysis>

## Summary
Closes #1652
Documentation was missing instructions for running Serena MCP Server tests, and the Docker image tag was inconsistent. This adds the missing test commands and makes the Serena MCP image tag explicit.

## Changes
- Added "Serena MCP Tests (Optional)" section to CONTRIBUTING.md with `make test-serena` and `make test-serena-gateway` commands
- Updated README.md to explicitly use `:latest` tag for the Serena MCP Docker image (`ghcr.io/github/serena-mcp-server:latest`)

I should verify this approach against the given examples to make sure it works.