### PR TITLE
fix(guard): resolve all Rust clippy warnings

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/backend.rs
+++ b/guards/github-guard/rust-guard/src/labels/backend.rs
@@ -71,6 +71,7 @@ pub struct IssueAuthorInfo {
 #[derive(Debug, Clone)]
 pub struct CollaboratorPermission {
     pub permission: Option<String>,
+    #[cfg_attr(not(test), allow(dead_code))]
     pub login: Option<String>,
 }
 

--- a/guards/github-guard/rust-guard/src/labels/helpers.rs
+++ b/guards/github-guard/rust-guard/src/labels/helpers.rs
@@ -240,7 +240,7 @@ pub fn is_blocked_user(username: &str, ctx: &PolicyContext) -> bool {
 /// Extract GitHub label names from a content item's `labels` array.
 ///
 /// Returns the `name` field from each element of the item's `labels` array.
-fn extract_github_label_names<'a>(item: &'a Value) -> Vec<&'a str> {
+fn extract_github_label_names(item: &Value) -> Vec<&str> {
     item.get("labels")
         .and_then(|v| v.as_array())
         .map(|arr| {

--- a/guards/github-guard/rust-guard/src/labels/mod.rs
+++ b/guards/github-guard/rust-guard/src/labels/mod.rs
@@ -35,6 +35,7 @@ mod response_paths;
 pub mod tool_rules;
 
 // Re-export commonly used items for backward compatibility
+#[allow(unused_imports)]
 pub use constants::MEDIUM_BUFFER_SIZE;
 
 // Re-export helpers - these are part of the public API and used by tests


### PR DESCRIPTION
Fixes all 3 clippy warnings in the Rust guard:

1. **Needless lifetimes** in `extract_github_label_names` — elided explicit lifetime annotations
2. **Unused import** on `MEDIUM_BUFFER_SIZE` re-export — added `#[allow(unused_imports)]`
3. **Dead code** on `CollaboratorPermission.login` — field is used in tests only, suppressed with `#[cfg_attr(not(test), allow(dead_code))]`

`cargo clippy` now produces zero warnings. All 248 tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>