### PR TITLE
feat: document and test write-sink accept rules for all repos scope types

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,14 +256,39 @@ For the complete JSON configuration specification with all validation rules, see
     Accept = ["private:github/gh-aw*"]
     ```
     - **`accept`**: Array of secrecy label patterns the sink accepts
-      - `"private:owner/repo*"` - Accept writes from agents that accessed private repos matching the pattern
+      - `"private:owner/repo"` - Accept writes from agents that accessed a specific private repo
+      - `"private:owner/prefix*"` - Accept writes from agents that accessed private repos matching the prefix
+      - `"private:owner"` - Accept writes from agents that accessed any repo in the owner's org (bare owner format)
       - `"public:owner/repo*"` - Accept writes from agents that accessed public repos matching the pattern
       - `"internal:owner/repo*"` - Accept writes from agents that accessed internal repos matching the pattern
-      - `"owner/repo*"` - Accept writes without visibility prefix (matches the repo scope pattern)
     - **How it works**: The write-sink classifies all operations as writes. For DIFC write checks:
       - Resource secrecy is set to the `accept` patterns → agent secrecy ⊆ resource secrecy passes
       - Resource integrity is left empty → no integrity requirements for writes
     - **When to use**: For servers like `safeoutputs` that buffer agent outputs for review, or any server that only receives data from the agent
+
+  ##### Mapping allow-only repos to write-sink accept
+
+  The write-sink `accept` entries must match the secrecy tags the GitHub guard assigns
+  to the agent via `label_agent`. The mapping depends on the `repos` configuration:
+
+  | `allow-only.repos` | Agent secrecy tags | `write-sink.accept` |
+  |---|---|---|
+  | `"all"` | `[]` (none) | Not needed |
+  | `"public"` | `[]` (none) | Not needed |
+  | `["owner/repo"]` | `["private:owner/repo"]` | `["private:owner/repo"]` |
+  | `["owner/*"]` | `["private:owner"]` | `["private:owner"]` |
+  | `["owner/prefix*"]` | `["private:owner/prefix*"]` | `["private:owner/prefix*"]` |
+  | `["O/R1", "O/R2"]` | `["private:O/R1", "private:O/R2"]` | `["private:O/R1", "private:O/R2"]` |
+  | `["O1/*", "O2/R"]` | `["private:O1", "private:O2/R"]` | `["private:O1", "private:O2/R"]` |
+
+  **Key rules**:
+  - `repos="all"` or `repos="public"` → no secrecy tags → write-sink not required
+  - `repos=["owner/*"]` (owner wildcard) → bare owner tag `"private:owner"` (no `/*` suffix)
+  - `repos=["owner/prefix*"]` (prefix wildcard) → `"private:owner/prefix*"` (suffix preserved)
+  - `repos=["owner/repo"]` (exact) → `"private:owner/repo"`
+  - Multi-entry repos produce one tag per entry; `accept` must include all of them
+  - `accept` can be a superset of the agent's secrecy (extra entries are harmless)
+  - `min-integrity` does not affect these rules (it only changes integrity labels)
 
   - For **other MCP servers** (Jira, WorkIQ, etc.), different policy schemas apply
   - JSON format uses `"guard-policies"` (with hyphen), TOML uses `guard_policies` (with underscore)

--- a/internal/config/config_difc_test.go
+++ b/internal/config/config_difc_test.go
@@ -521,7 +521,8 @@ func TestParseGuardPolicyJSON_WriteSink(t *testing.T) {
 	})
 
 	t.Run("rejects write-sink with invalid repo scope", func(t *testing.T) {
-		_, err := ParseGuardPolicyJSON(`{"write-sink":{"accept":["invalid-no-slash"]}}`)
+		// Use an entry with invalid characters (uppercase not allowed in owner names)
+		_, err := ParseGuardPolicyJSON(`{"write-sink":{"accept":["private:INVALID/repo"]}}`)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid")
 	})

--- a/internal/config/config_guardpolicies_test.go
+++ b/internal/config/config_guardpolicies_test.go
@@ -447,3 +447,187 @@ Accept = ["private:github/gh-aw*"]
 	assert.Len(t, acceptRaw, 1)
 	assert.Equal(t, "private:github/gh-aw*", acceptRaw[0])
 }
+
+// =============================================================================
+// Write-Sink Accept Entry Validation Tests
+//
+// These tests verify that validateAcceptEntry correctly validates all accept
+// entry formats, including bare owner names (for owner-wildcard scopes).
+// =============================================================================
+
+func TestValidateAcceptEntry_AllFormats(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   string
+		wantErr bool
+		desc    string
+	}{
+		// Valid: exact repo with visibility prefix
+		{
+			name:  "private:owner/repo",
+			entry: "private:github/gh-aw",
+			desc:  "exact repo with private prefix",
+		},
+		{
+			name:  "public:owner/repo",
+			entry: "public:github/gh-aw",
+			desc:  "exact repo with public prefix",
+		},
+		{
+			name:  "internal:owner/repo",
+			entry: "internal:github/gh-aw",
+			desc:  "exact repo with internal prefix",
+		},
+		// Valid: prefix wildcard with visibility prefix
+		{
+			name:  "private:owner/prefix*",
+			entry: "private:github/gh-aw*",
+			desc:  "prefix wildcard (repos=[\"github/gh-aw*\"])",
+		},
+		// Valid: owner wildcard with visibility prefix
+		{
+			name:  "private:owner/*",
+			entry: "private:github/*",
+			desc:  "owner wildcard scope (repos=[\"github/*\"])",
+		},
+		// Valid: bare owner (for repos=["owner/*"] → agent secrecy "private:owner")
+		{
+			name:  "private:owner (bare)",
+			entry: "private:myorg",
+			desc:  "bare owner name — matches repos=[\"myorg/*\"] agent secrecy",
+		},
+		{
+			name:  "private:owner with hyphen",
+			entry: "private:my-org",
+			desc:  "bare owner with hyphen",
+		},
+		{
+			name:  "private:owner with numbers",
+			entry: "private:org123",
+			desc:  "bare owner with numbers",
+		},
+		// Valid: without visibility prefix
+		{
+			name:  "owner/repo (no prefix)",
+			entry: "github/gh-aw",
+			desc:  "repo scope without visibility prefix",
+		},
+		{
+			name:  "owner/prefix* (no prefix)",
+			entry: "github/gh-aw*",
+			desc:  "prefix wildcard without visibility prefix",
+		},
+		{
+			name:  "owner/* (no prefix)",
+			entry: "github/*",
+			desc:  "owner wildcard without visibility prefix",
+		},
+		{
+			name:  "owner (no prefix, bare)",
+			entry: "myorg",
+			desc:  "bare owner without visibility prefix",
+		},
+		// Invalid entries
+		{
+			name:    "invalid visibility prefix",
+			entry:   "secret:github/gh-aw",
+			wantErr: true,
+			desc:    "unknown visibility prefix",
+		},
+		{
+			name:    "empty string",
+			entry:   "",
+			wantErr: true,
+			desc:    "empty entry is invalid",
+		},
+		{
+			name:    "wildcard in middle",
+			entry:   "private:github/gh*aw",
+			wantErr: true,
+			desc:    "wildcard must be at end only",
+		},
+		{
+			name:    "double wildcard",
+			entry:   "private:github/gh**",
+			wantErr: true,
+			desc:    "multiple wildcards not allowed",
+		},
+		{
+			name:    "owner too long",
+			entry:   "private:" + string(make([]byte, 40)),
+			wantErr: true,
+			desc:    "owner name exceeds 39 chars",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAcceptEntry(tc.entry)
+			if tc.wantErr {
+				assert.Error(t, err, "entry %q should be invalid: %s", tc.entry, tc.desc)
+			} else {
+				assert.NoError(t, err, "entry %q should be valid: %s", tc.entry, tc.desc)
+			}
+		})
+	}
+}
+
+// TestValidateWriteSinkPolicy_BareOwnerAccept tests that a write-sink policy with
+// bare owner accept entries (for repos=["owner/*"]) passes validation.
+func TestValidateWriteSinkPolicy_BareOwnerAccept(t *testing.T) {
+	policy := &WriteSinkPolicy{
+		Accept: []string{"private:myorg", "private:partner/shared-lib"},
+	}
+	err := ValidateWriteSinkPolicy(policy)
+	assert.NoError(t, err, "bare owner + repo pattern should both validate")
+}
+
+// TestValidateWriteSinkPolicy_AllScopeAcceptFormats tests validation for accept
+// entries derived from every repos scope type.
+func TestValidateWriteSinkPolicy_AllScopeAcceptFormats(t *testing.T) {
+	tests := []struct {
+		name   string
+		repos  string // description of the repos config
+		accept []string
+	}{
+		{
+			name:   "exact repo",
+			repos:  `["github/gh-aw"]`,
+			accept: []string{"private:github/gh-aw"},
+		},
+		{
+			name:   "owner wildcard",
+			repos:  `["myorg/*"]`,
+			accept: []string{"private:myorg"},
+		},
+		{
+			name:   "prefix wildcard",
+			repos:  `["github/gh-aw*"]`,
+			accept: []string{"private:github/gh-aw*"},
+		},
+		{
+			name:   "multiple exact repos",
+			repos:  `["github/repo1", "github/repo2"]`,
+			accept: []string{"private:github/repo1", "private:github/repo2"},
+		},
+		{
+			name:   "mixed owner + exact",
+			repos:  `["myorg/*", "partner/lib"]`,
+			accept: []string{"private:myorg", "private:partner/lib"},
+		},
+		{
+			name:   "mixed prefix + exact + owner",
+			repos:  `["github/gh-aw*", "github/copilot", "partner/*"]`,
+			accept: []string{"private:github/gh-aw*", "private:github/copilot", "private:partner"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := &WriteSinkPolicy{Accept: tc.accept}
+			err := ValidateWriteSinkPolicy(policy)
+			assert.NoError(t, err,
+				"repos=%s → accept=%v should pass validation", tc.repos, tc.accept)
+		})
+	}
+}

--- a/internal/config/guard_policy.go
+++ b/internal/config/guard_policy.go
@@ -185,8 +185,15 @@ func ValidateWriteSinkPolicy(ws *WriteSinkPolicy) error {
 }
 
 // validateAcceptEntry validates a single accept entry.
-// Format: "visibility:owner/repo-pattern" (e.g., "private:github/gh-aw*")
-// or just "owner/repo-pattern" (e.g., "github/gh-aw*").
+// Accepted formats:
+//   - "visibility:owner/repo-pattern" (e.g., "private:github/gh-aw*")
+//   - "visibility:owner"              (e.g., "private:myorg" — for owner-wildcard scopes)
+//   - "owner/repo-pattern"            (e.g., "github/gh-aw*" — without visibility prefix)
+//   - "owner"                         (e.g., "myorg" — bare owner without visibility prefix)
+//
+// The accept entries must match the secrecy tags produced by the GitHub guard's
+// label_agent. See WriteSinkAcceptRules for the mapping from allow-only repos
+// to the required accept values.
 func validateAcceptEntry(entry string) error {
 	scope := entry
 	if idx := strings.Index(entry, ":"); idx > 0 {
@@ -199,11 +206,41 @@ func validateAcceptEntry(entry string) error {
 			return fmt.Errorf("visibility prefix must be private, public, or internal; got %q", visibility)
 		}
 	}
-	if !isValidRepoScope(scope) {
-		return fmt.Errorf("scope %q is invalid; expected owner/*, owner/repo, or owner/re*", scope)
+	// Accept either "owner/repo-pattern" or bare "owner" (for owner-wildcard scopes
+	// where repos=["owner/*"] produces agent secrecy "private:owner")
+	if !isValidRepoScope(scope) && !isValidRepoOwner(scope) {
+		return fmt.Errorf("scope %q is invalid; expected owner, owner/*, owner/repo, or owner/re*", scope)
 	}
 	return nil
 }
+
+// WriteSinkAcceptRules documents the mapping from allow-only repos configuration
+// to the required write-sink accept values.
+//
+// The write-sink accept field must be a superset of the agent's secrecy tags,
+// which are determined by the allow-only repos configuration:
+//
+//	repos = "all"              → agent secrecy = []           → write-sink not required
+//	repos = "public"           → agent secrecy = []           → write-sink not required
+//	repos = ["O/R"]            → agent secrecy = ["private:O/R"]
+//	                             accept = ["private:O/R"]
+//	repos = ["O/*"]            → agent secrecy = ["private:O"]
+//	                             accept = ["private:O"]
+//	repos = ["O/P*"]           → agent secrecy = ["private:O/P*"]
+//	                             accept = ["private:O/P*"]
+//	repos = ["O/R1", "O/R2"]  → agent secrecy = ["private:O/R1", "private:O/R2"]
+//	                             accept = ["private:O/R1", "private:O/R2"]
+//	repos = ["O1/*", "O2/R"]  → agent secrecy = ["private:O1", "private:O2/R"]
+//	                             accept = ["private:O1", "private:O2/R"]
+//
+// The transformation rule:
+//
+//	repos entry "O/*"  (owner wildcard)  → accept "private:O"    (bare owner)
+//	repos entry "O/P*" (prefix wildcard) → accept "private:O/P*" (prefix preserved)
+//	repos entry "O/R"  (exact repo)      → accept "private:O/R"  (exact preserved)
+//
+// Note: min-integrity has no effect on these rules (it only affects integrity labels).
+var WriteSinkAcceptRules = "see godoc" // exists for documentation only
 
 // IsWriteSinkPolicy returns true if this policy configures a write-sink guard.
 func (p *GuardPolicy) IsWriteSinkPolicy() bool {

--- a/internal/guard/write_sink_test.go
+++ b/internal/guard/write_sink_test.go
@@ -148,3 +148,307 @@ func TestWriteSinkGuard_SecrecyMismatchFails(t *testing.T) {
 
 	assert.False(t, result.IsAllowed(), "write should fail: agent has secrecy tag not in accept list")
 }
+
+// =============================================================================
+// Write-Sink Accept Rules Tests
+//
+// These tests verify the mapping between allow-only repos configuration and
+// the required write-sink accept values. The rules are documented in
+// config.WriteSinkAcceptRules.
+//
+// The GitHub guard's label_agent produces agent secrecy tags based on the
+// repos scope. The write-sink accept must be a superset of those tags for
+// writes to succeed:
+//
+//   repos = "all"              → agent secrecy = []                → no write-sink needed
+//   repos = "public"           → agent secrecy = []                → no write-sink needed
+//   repos = ["O/R"]            → agent secrecy = ["private:O/R"]   → accept = ["private:O/R"]
+//   repos = ["O/*"]            → agent secrecy = ["private:O"]     → accept = ["private:O"]
+//   repos = ["O/P*"]           → agent secrecy = ["private:O/P*"]  → accept = ["private:O/P*"]
+//   repos = ["O/R1", "O/R2"]  → agent secrecy = ["private:O/R1", "private:O/R2"]
+//   repos = ["O1/*", "O2/R"]  → agent secrecy = ["private:O1", "private:O2/R"]
+// =============================================================================
+
+// TestWriteSinkAcceptRules_ExactRepo tests: repos=["org/repo"] → accept=["private:org/repo"]
+func TestWriteSinkAcceptRules_ExactRepo(t *testing.T) {
+	accept := []string{"private:github/gh-aw"}
+	g := NewWriteSinkGuard(accept)
+
+	// Agent secrecy from label_agent with repos=["github/gh-aw"]
+	agentSecrecy := difc.NewSecrecyLabelWithTags([]difc.Tag{"private:github/gh-aw"})
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.True(t, result.IsAllowed(), "exact repo: accept matches agent secrecy; got: %s", result.Reason)
+}
+
+// TestWriteSinkAcceptRules_OwnerWildcard tests: repos=["org/*"] → accept=["private:org"]
+// The owner wildcard produces a bare owner secrecy tag (no "/*" suffix).
+func TestWriteSinkAcceptRules_OwnerWildcard(t *testing.T) {
+	// repos=["myorg/*"] produces agent secrecy "private:myorg" (bare owner)
+	accept := []string{"private:myorg"}
+	g := NewWriteSinkGuard(accept)
+
+	agentSecrecy := difc.NewSecrecyLabelWithTags([]difc.Tag{"private:myorg"})
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.True(t, result.IsAllowed(), "owner wildcard: accept matches agent secrecy; got: %s", result.Reason)
+}
+
+// TestWriteSinkAcceptRules_OwnerWildcard_WrongAccept tests that using "private:org/*"
+// does NOT match "private:org" — DIFC tags are exact string matches.
+func TestWriteSinkAcceptRules_OwnerWildcard_WrongAccept(t *testing.T) {
+	// WRONG: accept has "private:myorg/*" but agent secrecy is "private:myorg"
+	accept := []string{"private:myorg/*"}
+	g := NewWriteSinkGuard(accept)
+
+	agentSecrecy := difc.NewSecrecyLabelWithTags([]difc.Tag{"private:myorg"})
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.False(t, result.IsAllowed(),
+		"owner wildcard with wrong accept: 'private:myorg/*' != 'private:myorg'")
+}
+
+// TestWriteSinkAcceptRules_PrefixWildcard tests: repos=["org/prefix*"] → accept=["private:org/prefix*"]
+func TestWriteSinkAcceptRules_PrefixWildcard(t *testing.T) {
+	accept := []string{"private:github/gh-aw*"}
+	g := NewWriteSinkGuard(accept)
+
+	// Agent secrecy from label_agent with repos=["github/gh-aw*"]
+	agentSecrecy := difc.NewSecrecyLabelWithTags([]difc.Tag{"private:github/gh-aw*"})
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.True(t, result.IsAllowed(), "prefix wildcard: accept matches agent secrecy; got: %s", result.Reason)
+}
+
+// TestWriteSinkAcceptRules_MultipleExactRepos tests: repos=["O/R1", "O/R2"] → accept=["private:O/R1", "private:O/R2"]
+func TestWriteSinkAcceptRules_MultipleExactRepos(t *testing.T) {
+	accept := []string{"private:github/repo1", "private:github/repo2"}
+	g := NewWriteSinkGuard(accept)
+
+	// Agent secrecy from label_agent with repos=["github/repo1", "github/repo2"]
+	agentSecrecy := difc.NewSecrecyLabelWithTags([]difc.Tag{
+		"private:github/repo1",
+		"private:github/repo2",
+	})
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.True(t, result.IsAllowed(), "multiple exact repos: accept covers all agent secrecy; got: %s", result.Reason)
+}
+
+// TestWriteSinkAcceptRules_MixedScopes tests: repos=["O1/*", "O2/repo"] → accept=["private:O1", "private:O2/repo"]
+func TestWriteSinkAcceptRules_MixedScopes(t *testing.T) {
+	accept := []string{"private:myorg", "private:partner/shared-lib"}
+	g := NewWriteSinkGuard(accept)
+
+	// Agent secrecy from label_agent with repos=["myorg/*", "partner/shared-lib"]
+	agentSecrecy := difc.NewSecrecyLabelWithTags([]difc.Tag{
+		"private:myorg",
+		"private:partner/shared-lib",
+	})
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.True(t, result.IsAllowed(), "mixed scopes: accept covers all agent secrecy; got: %s", result.Reason)
+}
+
+// TestWriteSinkAcceptRules_SupersetAcceptAllowed tests that accept can be a strict
+// superset of the agent's secrecy — extra entries are harmless.
+func TestWriteSinkAcceptRules_SupersetAcceptAllowed(t *testing.T) {
+	// Accept covers MORE than the agent has — should still work
+	accept := []string{"private:github/gh-aw*", "private:github/copilot*", "private:extra"}
+	g := NewWriteSinkGuard(accept)
+
+	// Agent only has one secrecy tag
+	agentSecrecy := difc.NewSecrecyLabelWithTags([]difc.Tag{"private:github/gh-aw*"})
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.True(t, result.IsAllowed(), "superset accept: extra entries are harmless; got: %s", result.Reason)
+}
+
+// TestWriteSinkAcceptRules_EmptyAgentSecrecy tests that an agent with no secrecy
+// (repos="all" or repos="public") can write to ANY sink, even without a write-sink.
+func TestWriteSinkAcceptRules_EmptyAgentSecrecy(t *testing.T) {
+	// Even an empty accept works if agent has no secrecy
+	g := NewWriteSinkGuard([]string{})
+
+	agentSecrecy := difc.NewSecrecyLabelWithTags(nil) // repos="all" or repos="public"
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.True(t, result.IsAllowed(), "empty agent secrecy: always passes write check; got: %s", result.Reason)
+}
+
+// TestWriteSinkAcceptRules_PartialAcceptFails tests that if accept covers only SOME
+// of the agent's secrecy tags, the write is blocked.
+func TestWriteSinkAcceptRules_PartialAcceptFails(t *testing.T) {
+	// Accept only covers one of two agent secrecy tags
+	accept := []string{"private:github/repo1"}
+	g := NewWriteSinkGuard(accept)
+
+	// Agent has two secrecy tags from repos=["github/repo1", "github/repo2"]
+	agentSecrecy := difc.NewSecrecyLabelWithTags([]difc.Tag{
+		"private:github/repo1",
+		"private:github/repo2",
+	})
+	agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+	resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+	require.NoError(t, err)
+
+	evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+	result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+	assert.False(t, result.IsAllowed(),
+		"partial accept: 'private:github/repo2' not covered → write blocked")
+}
+
+// TestWriteSinkAcceptRules_AllScopeTypes is a comprehensive table-driven test
+// covering all possible allow-only repos → write-sink accept mappings.
+func TestWriteSinkAcceptRules_AllScopeTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		repos         string // human description of the repos config
+		agentSecrecy  []difc.Tag
+		accept        []string
+		expectAllowed bool
+	}{
+		{
+			name:          "repos=all → empty secrecy, no sink needed",
+			repos:         `"all"`,
+			agentSecrecy:  nil,
+			accept:        []string{},
+			expectAllowed: true,
+		},
+		{
+			name:          "repos=public → empty secrecy, no sink needed",
+			repos:         `"public"`,
+			agentSecrecy:  nil,
+			accept:        []string{},
+			expectAllowed: true,
+		},
+		{
+			name:          "repos=[org/repo] → accept=[private:org/repo]",
+			repos:         `["github/gh-aw"]`,
+			agentSecrecy:  []difc.Tag{"private:github/gh-aw"},
+			accept:        []string{"private:github/gh-aw"},
+			expectAllowed: true,
+		},
+		{
+			name:          "repos=[org/*] → accept=[private:org]",
+			repos:         `["myorg/*"]`,
+			agentSecrecy:  []difc.Tag{"private:myorg"},
+			accept:        []string{"private:myorg"},
+			expectAllowed: true,
+		},
+		{
+			name:          "repos=[org/prefix*] → accept=[private:org/prefix*]",
+			repos:         `["github/gh-aw*"]`,
+			agentSecrecy:  []difc.Tag{"private:github/gh-aw*"},
+			accept:        []string{"private:github/gh-aw*"},
+			expectAllowed: true,
+		},
+		{
+			name:          "repos=[O/R1, O/R2] → accept=[private:O/R1, private:O/R2]",
+			repos:         `["github/repo1", "github/repo2"]`,
+			agentSecrecy:  []difc.Tag{"private:github/repo1", "private:github/repo2"},
+			accept:        []string{"private:github/repo1", "private:github/repo2"},
+			expectAllowed: true,
+		},
+		{
+			name:          "repos=[O1/*, O2/R] → accept=[private:O1, private:O2/R]",
+			repos:         `["myorg/*", "partner/lib"]`,
+			agentSecrecy:  []difc.Tag{"private:myorg", "private:partner/lib"},
+			accept:        []string{"private:myorg", "private:partner/lib"},
+			expectAllowed: true,
+		},
+		{
+			name:          "repos=[O/P*, O/R] → accept=[private:O/P*, private:O/R]",
+			repos:         `["github/gh-aw*", "github/copilot"]`,
+			agentSecrecy:  []difc.Tag{"private:github/gh-aw*", "private:github/copilot"},
+			accept:        []string{"private:github/gh-aw*", "private:github/copilot"},
+			expectAllowed: true,
+		},
+		// Failure cases
+		{
+			name:          "FAIL: repos=[org/*] with wrong accept format org/*",
+			repos:         `["myorg/*"]`,
+			agentSecrecy:  []difc.Tag{"private:myorg"},
+			accept:        []string{"private:myorg/*"}, // WRONG: should be "private:myorg"
+			expectAllowed: false,
+		},
+		{
+			name:          "FAIL: repos=[O/R1, O/R2] with partial accept",
+			repos:         `["github/repo1", "github/repo2"]`,
+			agentSecrecy:  []difc.Tag{"private:github/repo1", "private:github/repo2"},
+			accept:        []string{"private:github/repo1"}, // missing repo2
+			expectAllowed: false,
+		},
+		{
+			name:          "FAIL: repos=[org/repo] with different repo in accept",
+			repos:         `["github/gh-aw"]`,
+			agentSecrecy:  []difc.Tag{"private:github/gh-aw"},
+			accept:        []string{"private:github/other-repo"},
+			expectAllowed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWriteSinkGuard(tc.accept)
+
+			agentSecrecy := difc.NewSecrecyLabelWithTags(tc.agentSecrecy)
+			agentIntegrity := difc.NewIntegrityLabelWithTags(nil)
+
+			resource, operation, err := g.LabelResource(context.Background(), "create_issue", nil, nil, nil)
+			require.NoError(t, err)
+
+			evaluator := difc.NewEvaluatorWithMode(difc.EnforcementFilter)
+			result := evaluator.Evaluate(agentSecrecy, agentIntegrity, resource, operation)
+
+			if tc.expectAllowed {
+				assert.True(t, result.IsAllowed(),
+					"repos=%s: write should be allowed; got: %s", tc.repos, result.Reason)
+			} else {
+				assert.False(t, result.IsAllowed(),
+					"repos=%s: write should be blocked", tc.repos)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Documents and tests the mapping from `allow-only.repos` configuration to the required `write-sink.accept` values, and fixes a validation bug for owner-wildcard scopes.

## Bug Fix

`validateAcceptEntry` previously rejected bare owner names like `"private:myorg"`. This is the exact secrecy tag produced by the GitHub guard's `label_agent` when `repos=["myorg/*"]` (owner wildcard scope). The fix relaxes validation to accept both `"visibility:owner"` and `"visibility:owner/repo"` formats.

## Accept Rules

| `allow-only.repos` | Agent secrecy | `write-sink.accept` |
|---|---|---|
| `"all"` | `[]` | Not needed |
| `"public"` | `[]` | Not needed |
| `["owner/repo"]` | `["private:owner/repo"]` | `["private:owner/repo"]` |
| `["owner/*"]` | `["private:owner"]` | `["private:owner"]` |
| `["owner/prefix*"]` | `["private:owner/prefix*"]` | `["private:owner/prefix*"]` |

Key: `repos=["owner/*"]` → bare owner tag `"private:owner"` (no `/*` suffix). DIFC tags are exact string matches.

## Changes

- **`internal/config/guard_policy.go`**: Fix `validateAcceptEntry` to accept bare owner names; add `WriteSinkAcceptRules` godoc
- **`internal/guard/write_sink_test.go`**: 11 new DIFC evaluation tests covering all scope types
- **`internal/config/config_guardpolicies_test.go`**: 27 new validation test cases (accept entry formats + policy validation)
- **`internal/config/config_difc_test.go`**: Fix existing test that used bare owner as invalid input
- **`README.md`**: New "Mapping allow-only repos to write-sink accept" section with rules table

## Testing

`make agent-finished` passes (format, build, lint, all tests).