### PR TITLE
chore: disable issue-monster scheduled runs

### DIFF
--- a/.github/workflows/issue-monster.lock.yml
+++ b/.github/workflows/issue-monster.lock.yml
@@ -23,13 +23,10 @@
 #
 # The Cookie Monster of issues - assigns issues to Copilot agents one at a time
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"95259803e02e3003f6fe2b4f6125755bdfa0dddca55460e7ce3a365410b33a6e","compiler_version":"v0.58.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"4ba51a885267614c321eb1dbe60fc067c7aa822fbb877b7d9536debce71c55c0","compiler_version":"v0.58.2","strict":true}
 
 name: "Issue Monster"
 "on":
-  schedule:
-  - cron: "10 */1 * * *"
-    # Friendly format: every 1h (scattered)
   # skip-if-match: # Skip-if-match processed as search check in pre-activation job
     # max: 9
     # query: is:pr is:open is:draft author:app/copilot-swe-agent
@@ -252,8 +249,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    concurrency:
-      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""

--- a/.github/workflows/issue-monster.md
+++ b/.github/workflows/issue-monster.md
@@ -3,7 +3,6 @@ name: Issue Monster
 description: The Cookie Monster of issues - assigns issues to Copilot agents one at a time
 on:
   workflow_dispatch:
-  schedule: every 1h
   skip-if-match:
     query: "is:pr is:open is:draft author:app/copilot-swe-agent"
     max: 9


### PR DESCRIPTION
Removes the `schedule: every 1h` trigger from issue-monster. It was creating too many issues.

The workflow can still be triggered manually via `workflow_dispatch`.