### PR TITLE
fix: register guard test uses non-noop guard for policy validation

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -476,7 +476,7 @@ func TestCopyResponseHeaders(t *testing.T) {
 	t.Run("copies pagination and request ID headers", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		resp := &http.Response{Header: http.Header{
-			"Link":                 []string{`<https://api.github.com/repos/o/r/issues?page=2>; rel="next"`},
+			"Link":                []string{`<https://api.github.com/repos/o/r/issues?page=2>; rel="next"`},
 			"X-Github-Request-Id": []string{"abc-123"},
 		}}
 		copyResponseHeaders(w, resp)

--- a/internal/server/register_guard_test.go
+++ b/internal/server/register_guard_test.go
@@ -250,20 +250,23 @@ func TestRegisterGuard_WriteSinkPolicy_MultipleAcceptPatterns(t *testing.T) {
 
 // TestRegisterGuard_InvalidPolicy_ReturnsError verifies that when resolveGuardPolicy
 // returns an error (invalid AllowOnly policy), registerGuard propagates the error.
+// NOTE: The guard must be non-noop because requireGuardPolicyIfGuardEnabled
+// short-circuits for noop guards without validating the policy (by design).
 func TestRegisterGuard_InvalidPolicy_ReturnsError(t *testing.T) {
 	t.Setenv(wasmGuardsDirEnvVar, "")
+
+	// Register a non-noop guard type so the policy validation path is reached.
+	const guardType = "test-non-noop-for-invalid-policy"
+	guard.RegisterGuardType(guardType, func() (guard.Guard, error) {
+		return guard.NewWriteSinkGuard([]string{"*"}), nil
+	})
 
 	cfg := &config.Config{
 		Servers: map[string]*config.ServerConfig{
 			"github": {Type: "http", Guard: "my-guard"},
 		},
 		Guards: map[string]*config.GuardConfig{
-			"my-guard": {
-				Type: "noop",
-				// This is a valid guard config – but we'll use the *global* policy
-				// override to inject an invalid policy so that requireGuardPolicyIfGuardEnabled
-				// receives the guard and then resolveGuardPolicy validates and errors.
-			},
+			"my-guard": {Type: guardType},
 		},
 		// Invalid global policy: min-integrity value is not recognised
 		GuardPolicy: &config.GuardPolicy{


### PR DESCRIPTION
## Problem

`TestRegisterGuard_InvalidPolicy_ReturnsError` was failing on main because it used a `noop` guard type. `requireGuardPolicyIfGuardEnabled` intentionally short-circuits for noop guards (`g.Name() == "noop"`) without validating the policy — this is by design (documented in the companion test `TestRegisterGuard_GuardConfigFound_NoopType_GlobalAllowOnlyPolicy`).

## Fix

- Changed the test to register a non-noop guard type (`write-sink` via `guard.RegisterGuardType`) so the invalid global policy validation path is actually exercised
- Fixed gofmt whitespace alignment in `proxy_test.go`

## Testing

`make agent-finished` passes — all unit and integration tests green.