### PR TITLE
test: add server-level tests for write-sink and allow-only guard policies

### DIFF
--- a/internal/server/write_sink_guard_test.go
+++ b/internal/server/write_sink_guard_test.go
@@ -63,35 +63,38 @@ func newMCPBackend(t *testing.T, tools []map[string]interface{}) *httptest.Serve
 			return
 		}
 		method, _ := req["method"].(string)
+		w.Header().Set("Content-Type", "application/json")
 		switch method {
 		case "initialize":
-			resp := map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"jsonrpc": "2.0", "id": req["id"],
 				"result": map[string]interface{}{
 					"protocolVersion": "2024-11-05",
 					"capabilities":    map[string]interface{}{},
 					"serverInfo":      map[string]interface{}{"name": "test-backend", "version": "1.0"},
 				},
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(resp)
+			})
 		case "tools/list":
-			resp := map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"jsonrpc": "2.0", "id": req["id"],
 				"result": map[string]interface{}{"tools": tools},
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(resp)
+			})
 		case "tools/call":
-			resp := map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"jsonrpc": "2.0", "id": req["id"],
 				"result": map[string]interface{}{
 					"content": []map[string]interface{}{{"type": "text", "text": "ok"}},
 					"isError": false,
 				},
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(resp)
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0", "id": req["id"],
+				"error": map[string]interface{}{
+					"code":    -32601,
+					"message": "method not found: " + method,
+				},
+			})
 		}
 	}))
 }
@@ -313,26 +316,13 @@ func TestWriteSinkGuard_RejectsSecrecyMismatch(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(result1)
 
-	// Step 2: Write to safeoutputs — should be BLOCKED in filter mode
-	// because agent has private:github/secret-org* which is NOT in accept list
-	result2, _, err := us.callBackendTool(ctx, "safeoutputs", "create_issue", map[string]interface{}{
+	// Step 2: Write to safeoutputs — should be BLOCKED because agent has
+	// private:github/secret-org* which is NOT covered by the accept list.
+	// Non-read writes that fail DIFC always return an error (even in filter mode).
+	_, _, err = us.callBackendTool(ctx, "safeoutputs", "create_issue", map[string]interface{}{
 		"title": "Should be blocked",
 	})
-
-	// In filter mode, DIFC violations return a filtered response (not an error)
-	// The result should indicate it was blocked/filtered
-	if err != nil {
-		// Strict mode would return an error
-		require.Contains(err.Error(), "secrecy", "should fail due to secrecy mismatch")
-	} else {
-		// Filter mode returns isError=true with DIFC violation message
-		require.NotNil(result2)
-		if result2.IsError {
-			// Check the content for DIFC violation
-			content := result2.Content
-			require.NotEmpty(content, "filtered result should have content explaining the violation")
-		}
-	}
+	require.Error(err, "write-sink should reject write when agent has uncovered secrecy tags")
 }
 
 // TestNoopGuard_BlocksWriteAfterGitHubRead demonstrates that without a


### PR DESCRIPTION
Tests cover the interaction between GitHub (allow-only) and safeoutputs (write-sink) servers in the gateway:

- **TestWriteSinkGuardRegistration_FromConfig**: verifies write-sink guard is created from guard-policies config, not auto-upgraded from noop; also confirms DIFC is auto-enabled
- **TestWriteSinkGuard_AllowsWriteAfterGitHubRead**: e2e flow where agent reads from GitHub (acquires secrecy/integrity tags via allow-only guard), then writes to safeoutputs (accepted by write-sink guard whose accept patterns cover all acquired tags)
- **TestWriteSinkGuard_RejectsSecrecyMismatch**: agent acquires a secrecy tag from a second org not covered by the write-sink accept list; write to safeoutputs is blocked/filtered due to the DIFC violation
- **TestNoopGuard_BlocksWriteAfterGitHubRead**: without write-sink config, safeoutputs gets a noop guard; after a GitHub read taints the agent, writing to safeoutputs causes a DIFC integrity violation
- **TestWriteSinkPolicy_ResolvedForWriteSinkServer**: unit test for `resolveWriteSinkPolicy` — returns a policy for a server with write-sink config and nil for servers with only allow-only or no config
- **TestDIFCAutoEnable_WithWriteSinkAndAllowOnly**: DIFC is automatically enabled when the config contains at least one write-sink policy, even without an explicit `difc_mode`

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.