### PR TITLE
Fix build: inline removed getDefault* helpers, rename duplicate tests

### DIFF
--- a/internal/cmd/flags_difc_test.go
+++ b/internal/cmd/flags_difc_test.go
@@ -156,10 +156,10 @@ func TestGetDefaultDIFCSinkServerIDs(t *testing.T) {
 	}()
 
 	os.Unsetenv("MCP_GATEWAY_GUARDS_SINK_SERVER_IDS")
-	assert.Equal(t, "", getDefaultDIFCSinkServerIDs())
+	assert.Equal(t, "", os.Getenv("MCP_GATEWAY_GUARDS_SINK_SERVER_IDS"))
 
 	os.Setenv("MCP_GATEWAY_GUARDS_SINK_SERVER_IDS", "safeoutputs,github")
-	assert.Equal(t, "safeoutputs,github", getDefaultDIFCSinkServerIDs())
+	assert.Equal(t, "safeoutputs,github", os.Getenv("MCP_GATEWAY_GUARDS_SINK_SERVER_IDS"))
 }
 
 func TestParseDIFCSinkServerIDs(t *testing.T) {
@@ -286,9 +286,9 @@ func TestGetDefaultGuardPolicyInputs(t *testing.T) {
 	os.Setenv("MCP_GATEWAY_ALLOWONLY_SCOPE_REPO", "gh-aw-mcpg")
 	os.Setenv("MCP_GATEWAY_ALLOWONLY_MIN_INTEGRITY", "unapproved")
 
-	assert.NotEmpty(t, getDefaultGuardPolicyJSON())
+	assert.NotEmpty(t, os.Getenv("MCP_GATEWAY_GUARD_POLICY_JSON"))
 	assert.True(t, getDefaultAllowOnlyScopePublic())
-	assert.Equal(t, "lpcox", getDefaultAllowOnlyScopeOwner())
-	assert.Equal(t, "gh-aw-mcpg", getDefaultAllowOnlyScopeRepo())
-	assert.Equal(t, "unapproved", getDefaultAllowOnlyMinIntegrity())
+	assert.Equal(t, "lpcox", os.Getenv("MCP_GATEWAY_ALLOWONLY_SCOPE_OWNER"))
+	assert.Equal(t, "gh-aw-mcpg", os.Getenv("MCP_GATEWAY_ALLOWONLY_SCOPE_REPO"))
+	assert.Equal(t, "unapproved", os.Getenv("MCP_GATEWAY_ALLOWONLY_MIN_INTEGRITY"))
 }

--- a/internal/cmd/proxy.go
+++ b/internal/cmd/proxy.go
@@ -87,7 +87,7 @@ Local usage:
 		guardHelp += " (required)"
 	}
 	cmd.Flags().StringVar(&proxyGuardWasm, "guard-wasm", defaultGuard, guardHelp)
-	cmd.Flags().StringVar(&proxyPolicy, "policy", getDefaultGuardPolicyJSON(), "Guard policy JSON")
+	cmd.Flags().StringVar(&proxyPolicy, "policy", os.Getenv("MCP_GATEWAY_GUARD_POLICY_JSON"), "Guard policy JSON")
 	cmd.Flags().StringVar(&proxyToken, "github-token", "", "Fallback GitHub API token (default: forwards client Authorization header)")
 	cmd.Flags().StringVarP(&proxyListen, "listen", "l", "127.0.0.1:8080", "Proxy listen address")
 	cmd.Flags().StringVar(&proxyLogDir, "log-dir", getDefaultLogDir(), "Log file directory")

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -47,8 +47,8 @@ var rootCmd = &cobra.Command{
 	Version: cliVersion,
 	Long: `MCPG is a proxy server for Model Context Protocol (MCP) servers.
 It provides routing, aggregation, and management of multiple MCP backend servers.`,
-	SilenceUsage:      true,  // Don't show help on runtime errors
-	SilenceErrors:     true,  // Prevent cobra from printing errors — Execute() caller handles display
+	SilenceUsage:      true, // Don't show help on runtime errors
+	SilenceErrors:     true, // Prevent cobra from printing errors — Execute() caller handles display
 	PersistentPreRunE: preRun,
 	RunE:              run,
 	PersistentPostRun: postRun,
@@ -403,9 +403,9 @@ func resolveGuardPolicyOverride(cmd *cobra.Command) (*config.GuardPolicy, string
 	if hasScopePublic || hasScopeOwner || hasScopeRepo || hasMinIntegrity {
 		policy, err := config.BuildAllowOnlyPolicy(
 			getDefaultAllowOnlyScopePublic(),
-			getDefaultAllowOnlyScopeOwner(),
-			getDefaultAllowOnlyScopeRepo(),
-			getDefaultAllowOnlyMinIntegrity(),
+			os.Getenv("MCP_GATEWAY_ALLOWONLY_SCOPE_OWNER"),
+			os.Getenv("MCP_GATEWAY_ALLOWONLY_SCOPE_REPO"),
+			os.Getenv("MCP_GATEWAY_ALLOWONLY_MIN_INTEGRITY"),
 		)
 		if err != nil {
 			return nil, "", err

--- a/internal/config/config_core_test.go
+++ b/internal/config/config_core_test.go
@@ -241,9 +241,9 @@ args = ["run", "--rm", "-i", "ghcr.io/github/github-mcp-server:latest"]
 	assert.Equal(t, []string{"my-bot[bot]", "another-bot[bot]"}, cfg.Gateway.TrustedBots)
 }
 
-// TestLoadFromFile_MultipleServers verifies that multiple servers of different types
+// TestLoadFromFile_MixedStdioAndHTTPServers verifies that multiple servers of different types
 // are parsed correctly.
-func TestLoadFromFile_MultipleServers(t *testing.T) {
+func TestLoadFromFile_MixedStdioAndHTTPServers(t *testing.T) {
 	path := writeTempTOML(t, `
 [servers.github]
 command = "docker"

--- a/internal/config/docker_helpers_and_env_test.go
+++ b/internal/config/docker_helpers_and_env_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestValidateContainerID verifies the security-critical container ID validation.
+// TestValidateContainerID_SecurityCritical verifies the security-critical container ID validation.
 // Container IDs must be 12–64 lowercase hex characters (a-f, 0-9).
-func TestValidateContainerID(t *testing.T) {
+func TestValidateContainerID_SecurityCritical(t *testing.T) {
 	tests := []struct {
 		name    string
 		id      string
@@ -120,7 +120,7 @@ func TestValidateContainerID(t *testing.T) {
 }
 
 // TestGetGatewayPortFromEnv tests the env-based gateway port parsing.
-func TestGetGatewayPortFromEnv(t *testing.T) {
+func TestGetGatewayPortFromEnv_Comprehensive(t *testing.T) {
 	tests := []struct {
 		name     string
 		envValue string


### PR DESCRIPTION
## Problem

Main is broken — two recent Repo Assist PRs introduced compilation errors:

1. **PR #2383** removed `getDefaultGuardPolicyJSON`, `getDefaultAllowOnlyScopeOwner`, `getDefaultAllowOnlyScopeRepo`, `getDefaultAllowOnlyMinIntegrity`, and `getDefaultDIFCSinkServerIDs` from `flags_difc.go` but missed callers in `root.go`, `proxy.go`, and `flags_difc_test.go`. The PR couldn't build locally because `proxy.golang.org` was blocked by the firewall.

2. **PR #2381** added `config_core_test.go` and `docker_helpers_and_env_test.go` with test function names (`TestLoadFromFile_MultipleServers`, `TestValidateContainerID`, `TestGetGatewayPortFromEnv`) that collide with existing tests in `config_test.go` and `validation_env_test.go`.

## Fix

- Inline `os.Getenv()` calls at the 5 remaining call sites (matching the pattern PR #2383 applied in `flags_difc.go`)
- Rename 3 duplicate test functions to unique names

## Verification

`make agent-finished` passes (build, lint, all tests).