### PR TITLE
fix(guard): correct backend enrichment tool names and args

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/backend.rs
+++ b/guards/github-guard/rust-guard/src/labels/backend.rs
@@ -214,7 +214,7 @@ pub fn is_repo_private_with_callback(
 
 /// Determine whether a pull request is from a fork.
 ///
-/// This helper calls `get_pull_request` through the provided backend callback,
+/// This helper calls `pull_request_read` through the provided backend callback,
 /// extracts `base.repo.full_name` and `head.repo.full_name`, and returns:
 /// - `Some(true)` if the PR is from a fork (head repo differs from base repo)
 /// - `Some(false)` if the PR is direct (same repository)
@@ -233,7 +233,8 @@ pub fn is_forked_pull_request_with_callback(
     let args = serde_json::json!({
         "owner": owner,
         "repo": repo,
-        "pull_number": pull_number,
+        "pullNumber": pull_number,
+        "method": "get",
     });
 
     let args_str = args.to_string();
@@ -244,7 +245,7 @@ pub fn is_forked_pull_request_with_callback(
         owner, repo, pull_number
     ));
 
-    let len = match callback("get_pull_request", &args_str, &mut result_buffer) {
+    let len = match callback("pull_request_read", &args_str, &mut result_buffer) {
         Ok(len) if len > 0 => len,
         Ok(_) => return None,
         Err(code) => {
@@ -294,13 +295,14 @@ pub fn get_pull_request_facts_with_callback(
     let args = serde_json::json!({
         "owner": owner,
         "repo": repo,
-        "pull_number": pull_number,
+        "pullNumber": pull_number,
+        "method": "get",
     });
 
     let args_str = args.to_string();
     let mut result_buffer = vec![0u8; SMALL_BUFFER_SIZE];
 
-    let len = match callback("get_pull_request", &args_str, &mut result_buffer) {
+    let len = match callback("pull_request_read", &args_str, &mut result_buffer) {
         Ok(len) if len > 0 => len,
         _ => return None,
     };
@@ -370,6 +372,7 @@ pub fn get_issue_author_association_with_callback(
         "owner": owner,
         "repo": repo,
         "issue_number": issue_number,
+        "method": "get",
     });
 
     let args_str = args.to_string();
@@ -419,6 +422,7 @@ pub fn get_issue_author_info_with_callback(
         "owner": owner,
         "repo": repo,
         "issue_number": issue_number,
+        "method": "get",
     });
 
     let args_str = args.to_string();


### PR DESCRIPTION
## Problem

Backend enrichment calls in the GitHub guard's `backend.rs` used incorrect tool names and missing parameters, causing all enrichment to silently fail:

1. **PR enrichment** called `get_pull_request` — not a registered MCP tool (should be `pull_request_read`)
2. **PR enrichment** used `pull_number` arg — should be `pullNumber` and include `method: "get"`
3. **Issue enrichment** called `issue_read` without `method: "get"` parameter

This meant `author_login` was never fetched from the backend, so trusted bot detection (`github-actions[bot]`, `dependabot[bot]`, etc.) never ran for resource-level labels in `tool_rules`. Bot-authored PRs and issues defaulted to `none` integrity and were incorrectly filtered.

## Fix

- Change PR enrichment tool: `"get_pull_request"` → `"pull_request_read"`
- Fix PR enrichment args: `pull_number` → `pullNumber`, add `method: "get"`
- Fix issue enrichment args: add `method: "get"`

## Validation

Discovered via repo-assist run [23412180702](https://github.com/github/gh-aw-mcpg/actions/runs/23412180702) (v0.1.25) which showed 4 DIFC-FILTERED events for `github-actions[bot]` authored items.

### Note
`repo-assist.lock.yml` uses `:local` container build (inherited from main). Will revert after validation.