### PR TITLE
fix: remove redundant io.Writer type annotation (staticcheck QF1011)

### DIFF
--- a/internal/logger/file_logger_test.go
+++ b/internal/logger/file_logger_test.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -253,7 +252,8 @@ func TestFileLogger_GetWriter(t *testing.T) {
 		globalLoggerMu.RUnlock()
 
 		require.NotNil(t, logger)
-		var _ io.Writer = logger.GetWriter()
+		w := logger.GetWriter()
+		require.NotNil(t, w)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes staticcheck QF1011 lint warning in `internal/logger/file_logger_test.go`.

`GetWriter()` already returns `io.Writer`, making `var _ io.Writer = logger.GetWriter()` redundant. Replaced with a simple call + `require.NotNil` assertion and removed the unused `io` import.

## Verification

`make agent-finished` ✅ — all lint, build, and tests pass.