### PR TITLE
fix: suppress staticcheck SA1012 for intentional nil context test

### DIFF
--- a/internal/mcp/sdk_method_dispatch_test.go
+++ b/internal/mcp/sdk_method_dispatch_test.go
@@ -16,8 +16,7 @@ import (
 // GetAgentTagsSnapshotFromContext helper.
 func TestGetAgentTagsSnapshotFromContext(t *testing.T) {
 	t.Run("nil context returns false", func(t *testing.T) {
-		//nolint:staticcheck // SA1012: intentionally testing nil context handling
-		snapshot, ok := GetAgentTagsSnapshotFromContext(nil) //nolint:staticcheck
+		snapshot, ok := GetAgentTagsSnapshotFromContext(nil) //nolint:staticcheck // SA1012: intentionally testing nil context handling
 		assert.False(t, ok)
 		assert.Nil(t, snapshot)
 	})


### PR DESCRIPTION
Fixes `staticcheck` SA1012 lint error in `sdk_method_dispatch_test.go`. The test intentionally passes `nil` to `GetAgentTagsSnapshotFromContext` to verify graceful nil handling. Added `nolint:staticcheck` directive.

`make agent-finished` passes cleanly.