### PR TITLE
fix: restore #[allow(dead_code)] on is_bot helper

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/helpers.rs
+++ b/guards/github-guard/rust-guard/src/labels/helpers.rs
@@ -856,6 +856,7 @@ pub fn commit_integrity(
 }
 
 /// Check if a user appears to be a bot
+#[allow(dead_code)]
 pub fn is_bot(username: &str) -> bool {
     let lower = username.to_lowercase();
     lower.ends_with("[bot]")


### PR DESCRIPTION
The `#[allow(dead_code)]` annotation on `is_bot()` in `helpers.rs` was accidentally removed by commit dd179ba when cleaning up stale dead_code attributes. The function is only used by test code in `permissions.rs`, so it still needs the suppression.

**Change**: Add `#[allow(dead_code)]` back to `is_bot()` (1 line).

**Tests**: 57/57 pass, WASM build verified.