### PR TITLE
fix: suppress dead_code warning on is_forked_pull_request_with_callback

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/backend.rs
+++ b/guards/github-guard/rust-guard/src/labels/backend.rs
@@ -211,6 +211,7 @@ pub fn is_repo_private_with_callback(
 /// - `Some(true)` if the PR is from a fork (head repo differs from base repo)
 /// - `Some(false)` if the PR is direct (same repository)
 /// - `None` if the result cannot be determined
+#[allow(dead_code)]
 pub fn is_forked_pull_request_with_callback(
     callback: GithubMcpCallback,
     owner: &str,


### PR DESCRIPTION
Adds `#[allow(dead_code)]` to `is_forked_pull_request_with_callback` in `backend.rs`.

This function is only called from tests (same pattern as `is_bot`, `is_owner`, and `is_repo_private` helpers which already have the annotation).

**Before:** `warning: function `is_forked_pull_request_with_callback` is never used`
**After:** Clean build, 66 tests pass, zero warnings.