### PR TITLE
test: add unit tests for internal/httputil package

### DIFF
--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -73,9 +73,9 @@ func TestWriteJSONResponse(t *testing.T) {
 
 	t.Run("encodes nil body as JSON null", func(t *testing.T) {
 		rec := httptest.NewRecorder()
-		WriteJSONResponse(rec, http.StatusNoContent, nil)
+		WriteJSONResponse(rec, http.StatusOK, nil)
 
-		assert.Equal(t, http.StatusNoContent, rec.Code)
+		assert.Equal(t, http.StatusOK, rec.Code)
 		assert.JSONEq(t, "null", rec.Body.String())
 	})
 


### PR DESCRIPTION
## Summary

Adds unit tests for the `internal/httputil` package, which previously had no test coverage.

## Tests Added

10 test cases for `WriteJSONResponse`:
- Content-Type header (`application/json`)
- Status code propagation (200, 201, 400, 404, 500)
- JSON encoding: structs, maps, slices, nested types
- Edge cases: nil body, empty struct, special characters, unicode

## Verification

`make agent-finished` ✅