### PR TITLE
fix: use repo visibility for actions_get and get_job_logs secrecy

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/mod.rs
+++ b/guards/github-guard/rust-guard/src/labels/mod.rs
@@ -1802,7 +1802,7 @@ mod tests {
             &ctx,
         );
 
-        assert_eq!(secrecy, secret_label(), "get_job_logs must carry secret secrecy (logs may leak tokens)");
+        assert_eq!(secrecy, Vec::<String>::new(), "get_job_logs secrecy inherits repo visibility (empty in tests)");
         assert_eq!(integrity, writer_integrity("github/copilot", &ctx), "get_job_logs must have approved integrity (system-generated output)");
     }
 

--- a/guards/github-guard/rust-guard/src/labels/tool_rules.rs
+++ b/guards/github-guard/rust-guard/src/labels/tool_rules.rs
@@ -315,21 +315,11 @@ pub fn apply_tool_labels(
 
         // === GitHub Actions ===
         "actions_get" | "actions_list" => {
-            // S(workflow/artifact) = inherits from repo secrecy
+            // S(workflow/artifact) = inherits from repo visibility
+            // Public repos: artifacts are public. Private repos: artifacts are private-scoped.
             // I(workflow/artifact) = approved - maintained by repo team
             secrecy = apply_repo_visibility_secrecy(&owner, &repo, repo_id, secrecy, ctx);
             integrity = writer_integrity(repo_id, ctx);
-
-            // Additional secrecy checks for workflow files
-            if tool_name == "actions_get"
-                && tool_args
-                    .get("method")
-                    .and_then(|v| v.as_str())
-                    == Some("download_workflow_run_artifact")
-            {
-                // Artifacts may contain secrets
-                secrecy = secret_label();
-            }
         }
 
         // === Content Access ===
@@ -456,10 +446,9 @@ pub fn apply_tool_labels(
 
         // === Job Logs (Actions) ===
         "get_job_logs" => {
-            // Job logs may contain secrets (environment variables, tokens leaked in output).
-            // S = secret (conservative — logs can leak any secret)
+            // S = inherits from repo visibility (public repo logs are public)
             // I = approved — CI output is system-generated, not user-controlled
-            secrecy = secret_label();
+            secrecy = apply_repo_visibility_secrecy(&owner, &repo, repo_id, secrecy, ctx);
             integrity = writer_integrity(repo_id, ctx);
         }
 


### PR DESCRIPTION
## Summary

`actions_get` (artifact downloads) and `get_job_logs` were unconditionally labeled with `[secret]` secrecy in the Rust guard. This blocked the audit workflow from reading firewall-audit-logs and job logs for **public repos** like `github/gh-aw`.

## Changes

**`guards/github-guard/rust-guard/src/labels/tool_rules.rs`**
- `actions_get`: Removed the special-case that upgraded artifact downloads to `secret_label()`. Now uses `apply_repo_visibility_secrecy()` consistently for all `actions_get`/`actions_list` operations.
- `get_job_logs`: Changed from unconditional `secret_label()` to `apply_repo_visibility_secrecy()`.

Both tools now follow the same pattern as other repo-scoped resources:
| Repo visibility | Secrecy label |
|-----------------|---------------|
| Public | `[]` (empty — no restriction) |
| Private | `[private:owner/repo]` |
| Unknown (runtime) | `[private:owner/repo]` (fail-secure) |

**`guards/github-guard/rust-guard/src/labels/mod.rs`**
- Updated `test_apply_tool_labels_get_job_logs` assertion to match new behavior.

## Motivation

The integrity filtering audit workflow (issue #2457) runs against the public `github/gh-aw` repo. When it tried to download `firewall-audit-logs` artifacts or read job logs, DIFC blocked access because the agent had no `[secret]` clearance — and there's no mechanism to grant it. Since the repo is public, these resources should have empty secrecy labels, just like other public repo data.

Fixes #2457