### PR TITLE
refactor: deduplicate code across logger, validation, and launcher packages

### DIFF
--- a/internal/config/rules/rules.go
+++ b/internal/config/rules/rules.go
@@ -249,3 +249,36 @@ func AbsolutePath(value, fieldName, jsonPath string) *ValidationError {
 		Suggestion: "Use an absolute path: Unix paths start with '/' (e.g., '/tmp/payloads'), Windows paths start with a drive letter (e.g., 'C:\\payloads')",
 	}
 }
+
+// InvalidPattern creates a ValidationError for values that don't match a required pattern.
+// Used by validation_schema.go for container, mount, URL, and other pattern validations.
+func InvalidPattern(fieldName, value, jsonPath, suggestion string) *ValidationError {
+	return &ValidationError{
+		Field:      fieldName,
+		Message:    fmt.Sprintf("%s '%s' does not match required pattern", fieldName, value),
+		JSONPath:   jsonPath,
+		Suggestion: suggestion,
+	}
+}
+
+// InvalidValue creates a ValidationError for field values that violate a constraint.
+// The message describes the specific constraint violation.
+func InvalidValue(fieldName, message, jsonPath, suggestion string) *ValidationError {
+	return &ValidationError{
+		Field:      fieldName,
+		Message:    message,
+		JSONPath:   jsonPath,
+		Suggestion: suggestion,
+	}
+}
+
+// SchemaValidationError creates a ValidationError for custom schema validation failures.
+// Used by validation.go for the various stages of custom schema fetching, parsing, and validation.
+func SchemaValidationError(serverType, message, jsonPath, suggestion string) *ValidationError {
+	return &ValidationError{
+		Field:      "type",
+		Message:    fmt.Sprintf("%s for server type '%s'", message, serverType),
+		JSONPath:   jsonPath,
+		Suggestion: suggestion,
+	}
+}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -206,12 +206,10 @@ func validateAgainstCustomSchema(name string, server *StdinServerConfig, schemaU
 	schemaJSON, err := fetchAndFixSchema(schemaURL)
 	if err != nil {
 		logValidation.Printf("Failed to fetch custom schema: name=%s, url=%s, error=%v", name, schemaURL, err)
-		return &rules.ValidationError{
-			Field:      "type",
-			Message:    fmt.Sprintf("failed to fetch custom schema for server type '%s': %v", server.Type, err),
-			JSONPath:   jsonPath,
-			Suggestion: fmt.Sprintf("Ensure the schema URL '%s' is accessible and returns a valid JSON Schema", schemaURL),
-		}
+		return rules.SchemaValidationError(server.Type,
+			fmt.Sprintf("failed to fetch custom schema: %v", err),
+			jsonPath,
+			fmt.Sprintf("Ensure the schema URL '%s' is accessible and returns a valid JSON Schema", schemaURL))
 	}
 
 	logValidation.Printf("Custom schema fetched successfully: name=%s, size=%d bytes", name, len(schemaJSON))
@@ -219,12 +217,10 @@ func validateAgainstCustomSchema(name string, server *StdinServerConfig, schemaU
 	// Parse the schema to extract its $id
 	var schemaObj map[string]interface{}
 	if err := json.Unmarshal(schemaJSON, &schemaObj); err != nil {
-		return &rules.ValidationError{
-			Field:      "type",
-			Message:    fmt.Sprintf("failed to parse custom schema for server type '%s': %v", server.Type, err),
-			JSONPath:   jsonPath,
-			Suggestion: fmt.Sprintf("The schema at '%s' must be valid JSON", schemaURL),
-		}
+		return rules.SchemaValidationError(server.Type,
+			fmt.Sprintf("failed to parse custom schema: %v", err),
+			jsonPath,
+			fmt.Sprintf("The schema at '%s' must be valid JSON", schemaURL))
 	}
 
 	schemaID, ok := schemaObj["$id"].(string)
@@ -238,32 +234,26 @@ func validateAgainstCustomSchema(name string, server *StdinServerConfig, schemaU
 
 	// Add the schema with both URLs (the fetch URL and the $id URL)
 	if err := compiler.AddResource(schemaURL, strings.NewReader(string(schemaJSON))); err != nil {
-		return &rules.ValidationError{
-			Field:      "type",
-			Message:    fmt.Sprintf("failed to compile custom schema for server type '%s': %v", server.Type, err),
-			JSONPath:   jsonPath,
-			Suggestion: fmt.Sprintf("The schema at '%s' must be a valid JSON Schema Draft 7 document", schemaURL),
-		}
+		return rules.SchemaValidationError(server.Type,
+			fmt.Sprintf("failed to compile custom schema: %v", err),
+			jsonPath,
+			fmt.Sprintf("The schema at '%s' must be a valid JSON Schema Draft 7 document", schemaURL))
 	}
 	if schemaID != schemaURL {
 		if err := compiler.AddResource(schemaID, strings.NewReader(string(schemaJSON))); err != nil {
-			return &rules.ValidationError{
-				Field:      "type",
-				Message:    fmt.Sprintf("failed to compile custom schema with $id for server type '%s': %v", server.Type, err),
-				JSONPath:   jsonPath,
-				Suggestion: fmt.Sprintf("Check the $id field in the schema at '%s'", schemaURL),
-			}
+			return rules.SchemaValidationError(server.Type,
+				fmt.Sprintf("failed to compile custom schema with $id: %v", err),
+				jsonPath,
+				fmt.Sprintf("Check the $id field in the schema at '%s'", schemaURL))
 		}
 	}
 
 	schema, err := compiler.Compile(schemaID)
 	if err != nil {
-		return &rules.ValidationError{
-			Field:      "type",
-			Message:    fmt.Sprintf("failed to compile custom schema for server type '%s': %v", server.Type, err),
-			JSONPath:   jsonPath,
-			Suggestion: fmt.Sprintf("The schema at '%s' must be a valid JSON Schema Draft 7 document", schemaURL),
-		}
+		return rules.SchemaValidationError(server.Type,
+			fmt.Sprintf("failed to compile custom schema: %v", err),
+			jsonPath,
+			fmt.Sprintf("The schema at '%s' must be a valid JSON Schema Draft 7 document", schemaURL))
 	}
 
 	logValidation.Printf("Custom schema compiled successfully: name=%s", name)
@@ -275,22 +265,16 @@ func validateAgainstCustomSchema(name string, server *StdinServerConfig, schemaU
 	// Marshal the struct to JSON first
 	serverJSON, err := json.Marshal(server)
 	if err != nil {
-		return &rules.ValidationError{
-			Field:      "type",
-			Message:    fmt.Sprintf("failed to marshal server config for validation: %v", err),
-			JSONPath:   jsonPath,
-			Suggestion: "Internal error - please report this issue",
-		}
+		return rules.SchemaValidationError(server.Type,
+			fmt.Sprintf("failed to marshal server config for validation: %v", err),
+			jsonPath, "Internal error - please report this issue")
 	}
 
 	// Unmarshal to map to get struct fields
 	if err := json.Unmarshal(serverJSON, &serverMap); err != nil {
-		return &rules.ValidationError{
-			Field:      "type",
-			Message:    fmt.Sprintf("failed to unmarshal server config for validation: %v", err),
-			JSONPath:   jsonPath,
-			Suggestion: "Internal error - please report this issue",
-		}
+		return rules.SchemaValidationError(server.Type,
+			fmt.Sprintf("failed to unmarshal server config for validation: %v", err),
+			jsonPath, "Internal error - please report this issue")
 	}
 
 	// Merge additional properties (custom fields) into the map
@@ -301,12 +285,10 @@ func validateAgainstCustomSchema(name string, server *StdinServerConfig, schemaU
 	// Validate the merged map against the custom schema
 	if err := schema.Validate(serverMap); err != nil {
 		logValidation.Printf("Custom schema validation failed: name=%s, error=%v", name, err)
-		return &rules.ValidationError{
-			Field:      "type",
-			Message:    fmt.Sprintf("server configuration does not match custom schema for type '%s': %v", server.Type, err),
-			JSONPath:   jsonPath,
-			Suggestion: fmt.Sprintf("Update the server configuration to match the schema requirements at '%s'", schemaURL),
-		}
+		return rules.SchemaValidationError(server.Type,
+			fmt.Sprintf("server configuration does not match custom schema: %v", err),
+			jsonPath,
+			fmt.Sprintf("Update the server configuration to match the schema requirements at '%s'", schemaURL))
 	}
 
 	logValidation.Printf("Custom schema validation passed: name=%s, type=%s", name, server.Type)
@@ -331,12 +313,10 @@ func validateCustomSchemas(customSchemas map[string]interface{}) error {
 		if schemaURL, ok := schemaValue.(string); ok && schemaURL != "" {
 			if !strings.HasPrefix(schemaURL, "https://") {
 				logValidation.Printf("Non-HTTPS schema URL in customSchemas: typeName=%s, url=%s", typeName, schemaURL)
-				return &rules.ValidationError{
-					Field:      "customSchemas." + typeName,
-					Message:    fmt.Sprintf("custom schema URL must use HTTPS, got '%s'", schemaURL),
-					JSONPath:   "customSchemas." + typeName,
-					Suggestion: "Use an HTTPS URL for the custom schema (e.g., 'https://example.com/schema.json')",
-				}
+				return rules.InvalidValue("customSchemas."+typeName,
+					fmt.Sprintf("custom schema URL must use HTTPS, got '%s'", schemaURL),
+					"customSchemas."+typeName,
+					"Use an HTTPS URL for the custom schema (e.g., 'https://example.com/schema.json')")
 			}
 		}
 	}

--- a/internal/config/validation_schema.go
+++ b/internal/config/validation_schema.go
@@ -421,46 +421,34 @@ func validateStringPatterns(stdinCfg *StdinConfig) error {
 		// Validate container pattern for stdio servers
 		if server.Type == "" || server.Type == "stdio" || server.Type == "local" {
 			if server.Container != "" && !containerPattern.MatchString(server.Container) {
-				return &rules.ValidationError{
-					Field:      "container",
-					Message:    fmt.Sprintf("container image '%s' does not match required pattern", server.Container),
-					JSONPath:   fmt.Sprintf("%s.container", jsonPath),
-					Suggestion: "Use a valid container image format (e.g., 'ghcr.io/owner/image:tag' or 'owner/image:latest')",
-				}
+				return rules.InvalidPattern("container", server.Container,
+					fmt.Sprintf("%s.container", jsonPath),
+					"Use a valid container image format (e.g., 'ghcr.io/owner/image:tag' or 'owner/image:latest')")
 			}
 
 			// Validate mount patterns
 			for i, mount := range server.Mounts {
 				if !mountPattern.MatchString(mount) {
-					return &rules.ValidationError{
-						Field:      "mounts",
-						Message:    fmt.Sprintf("mount '%s' does not match required pattern", mount),
-						JSONPath:   fmt.Sprintf("%s.mounts[%d]", jsonPath, i),
-						Suggestion: "Use format 'source:dest:mode' where mode is 'ro' or 'rw'",
-					}
+					return rules.InvalidPattern("mounts", mount,
+						fmt.Sprintf("%s.mounts[%d]", jsonPath, i),
+						"Use format 'source:dest:mode' where mode is 'ro' or 'rw'")
 				}
 			}
 
 			// Validate entrypoint is not empty if provided
 			if server.Entrypoint != "" && len(strings.TrimSpace(server.Entrypoint)) == 0 {
-				return &rules.ValidationError{
-					Field:      "entrypoint",
-					Message:    "entrypoint cannot be empty or whitespace only",
-					JSONPath:   fmt.Sprintf("%s.entrypoint", jsonPath),
-					Suggestion: "Provide a valid entrypoint path or remove the field",
-				}
+				return rules.InvalidValue("entrypoint", "entrypoint cannot be empty or whitespace only",
+					fmt.Sprintf("%s.entrypoint", jsonPath),
+					"Provide a valid entrypoint path or remove the field")
 			}
 		}
 
 		// Validate URL pattern for HTTP servers
 		if server.Type == "http" {
 			if server.URL != "" && !urlPattern.MatchString(server.URL) {
-				return &rules.ValidationError{
-					Field:      "url",
-					Message:    fmt.Sprintf("url '%s' does not match required pattern", server.URL),
-					JSONPath:   fmt.Sprintf("%s.url", jsonPath),
-					Suggestion: "Use a valid HTTP or HTTPS URL (e.g., 'https://api.example.com/mcp')",
-				}
+				return rules.InvalidPattern("url", server.URL,
+					fmt.Sprintf("%s.url", jsonPath),
+					"Use a valid HTTP or HTTPS URL (e.g., 'https://api.example.com/mcp')")
 			}
 		}
 	}
@@ -477,12 +465,10 @@ func validateStringPatterns(stdinCfg *StdinConfig) error {
 		if stdinCfg.Gateway.Domain != "" {
 			domain := stdinCfg.Gateway.Domain
 			if domain != "localhost" && domain != "host.docker.internal" && !domainVarPattern.MatchString(domain) {
-				return &rules.ValidationError{
-					Field:      "domain",
-					Message:    fmt.Sprintf("domain '%s' must be 'localhost', 'host.docker.internal', or a variable expression", domain),
-					JSONPath:   "gateway.domain",
-					Suggestion: "Use 'localhost', 'host.docker.internal', or a variable like '${MCP_GATEWAY_DOMAIN}'",
-				}
+				return rules.InvalidValue("domain",
+					fmt.Sprintf("domain '%s' must be 'localhost', 'host.docker.internal', or a variable expression", domain),
+					"gateway.domain",
+					"Use 'localhost', 'host.docker.internal', or a variable like '${MCP_GATEWAY_DOMAIN}'")
 			}
 		}
 	}

--- a/internal/launcher/log_helpers.go
+++ b/internal/launcher/log_helpers.go
@@ -29,13 +29,13 @@ func (l *Launcher) logSecurityWarning(serverID string, serverCfg *config.ServerC
 
 // logLaunchStart logs server launch initiation
 func (l *Launcher) logLaunchStart(serverID, sessionID string, serverCfg *config.ServerConfig, isDirectCommand bool) {
+	suffix := sessionSuffix(sessionID)
+	logger.LogInfoWithServer(serverID, "backend", "Launching MCP backend server%s: server=%s%s, command=%s, args=%v",
+		suffix, serverID, suffix, serverCfg.Command, sanitize.SanitizeArgs(serverCfg.Args))
+	log.Printf("[LAUNCHER] Starting MCP server: %s%s", serverID, suffix)
 	if sessionID != "" {
-		logger.LogInfoWithServer(serverID, "backend", "Launching MCP backend server for session: server=%s, session=%s, command=%s, args=%v", serverID, sessionID, serverCfg.Command, sanitize.SanitizeArgs(serverCfg.Args))
-		log.Printf("[LAUNCHER] Starting MCP server for session: %s (session: %s)", serverID, sessionID)
 		logLauncher.Printf("Launching new session server: serverID=%s, sessionID=%s, command=%s", serverID, sessionID, serverCfg.Command)
 	} else {
-		logger.LogInfoWithServer(serverID, "backend", "Launching MCP backend server: %s, command=%s, args=%v", serverID, serverCfg.Command, sanitize.SanitizeArgs(serverCfg.Args))
-		log.Printf("[LAUNCHER] Starting MCP server: %s", serverID)
 		logLauncher.Printf("Launching new server: serverID=%s, command=%s, inContainer=%v, isDirectCommand=%v",
 			serverID, serverCfg.Command, l.runningInContainer, isDirectCommand)
 	}
@@ -96,31 +96,19 @@ func (l *Launcher) logLaunchError(serverID, sessionID string, err error, serverC
 
 // logTimeoutError logs startup timeout diagnostics
 func (l *Launcher) logTimeoutError(serverID, sessionID string) {
+	suffix := sessionSuffix(sessionID)
 	logger.LogErrorWithServer(serverID, "backend", "MCP backend server startup timeout%s: server=%s%s, timeout=%v",
-		sessionSuffix(sessionID), serverID, sessionSuffix(sessionID), l.startupTimeout)
-	if sessionID != "" {
-		log.Printf("[LAUNCHER] ❌ Server '%s' (session: %s) startup timed out after %v", serverID, sessionID, l.startupTimeout)
-	} else {
-		log.Printf("[LAUNCHER] ❌ Server '%s' startup timed out after %v", serverID, l.startupTimeout)
-	}
+		suffix, serverID, suffix, l.startupTimeout)
+	log.Printf("[LAUNCHER] ❌ Server '%s'%s startup timed out after %v", serverID, suffix, l.startupTimeout)
 	log.Printf("[LAUNCHER] ⚠️  The server may be hanging or taking too long to initialize")
 	log.Printf("[LAUNCHER] ⚠️  Consider increasing 'startupTimeout' in gateway config if server needs more time")
-	if sessionID != "" {
-		logLauncher.Printf("Startup timeout occurred: serverID=%s, sessionID=%s, timeout=%v", serverID, sessionID, l.startupTimeout)
-	} else {
-		logLauncher.Printf("Startup timeout occurred: serverID=%s, timeout=%v", serverID, l.startupTimeout)
-	}
+	logLauncher.Printf("Startup timeout occurred: serverID=%s%s, timeout=%v", serverID, suffix, l.startupTimeout)
 }
 
 // logLaunchSuccess logs successful server launch
 func (l *Launcher) logLaunchSuccess(serverID, sessionID string) {
-	if sessionID != "" {
-		logger.LogInfoWithServer(serverID, "backend", "Successfully launched MCP backend server for session: server=%s, session=%s", serverID, sessionID)
-		log.Printf("[LAUNCHER] Successfully launched: %s (session: %s)", serverID, sessionID)
-		logLauncher.Printf("Session connection established: serverID=%s, sessionID=%s", serverID, sessionID)
-	} else {
-		logger.LogInfoWithServer(serverID, "backend", "Successfully launched MCP backend server: %s", serverID)
-		log.Printf("[LAUNCHER] Successfully launched: %s", serverID)
-		logLauncher.Printf("Connection established: serverID=%s", serverID)
-	}
+	suffix := sessionSuffix(sessionID)
+	logger.LogInfoWithServer(serverID, "backend", "Successfully launched MCP backend server%s: server=%s%s", suffix, serverID, suffix)
+	log.Printf("[LAUNCHER] Successfully launched: %s%s", serverID, suffix)
+	logLauncher.Printf("Connection established: serverID=%s%s", serverID, suffix)
 }

--- a/internal/logger/common.go
+++ b/internal/logger/common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 // Close Pattern for Logger Types
@@ -261,6 +262,14 @@ import (
 // When adding a new logger access point:
 //  1. Use withGlobalLogger instead of manual RLock/RUnlock
 //  2. Pass the appropriate mutex, logger pointer, and callback function
+
+// formatLogLine builds the standard log line used by FileLogger and ServerFileLogger.
+// Centralizing the format ensures consistency across all file-based loggers.
+func formatLogLine(level LogLevel, category, format string, args ...interface{}) string {
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	message := fmt.Sprintf(format, args...)
+	return fmt.Sprintf("[%s] [%s] [%s] %s", timestamp, level, category, message)
+}
 
 // It syncs buffered data before closing and handles errors appropriately.
 // The mutex should already be held by the caller.

--- a/internal/logger/file_logger.go
+++ b/internal/logger/file_logger.go
@@ -1,13 +1,11 @@
 package logger
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 )
 
 // FileLogger manages logging to a file with fallback to stdout
@@ -82,10 +80,7 @@ func (fl *FileLogger) Log(level LogLevel, category, format string, args ...inter
 	fl.mu.Lock()
 	defer fl.mu.Unlock()
 
-	timestamp := time.Now().UTC().Format(time.RFC3339)
-	message := fmt.Sprintf(format, args...)
-
-	logLine := fmt.Sprintf("[%s] [%s] [%s] %s", timestamp, level, category, message)
+	logLine := formatLogLine(level, category, format, args...)
 	fl.logger.Println(logLine)
 
 	// Flush the log to disk immediately to ensure it's readable by other processes

--- a/internal/logger/server_file_logger.go
+++ b/internal/logger/server_file_logger.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 )
 
 // ServerFileLogger manages per-serverID log files
@@ -108,10 +107,7 @@ func (sfl *ServerFileLogger) Log(serverID string, level LogLevel, category, form
 		return
 	}
 
-	timestamp := time.Now().UTC().Format(time.RFC3339)
-	message := fmt.Sprintf(format, args...)
-	logLine := fmt.Sprintf("[%s] [%s] [%s] %s", timestamp, level, category, message)
-
+	logLine := formatLogLine(level, category, format, args...)
 	logger.Println(logLine)
 
 	// Flush to disk immediately


### PR DESCRIPTION
## Summary

Addresses all 15 open duplicate-code issues by implementing 4 targeted refactorings and closing issues where patterns were already resolved.

## Changes

### 1. `formatLogLine` helper (logger/common.go)
Centralizes the `[timestamp] [level] [category] message` log line format used identically by `FileLogger.Log()` and `ServerFileLogger.Log()`.

### 2. Session-conditional logging (launcher/log_helpers.go)
Consolidates `if sessionID != ""` branches in `logLaunchStart`, `logTimeoutError`, and `logLaunchSuccess` using the existing `sessionSuffix()` helper consistently.

### 3. `InvalidPattern` + `InvalidValue` helpers (config/rules/rules.go)
New reusable helpers for pattern validation and constraint violations. Applied to 5 inline `ValidationError` constructions in `validation_schema.go` (container, mount, URL, entrypoint, domain).

### 4. `SchemaValidationError` helper (config/rules/rules.go)
New helper for custom schema validation failures. Applied to 8 inline constructions in `validation.go` with consistent message format.

### Already resolved patterns (close only)
- **#1767** (DIFC tag mutation): `modifyTag` helper already exists in `difc/agent.go`
- **#1768** (Global logger RWMutex): `withGlobalLogger` helper already exists in `logger/global_helpers.go`
- **#1766** (Logger init boilerplate): `initLogger` generic helper already exists in `logger/common.go`
- **#1813** (Auth header extraction): Already properly delegated to `auth.header.go`
- **#1883** (Log level dispatch): Already optimized with `logFuncs` map + one-liner wrappers

## Closes
#1882, #1824, #1810, #1766, #1768, #1885, #1811, #1825, #1767, #1883, #1826, #1812, #1884, #1813, #1827