### PR TITLE
fix: use 'target' (singular) for setup-rust-toolchain action input

### DIFF
--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -1159,7 +1159,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # a0b538fa0b742a6aa35d6e2c169b4bd06d225a98
         with:
-          targets: wasm32-wasip1
+          target: wasm32-wasip1
       - name: Build baked WASM guard
         run: |
           make -C guards/github-guard build

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -279,7 +279,7 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@a0b538fa0b742a6aa35d6e2c169b4bd06d225a98 # v1.15.3
         with:
-          targets: wasm32-wasip1
+          target: wasm32-wasip1
 
       - name: Build baked WASM guard
         run: |


### PR DESCRIPTION
The `actions-rust-lang/setup-rust-toolchain` action expects `target` (singular), not `targets` (plural). The typo caused `wasm32-wasip1` to silently not be installed, failing the WASM guard build in the release workflow with:

```
error[E0463]: can't find crate for `std`
  = note: the `wasm32-wasip1` target may not be installed
```

The action logged:
```
##[warning]Unexpected input(s) 'targets', valid inputs are ['toolchain', 'target', 'components', ...]
```

**Fix:** `targets:` → `target:` in both `release.md` and `release.lock.yml`.