### PR TITLE
fix: suppress dead_code warnings in github-guard

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/helpers.rs
+++ b/guards/github-guard/rust-guard/src/labels/helpers.rs
@@ -829,6 +829,7 @@ pub fn is_owner(author: &str, owner: &str) -> bool {
 }
 
 /// Check if a user appears to be a bot
+#[allow(dead_code)]
 pub fn is_bot(username: &str) -> bool {
     let lower = username.to_lowercase();
     lower.ends_with("[bot]")

--- a/guards/github-guard/rust-guard/src/permissions.rs
+++ b/guards/github-guard/rust-guard/src/permissions.rs
@@ -3,6 +3,10 @@
 //! This module provides functions to query repository permissions
 //! using the backend MCP server. This enables dynamic integrity
 //! labeling based on actual GitHub permissions.
+//!
+//! Note: This module is scaffolding for future permission-based
+//! integrity labeling. Not yet wired into production code paths.
+#![allow(dead_code)]
 
 use crate::labels::{constants::label_constants, MEDIUM_BUFFER_SIZE};
 use serde_json::Value;


### PR DESCRIPTION
Fixes all 8 compiler warnings in the github-guard Rust crate.

## Changes


- **`labels/helpers.rs`**: Added `#[allow(dead_code)]` to `is_bot()` helper, which is only consumed by `permissions` tests.

## Verification

- `make test` (github-guard): 57 tests pass, 0 warnings
- `make agent-finished` (top-level): all checks pass