### PR TITLE
feat: guard tool coverage for GitHub MCP server + proxy router expansion

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/helpers.rs
+++ b/guards/github-guard/rust-guard/src/labels/helpers.rs
@@ -212,6 +212,7 @@ fn extract_github_label_names<'a>(item: &'a Value) -> Vec<&'a str> {
 
 /// Check whether a content item carries at least one label from the configured
 /// `approval-labels` list (case-insensitive comparison).
+#[cfg(test)]
 pub fn has_approval_label(item: &Value, ctx: &PolicyContext) -> bool {
     first_matching_approval_label(item, ctx).is_some()
 }

--- a/guards/github-guard/rust-guard/src/labels/mod.rs
+++ b/guards/github-guard/rust-guard/src/labels/mod.rs
@@ -44,12 +44,14 @@ pub use constants::MEDIUM_BUFFER_SIZE;
 pub use helpers::{
     blocked_integrity, commit_integrity, ensure_integrity_baseline, extract_items_array,
     extract_number_as_string, extract_repo_from_item, extract_repo_info,
-    extract_repo_info_from_search_query, get_bool_or, get_nested_str, get_str_or, has_approval_label,
+    extract_repo_info_from_search_query, get_bool_or, get_nested_str, get_str_or,
     is_blocked_user, is_bot, issue_integrity, limit_items_with_log, make_item_path, merged_integrity,
     none_integrity, pr_integrity, private_scope_label, private_user_label, project_github_label,
     reader_integrity, secret_label, writer_integrity, MinIntegrity, PolicyContext, PolicyScopeEntry,
     ScopeKind,
 };
+#[cfg(test)]
+pub use helpers::has_approval_label;
 
 // Re-export response labeling functions (wrappers that pass PolicyContext)
 pub fn apply_tool_labels(


### PR DESCRIPTION
## Problem

Cross-referencing all tool names from `github/github-mcp-server` source against the guard's `tool_rules.rs` revealed 22 read tools falling through to the default `_ =>` case, which inherits empty labels. This means these tools had no integrity or secrecy labeling, causing them to either be filtered at any `min-integrity` threshold or leak private data without secrecy tags.

Additionally, the proxy router had gaps where Actions, discussions, user, and notification endpoints either fell through to a generic `get_file_contents` fallback (wrong security labels) or were blocked entirely.

## Changes

### Guard: New tool coverage in `tool_rules.rs` (22 read tools)

| Category | Tools | Secrecy | Integrity | Rationale |
|----------|-------|---------|-----------|-----------|
| **Actions** | `get_job_logs` | `secret` | approved | Logs may contain leaked env vars/tokens |
| **Context** | `get_me` | `private:user` | project:github | User PII (email, profile) |
| **Context** | `get_teams`, `get_team_members` | `private:user` | project:github | Org structure is sensitive |
| **Discussions** | `list_discussions`, `get_discussion` | repo visibility | approved | User content, similar to issues |
| **Discussions** | `get_discussion_comments` | repo visibility | approved | User content, similar to issue comments |
| **Discussions** | `list_discussion_categories` | repo visibility | approved | Maintainer-managed metadata |
| **Gists** | `list_gists`, `get_gist` | `private:user` | unapproved | User content, no repo-level trust signal |
| **Git** | `get_repository_tree` | repo visibility | approved | Repo metadata |
| **Labels** | `list_label` | repo visibility | approved | Maintainer-managed metadata |
| **Notifications** | `list_notifications`, `get_notification_details` | `private:user` | none (empty) | References external content of unknown trust |
| **Projects** | `projects_list`, `projects_get` | `[]` | approved:owner | New canonical project tool names |
| **Repos** | `list_starred_repositories` | `private:user` | project:github | Reveals user preferences/interests |
| **Search** | `search_orgs` | `[]` | project:github | Public GitHub-controlled metadata |
| **Security** | `list_global_security_advisories`, `get_global_security_advisory` | `[]` | project:github | Published GHSA CVE data |
| **Security** | `list_repository_security_advisories`, `list_org_repository_security_advisories` | `private:repo` | approved | May contain embargoed vulnerability info |

Also updated `tools.rs`: added `actions_run_trigger`, `projects_write`, `add_reply_to_pull_request_comment` to write operations.

### Guard: Unit tests (37 new tests)

Every new tool has corresponding tests for `label_resource` and `label_response`.

### Guard: Compiler warning fix

Gated `has_approval_label` with `#[cfg(test)]` (only used in tests).

### Proxy: 22 new REST routes + 5 GraphQL patterns

- **Actions**: get workflow/run/job, workflow-specific runs, attempt jobs/logs, artifacts, caches, secrets, variables, environment config
- **Discussions**: list, single, comments (REST + GraphQL)
- **User**: `/user`, `/user/keys|ssh_signing_keys|gpg_keys` (REST), `viewer {}` (GraphQL)
- **Notifications**: `/notifications`
- **Check runs**: `/commits/{sha}/check-runs|check-suites`
- **Org-scoped**: `/orgs/{org}/actions/secrets|variables`
- **Organization**: `organization()` GraphQL

**Valid integrity levels**: `merged` > `approved` > `unapproved` > `none` > `blocked`