### PR TITLE
fix: don't use Gateway.Domain in gateway output URLs

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -437,14 +437,16 @@ func writeGatewayConfig(cfg *config.Config, listenAddr, mode string, w io.Writer
 	}
 	debugLog.Printf("Parsed listen address: host=%s, port=%s", host, port)
 
-	// Determine domain for client-reachable URLs.
-	// If the config specifies a domain, prefer that. Otherwise, use the listen
-	// host — but map wildcard bind addresses (0.0.0.0, ::) to 127.0.0.1 since
-	// clients cannot connect to wildcard addresses.
+	// Determine domain for gateway output URLs.
+	// Use the listen host, but map wildcard bind addresses (0.0.0.0, ::) to
+	// 127.0.0.1 since clients cannot connect to wildcard addresses.
+	// Note: cfg.Gateway.Domain is NOT used here because the gateway output is
+	// consumed by host-side tools (health checks, connectivity checks) that
+	// need localhost-reachable URLs. The domain field (e.g., "host.docker.internal")
+	// is applied by the downstream converter when generating agent configs for
+	// container-side access.
 	domain := host
-	if cfg.Gateway != nil && cfg.Gateway.Domain != "" {
-		domain = cfg.Gateway.Domain
-	} else if domain == "0.0.0.0" || domain == "::" || domain == "[::]" {
+	if domain == "0.0.0.0" || domain == "::" || domain == "[::]" {
 		domain = "127.0.0.1"
 	}
 

--- a/internal/cmd/stdout_config_test.go
+++ b/internal/cmd/stdout_config_test.go
@@ -119,7 +119,7 @@ func TestWriteGatewayConfigToStdout(t *testing.T) {
 			wantAPIKey: "ipv6-key",
 		},
 		{
-			name: "domain config overrides listen host",
+			name: "domain config does not override listen host in gateway output",
 			cfg: &config.Config{
 				Servers: map[string]*config.ServerConfig{
 					"github": {Command: "docker"},
@@ -131,7 +131,7 @@ func TestWriteGatewayConfigToStdout(t *testing.T) {
 			},
 			listenAddr: "0.0.0.0:8080",
 			mode:       "routed",
-			wantHost:   "my-gateway.local",
+			wantHost:   "127.0.0.1",
 			wantPort:   "8080",
 			wantAPIKey: "domain-key",
 		},

--- a/test/integration/auth_config_test.go
+++ b/test/integration/auth_config_test.go
@@ -117,7 +117,7 @@ func TestOutputConfigWithAuthHeaders(t *testing.T) {
 			t.Errorf("Expected non-empty url, got: %v", echoserver["url"])
 		}
 
-		expectedURL := fmt.Sprintf("http://localhost:%d/mcp/echoserver", port)
+		expectedURL := fmt.Sprintf("http://127.0.0.1:%d/mcp/echoserver", port)
 		assert.Equal(t, expectedURL, url, "url = %q, got: %q")
 
 		// Verify headers object is present per spec section 5.4


### PR DESCRIPTION
## Problem

The `smoke-allowonly` workflow fails with `Ping failed: HTTP 000` on all MCP server connectivity checks when using gateway v0.1.12+.

**Root cause**: Commit 9a70098 added logic to prefer `cfg.Gateway.Domain` (e.g., `host.docker.internal`) in `writeGatewayConfig` output URLs. The gateway output config is consumed by the gh-aw infrastructure's connectivity check script, which runs on the **host** runner. `host.docker.internal` doesn't resolve from the host, causing curl to get no TCP connection (HTTP 000).

**Evidence**:
- v0.1.8 (success): gateway output URLs used `http://0.0.0.0:80/mcp/*` → curl treats as localhost → works
- v0.1.12 (failure): gateway output URLs used `http://host.docker.internal:80/mcp/*` → DNS fails from host → HTTP 000
- Health check on `localhost:80` always passes — the gateway IS running
- Gateway logs show zero MCP requests in failing runs (requests never reach the gateway)

## Fix

Remove the `cfg.Gateway.Domain` preference from `writeGatewayConfig`. The gateway output should always use the listen host (with wildcard addresses mapped to `127.0.0.1`). The downstream converter already handles domain mapping when generating agent configs for container-side access.

## Changes

- `internal/cmd/root.go`: Remove domain preference, keep wildcard→127.0.0.1 mapping
- `internal/cmd/stdout_config_test.go`: Update test expectations
- `test/integration/auth_config_test.go`: Update URL expectation

All tests pass (`make agent-finished` ✓).