### PR TITLE
feat(guard): elevate trusted first-party bot integrity to approved

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/backend.rs
+++ b/guards/github-guard/rust-guard/src/labels/backend.rs
@@ -35,8 +35,16 @@ fn set_cached_repo_visibility(repo_id: &str, is_private: bool) {
 #[derive(Debug, Clone)]
 pub struct PullRequestFacts {
     pub author_association: Option<String>,
+    pub author_login: Option<String>,
     pub is_merged: bool,
     pub is_forked: Option<bool>,
+}
+
+/// Author information for an issue, including login and association.
+#[derive(Debug, Clone)]
+pub struct IssueAuthorInfo {
+    pub author_association: Option<String>,
+    pub author_login: Option<String>,
 }
 
 /// Check whether a repository is private using the backend MCP server.
@@ -332,14 +340,22 @@ pub fn get_pull_request_facts_with_callback(
         .and_then(|v| v.as_str())
         .map(String::from);
 
+    let author_login = pr
+        .get("user")
+        .and_then(|u| u.get("login"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
     Some(PullRequestFacts {
         author_association,
+        author_login,
         is_merged,
         is_forked,
     })
 }
 
 /// Fetch issue author_association value for resource-level initialization.
+#[allow(dead_code)]
 pub fn get_issue_author_association_with_callback(
     callback: GithubMcpCallback,
     owner: &str,
@@ -383,8 +399,64 @@ pub fn get_pull_request_facts(
     get_pull_request_facts_with_callback(crate::invoke_backend, owner, repo, pull_number)
 }
 
+#[allow(dead_code)]
 pub fn get_issue_author_association(owner: &str, repo: &str, issue_number: &str) -> Option<String> {
     get_issue_author_association_with_callback(crate::invoke_backend, owner, repo, issue_number)
+}
+
+/// Fetch issue author info (association + login) for resource-level initialization.
+pub fn get_issue_author_info_with_callback(
+    callback: GithubMcpCallback,
+    owner: &str,
+    repo: &str,
+    issue_number: &str,
+) -> Option<IssueAuthorInfo> {
+    if owner.is_empty() || repo.is_empty() || issue_number.is_empty() {
+        return None;
+    }
+
+    let args = serde_json::json!({
+        "owner": owner,
+        "repo": repo,
+        "issue_number": issue_number,
+    });
+
+    let args_str = args.to_string();
+    let mut result_buffer = vec![0u8; SMALL_BUFFER_SIZE];
+
+    let len = match callback("issue_read", &args_str, &mut result_buffer) {
+        Ok(len) if len > 0 => len,
+        _ => return None,
+    };
+
+    let response_str = std::str::from_utf8(&result_buffer[..len]).ok()?;
+    let response = serde_json::from_str::<Value>(response_str).ok()?;
+    let issue = super::extract_mcp_response(&response);
+
+    let author_association = issue
+        .get("author_association")
+        .or_else(|| issue.get("authorAssociation"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let author_login = issue
+        .get("user")
+        .and_then(|u| u.get("login"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    Some(IssueAuthorInfo {
+        author_association,
+        author_login,
+    })
+}
+
+pub fn get_issue_author_info(
+    owner: &str,
+    repo: &str,
+    issue_number: &str,
+) -> Option<IssueAuthorInfo> {
+    get_issue_author_info_with_callback(crate::invoke_backend, owner, repo, issue_number)
 }
 
 fn extract_repo_private_flag(response: &Value, repo_id: &str) -> Option<bool> {

--- a/guards/github-guard/rust-guard/src/labels/helpers.rs
+++ b/guards/github-guard/rust-guard/src/labels/helpers.rs
@@ -693,8 +693,27 @@ pub fn author_association_floor_from_str(
     }
 }
 
+/// Extract the author login from an item, checking common GitHub API fields.
+/// Returns empty string if no login found.
+fn extract_author_login(item: &Value) -> &str {
+    // Issues and PRs use user.login
+    let login = get_nested_str(item, "user", "login");
+    if !login.is_empty() {
+        return login;
+    }
+    // Commits use author.login
+    get_nested_str(item, "author", "login")
+}
+
 /// Extract author_association from an item and return initial integrity floor.
+/// Trusted first-party GitHub bots are elevated to approved (writer) integrity
+/// regardless of their author_association value.
 pub fn author_association_floor(item: &Value, scope: &str, ctx: &PolicyContext) -> Vec<String> {
+    let author_login = extract_author_login(item);
+    if !author_login.is_empty() && is_trusted_first_party_bot(author_login) {
+        return writer_integrity(scope, ctx);
+    }
+
     let association = item
         .get("author_association")
         .and_then(|v| v.as_str())
@@ -846,7 +865,29 @@ pub fn commit_integrity(
     ensure_integrity_baseline(repo_full_name, integrity, ctx)
 }
 
-/// Check if a user appears to be a bot
+/// Check if a user is a trusted first-party GitHub bot.
+///
+/// These bots are platform services whose presence requires explicit admin
+/// configuration. Their authored objects receive approved (writer) integrity
+/// regardless of author_association.
+///
+/// Trusted bots:
+/// - dependabot[bot]: GitHub dependency updater
+/// - github-actions[bot]: GitHub Actions workflow actor (GITHUB_TOKEN)
+/// - github-merge-queue[bot]: GitHub merge queue automation
+/// - copilot: GitHub Copilot AI assistant
+pub fn is_trusted_first_party_bot(username: &str) -> bool {
+    let lower = username.to_lowercase();
+    lower == "dependabot[bot]"
+        || lower == "github-actions[bot]"
+        || lower == "github-merge-queue[bot]"
+        || lower == "copilot"
+}
+
+/// Check if a user appears to be a bot (broad detection).
+///
+/// This is a broader check that includes third-party bots.
+/// For integrity elevation, use is_trusted_first_party_bot() instead.
 #[allow(dead_code)]
 pub fn is_bot(username: &str) -> bool {
     let lower = username.to_lowercase();

--- a/guards/github-guard/rust-guard/src/labels/mod.rs
+++ b/guards/github-guard/rust-guard/src/labels/mod.rs
@@ -826,6 +826,161 @@ mod tests {
     }
 
     #[test]
+    fn test_trusted_first_party_bot_detection() {
+        use super::helpers::is_trusted_first_party_bot;
+
+        // Trusted first-party bots
+        assert!(is_trusted_first_party_bot("dependabot[bot]"));
+        assert!(is_trusted_first_party_bot("github-actions[bot]"));
+        assert!(is_trusted_first_party_bot("github-merge-queue[bot]"));
+        assert!(is_trusted_first_party_bot("copilot"));
+
+        // Case-insensitive
+        assert!(is_trusted_first_party_bot("Dependabot[bot]"));
+        assert!(is_trusted_first_party_bot("GitHub-Actions[bot]"));
+        assert!(is_trusted_first_party_bot("Copilot"));
+
+        // Not trusted (third-party bots)
+        assert!(!is_trusted_first_party_bot("renovate[bot]"));
+        assert!(!is_trusted_first_party_bot("renovate-bot"));
+        assert!(!is_trusted_first_party_bot("codecov[bot]"));
+        assert!(!is_trusted_first_party_bot("snyk-bot"));
+
+        // Not bots
+        assert!(!is_trusted_first_party_bot("octocat"));
+        assert!(!is_trusted_first_party_bot("dependabot"));
+        assert!(!is_trusted_first_party_bot("github-actions"));
+        assert!(!is_trusted_first_party_bot(""));
+    }
+
+    #[test]
+    fn test_trusted_bot_issue_integrity_public_repo() {
+        let ctx = default_ctx();
+        let repo = "github/copilot";
+        let owner = "github";
+        let repo_name = "copilot";
+
+        // Trusted bot issue on public repo gets approved (writer) integrity
+        // even though author_association is NONE
+        let dependabot_issue = json!({
+            "user": {"login": "dependabot[bot]"},
+            "author_association": "NONE"
+        });
+        assert_eq!(
+            issue_integrity(&dependabot_issue, repo, owner, repo_name, false, &ctx),
+            writer_integrity(repo, &ctx)
+        );
+
+        let actions_issue = json!({
+            "user": {"login": "github-actions[bot]"},
+            "author_association": "NONE"
+        });
+        assert_eq!(
+            issue_integrity(&actions_issue, repo, owner, repo_name, false, &ctx),
+            writer_integrity(repo, &ctx)
+        );
+
+        let merge_queue_issue = json!({
+            "user": {"login": "github-merge-queue[bot]"}
+        });
+        assert_eq!(
+            issue_integrity(&merge_queue_issue, repo, owner, repo_name, false, &ctx),
+            writer_integrity(repo, &ctx)
+        );
+
+        let copilot_issue = json!({
+            "user": {"login": "copilot"},
+            "author_association": "NONE"
+        });
+        assert_eq!(
+            issue_integrity(&copilot_issue, repo, owner, repo_name, false, &ctx),
+            writer_integrity(repo, &ctx)
+        );
+
+        // Non-trusted bot still gets none integrity on public repo
+        let renovate_issue = json!({
+            "user": {"login": "renovate[bot]"},
+            "author_association": "NONE"
+        });
+        assert_eq!(
+            issue_integrity(&renovate_issue, repo, owner, repo_name, false, &ctx),
+            none_integrity(repo, &ctx)
+        );
+    }
+
+    #[test]
+    fn test_trusted_bot_pr_integrity_public_repo() {
+        let ctx = default_ctx();
+        let repo = "github/copilot";
+
+        // Trusted bot open PR on public repo gets approved (writer) integrity
+        let dependabot_pr = json!({
+            "user": {"login": "dependabot[bot]"},
+            "author_association": "NONE",
+            "merged": false
+        });
+        assert_eq!(
+            pr_integrity(&dependabot_pr, repo, false, Some(false), &ctx),
+            writer_integrity(repo, &ctx)
+        );
+
+        // Trusted bot forked PR still gets at least approved from bot status
+        let actions_forked_pr = json!({
+            "user": {"login": "github-actions[bot]"},
+            "author_association": "NONE",
+            "merged": false
+        });
+        assert_eq!(
+            pr_integrity(&actions_forked_pr, repo, false, Some(true), &ctx),
+            writer_integrity(repo, &ctx)
+        );
+
+        // Trusted bot merged PR gets merged integrity
+        let copilot_merged_pr = json!({
+            "user": {"login": "copilot"},
+            "author_association": "NONE",
+            "merged_at": "2024-01-15T10:00:00Z"
+        });
+        assert_eq!(
+            pr_integrity(&copilot_merged_pr, repo, false, Some(false), &ctx),
+            merged_integrity(repo, &ctx)
+        );
+
+        // Non-trusted bot open forked PR gets reader integrity only
+        let renovate_pr = json!({
+            "user": {"login": "renovate[bot]"},
+            "author_association": "NONE",
+            "merged": false
+        });
+        assert_eq!(
+            pr_integrity(&renovate_pr, repo, false, Some(true), &ctx),
+            reader_integrity(repo, &ctx)
+        );
+    }
+
+    #[test]
+    fn test_trusted_bot_commit_integrity() {
+        let ctx = default_ctx();
+        let repo = "github/copilot";
+
+        // Trusted bot commit on public non-default branch gets approved
+        let bot_commit = json!({
+            "author": {"login": "github-actions[bot]"},
+            "author_association": "NONE"
+        });
+        assert_eq!(
+            commit_integrity(&bot_commit, repo, false, false, &ctx),
+            writer_integrity(repo, &ctx)
+        );
+
+        // Trusted bot commit on default branch gets merged
+        assert_eq!(
+            commit_integrity(&bot_commit, repo, false, true, &ctx),
+            merged_integrity(repo, &ctx)
+        );
+    }
+
+    #[test]
     fn test_get_str_or() {
         let value = json!({"name": "Alice", "count": 42});
         assert_eq!(get_str_or(&value, "name", "default"), "Alice");

--- a/guards/github-guard/rust-guard/src/labels/tool_rules.rs
+++ b/guards/github-guard/rust-guard/src/labels/tool_rules.rs
@@ -9,8 +9,9 @@ use super::constants::{field_names, SENSITIVE_FILE_KEYWORDS, SENSITIVE_FILE_PATT
 use super::helpers::{
     author_association_floor_from_str, ensure_integrity_baseline, extract_number_as_string,
     extract_repo_info, extract_repo_info_from_search_query, is_default_branch_commit_context,
-    is_default_branch_ref, max_integrity, merged_integrity, policy_private_scope_label,
-    project_github_label, reader_integrity, secret_label, writer_integrity, PolicyContext,
+    is_default_branch_ref, is_trusted_first_party_bot, max_integrity, merged_integrity,
+    policy_private_scope_label, project_github_label, reader_integrity, secret_label,
+    writer_integrity, PolicyContext,
 };
 
 fn apply_repo_visibility_secrecy(
@@ -93,13 +94,27 @@ pub fn apply_tool_labels(
                 if let Some(issue_num) =
                     extract_number_as_string(tool_args, field_names::ISSUE_NUMBER)
                 {
-                    let floor = author_association_floor_from_str(
-                        repo_id,
-                        super::backend::get_issue_author_association(&owner, &repo, &issue_num)
-                            .as_deref(),
-                        ctx,
-                    );
-                    integrity = max_integrity(repo_id, integrity, floor, ctx);
+                    if let Some(info) =
+                        super::backend::get_issue_author_info(&owner, &repo, &issue_num)
+                    {
+                        let mut floor = author_association_floor_from_str(
+                            repo_id,
+                            info.author_association.as_deref(),
+                            ctx,
+                        );
+                        // Elevate trusted first-party bots to approved
+                        if let Some(ref login) = info.author_login {
+                            if is_trusted_first_party_bot(login) {
+                                floor = max_integrity(
+                                    repo_id,
+                                    floor,
+                                    writer_integrity(repo_id, ctx),
+                                    ctx,
+                                );
+                            }
+                        }
+                        integrity = max_integrity(repo_id, integrity, floor, ctx);
+                    }
                 }
             }
         }
@@ -133,6 +148,18 @@ pub fn apply_tool_labels(
                             facts.author_association.as_deref(),
                             ctx,
                         );
+
+                        // Elevate trusted first-party bots to approved
+                        if let Some(ref login) = facts.author_login {
+                            if is_trusted_first_party_bot(login) {
+                                integrity = max_integrity(
+                                    repo_id,
+                                    integrity,
+                                    writer_integrity(repo_id, ctx),
+                                    ctx,
+                                );
+                            }
+                        }
 
                         if repo_private == Some(true) {
                             integrity = max_integrity(


### PR DESCRIPTION
## Summary

Objects authored by trusted first-party GitHub bots now receive **approved (writer) integrity** regardless of their `author_association` value from the GitHub API.

## Problem

Bot-authored issues, PRs, and commits were receiving baseline `none` integrity because their `author_association` from the GitHub API is typically `NONE`. This caused them to be incorrectly blocked by guard policies with `min-integrity` settings above `none`.

For example, with `min-integrity: merged`, **all** dependabot PRs and github-actions issues were filtered out — even though these bots are trusted platform services explicitly configured by repo admins.

## Solution

Introduced `is_trusted_first_party_bot()` to identify 4 GitHub platform bots:

| Bot | Service |
|-----|---------|
| `dependabot[bot]` | GitHub dependency updater |
| `github-actions[bot]` | GitHub Actions workflow actor (GITHUB_TOKEN) |
| `github-merge-queue[bot]` | GitHub merge queue automation |
| `copilot` | GitHub Copilot AI assistant |

These bots receive `approved` (writer) integrity because:
1. Their presence requires **explicit admin configuration**
2. They are **GitHub first-party** platform services (no supply-chain risk)
3. Their actions carry **implicit admin endorsement**

## Changes

### `helpers.rs`
- Added `is_trusted_first_party_bot()` — narrow 4-bot detection (exact match)
- Added `extract_author_login()` — checks `user.login` (issues/PRs) and `author.login` (commits)
- Modified `author_association_floor()` — checks for trusted bots before falling back to `author_association`
- Kept existing `is_bot()` for broad bot detection (unchanged)

### `backend.rs`
- Added `author_login: Option<String>` to `PullRequestFacts`
- Added `IssueAuthorInfo` struct with `author_association` + `author_login`
- Added `get_issue_author_info()` / `get_issue_author_info_with_callback()` for request-time bot detection

### `tool_rules.rs`
- Updated issue path (`get_issue`/`issue_read`) to use `get_issue_author_info` and check trusted bot status
- Updated PR path (`get_pull_request`/`pull_request_read`) to check `facts.author_login` for trusted bots

### Tests (155 new lines)
- `test_trusted_first_party_bot_detection` — all 4 bots detected, case-insensitive, third-party bots excluded
- `test_trusted_bot_issue_integrity_public_repo` — all 4 bots get approved on public repos
- `test_trusted_bot_pr_integrity_public_repo` — bot PRs get approved, merged bot PRs get merged
- `test_trusted_bot_commit_integrity` — bot commits get approved/merged based on branch

## Design Decisions

- **Narrow trust list**: Only 4 first-party GitHub bots — third-party bots (renovate, codecov, etc.) should be handled via policy configuration
- **Exact match**: `dependabot[bot]` (not just `dependabot`) to avoid false positives
- **Two code paths covered**: Both response-time filtering (`author_association_floor`) and request-time labeling (`tool_rules.rs`)
- **No behavior change for non-bot users**: Existing `author_association` logic unchanged