### PR TITLE
fix: update DIFC test assertions to match new notice format

### DIFF
--- a/internal/server/call_backend_tool_difc_test.go
+++ b/internal/server/call_backend_tool_difc_test.go
@@ -232,8 +232,8 @@ func TestCallBackendTool_Phase2_WriteOperationBlocked(t *testing.T) {
 	assert.True(result.IsError, "write should be blocked — result should be an error")
 	assert.Nil(data, "no data should be returned when write is blocked")
 	require.Error(err)
-	assert.Contains(err.Error(), "DIFC policy violation",
-		"error should mention DIFC policy violation")
+	assert.Contains(err.Error(), "DIFC Violation:",
+		"error should mention DIFC Violation")
 }
 
 // TestCallBackendTool_Phase2_ReadOperationNotBlocked verifies that read operations
@@ -491,7 +491,7 @@ func TestCallBackendTool_Phase5_FilterMode_PartialCollection(t *testing.T) {
 	var foundNotice bool
 	for _, c := range result.Content {
 		if tc, ok := c.(*sdk.TextContent); ok {
-			if strings.Contains(tc.Text, "DIFC") || strings.Contains(tc.Text, "filtered") {
+			if strings.Contains(tc.Text, "Filtered") || strings.Contains(tc.Text, "DIFC") || strings.Contains(tc.Text, "filtered") {
 				foundNotice = true
 				break
 			}


### PR DESCRIPTION
Fixes 2 test failures in `call_backend_tool_difc_test.go` caused by notice format changes that landed on main:

- **Phase2 write block**: Test expected `"DIFC policy violation"` but evaluator now emits `"DIFC Violation:"` (changed in b1cb2a7)
- **Phase5 filter notice**: Test searched for `"DIFC"` or `"filtered"` (lowercase) but notice now says `"[Filtered]"` (capital F, changed in 8ecdf2c)

Minimal fix — updates the assertion strings to match the current code.