### PR TITLE
feat: enable difc-proxy feature flag on all guarded workflows

### DIFF
--- a/.github/workflows/daily-compliance-checker.lock.yml
+++ b/.github/workflows/daily-compliance-checker.lock.yml
@@ -22,7 +22,7 @@
 #
 # Daily automated compliance checker that validates MCP Gateway implementation against the official specification
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b71cb9f9984a9272c673661b3520792713a1115ffc225073b50510016ecc3f0a","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c08edde1cd2971fc461ad1e2a07eeeef6584becd883de0bbc9fd582d3f5cecba","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Daily Compliance Checker"
 "on":
@@ -126,15 +126,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_758bda35cbb845c9_EOF'
+          cat << 'GH_AW_PROMPT_be8b0c69f4cef933_EOF'
           <system>
-          GH_AW_PROMPT_758bda35cbb845c9_EOF
+          GH_AW_PROMPT_be8b0c69f4cef933_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_758bda35cbb845c9_EOF'
+          cat << 'GH_AW_PROMPT_be8b0c69f4cef933_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -166,14 +166,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_758bda35cbb845c9_EOF
+          GH_AW_PROMPT_be8b0c69f4cef933_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_758bda35cbb845c9_EOF'
+          cat << 'GH_AW_PROMPT_be8b0c69f4cef933_EOF'
           </system>
-          GH_AW_PROMPT_758bda35cbb845c9_EOF
-          cat << 'GH_AW_PROMPT_758bda35cbb845c9_EOF'
+          GH_AW_PROMPT_be8b0c69f4cef933_EOF
+          cat << 'GH_AW_PROMPT_be8b0c69f4cef933_EOF'
           {{#runtime-import .github/workflows/daily-compliance-checker.md}}
-          GH_AW_PROMPT_758bda35cbb845c9_EOF
+          GH_AW_PROMPT_be8b0c69f4cef933_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -352,12 +352,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_efe01f16e66dc3f9_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_e0f59fe42fc46183_EOF'
           {"create_issue":{"labels":["compliance","automation","specification"],"max":1,"title_prefix":"[compliance] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_efe01f16e66dc3f9_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e0f59fe42fc46183_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_eae0888b5443fd59_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_503f9e03066bcd3b_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[compliance] \". Labels [\"compliance\" \"automation\" \"specification\"] will be automatically added."
@@ -365,8 +365,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_eae0888b5443fd59_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_63dfcc73ac571718_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_503f9e03066bcd3b_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_08e9e48f4fccd659_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -459,7 +459,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_63dfcc73ac571718_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_08e9e48f4fccd659_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -525,7 +525,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_0979575eb9ede894_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_91db710c684e56ca_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -570,7 +570,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0979575eb9ede894_EOF
+          GH_AW_MCP_CONFIG_91db710c684e56ca_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -757,6 +757,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/daily-compliance-checker.md
+++ b/.github/workflows/daily-compliance-checker.md
@@ -43,6 +43,8 @@ tools:
   cache-memory:
 
 timeout-minutes: 30
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/gateway-issue-dispatcher.lock.yml
+++ b/.github/workflows/gateway-issue-dispatcher.lock.yml
@@ -22,7 +22,7 @@
 #
 # Audits github/gh-aw issues labeled 'gateway' and creates tracking issues in github/gh-aw-mcpg with proposed solutions
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"38ada8263b417259bb6d2d75b30e026687a3bdfb7e129757d303e08f78887b92","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e1377bbed39a99fb04bd004b709b2a59d79b8479344ea3df881d350435b8bab1","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Gateway Issue Dispatcher"
 "on":
@@ -126,14 +126,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_380de36ee5a82b26_EOF'
+          cat << 'GH_AW_PROMPT_57f06b2554d02b2a_EOF'
           <system>
-          GH_AW_PROMPT_380de36ee5a82b26_EOF
+          GH_AW_PROMPT_57f06b2554d02b2a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_380de36ee5a82b26_EOF'
+          cat << 'GH_AW_PROMPT_57f06b2554d02b2a_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -165,14 +165,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_380de36ee5a82b26_EOF
+          GH_AW_PROMPT_57f06b2554d02b2a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_380de36ee5a82b26_EOF'
+          cat << 'GH_AW_PROMPT_57f06b2554d02b2a_EOF'
           </system>
-          GH_AW_PROMPT_380de36ee5a82b26_EOF
-          cat << 'GH_AW_PROMPT_380de36ee5a82b26_EOF'
+          GH_AW_PROMPT_57f06b2554d02b2a_EOF
+          cat << 'GH_AW_PROMPT_57f06b2554d02b2a_EOF'
           {{#runtime-import .github/workflows/gateway-issue-dispatcher.md}}
-          GH_AW_PROMPT_380de36ee5a82b26_EOF
+          GH_AW_PROMPT_57f06b2554d02b2a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -323,12 +323,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_025dcdad6c1cafc9_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_fc4082ff08ca4e90_EOF'
           {"add_comment":{"max":10,"target":"*","target-repo":"github/gh-aw"},"create_issue":{"labels":["gateway","from-gh-aw"],"max":10,"target-repo":"github/gh-aw-mcpg"},"max_bot_mentions":1,"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_025dcdad6c1cafc9_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_fc4082ff08ca4e90_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_97e6bc32d86d8268_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a5166d761fe6fde0_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 10 comment(s) can be added. Target: *. Comments will be added in repository \"github/gh-aw\".",
@@ -337,8 +337,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_97e6bc32d86d8268_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_d3315c6b810977a3_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_a5166d761fe6fde0_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_58b21d34cd6bea2b_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -449,7 +449,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_d3315c6b810977a3_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_58b21d34cd6bea2b_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -515,7 +515,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_9d1dbe8bb05e43f5_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_d05235028529fe8b_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -562,7 +562,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9d1dbe8bb05e43f5_EOF
+          GH_AW_MCP_CONFIG_d05235028529fe8b_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -736,6 +736,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/gateway-issue-dispatcher.md
+++ b/.github/workflows/gateway-issue-dispatcher.md
@@ -32,6 +32,8 @@ safe-outputs:
     pull-requests: false
 
 timeout-minutes: 20
+features:
+  difc-proxy: true
 ---
 
 # Gateway Issue Dispatcher

--- a/.github/workflows/github-mcp-guard-coverage-checker.lock.yml
+++ b/.github/workflows/github-mcp-guard-coverage-checker.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"341c8edc2f8310169d89907b316da3e95ae85bfcae9374f17e03d0ada5e3eda8","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"77c6f455928c8be5a512d3fdab8901e6656159c6efe51a012dc27f2dae8572ac","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "GitHub Guard Coverage Checker (MCP + CLI)"
 "on":
@@ -131,15 +131,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_ac794003f8c4c4bd_EOF'
+          cat << 'GH_AW_PROMPT_b7d93069b6779ba4_EOF'
           <system>
-          GH_AW_PROMPT_ac794003f8c4c4bd_EOF
+          GH_AW_PROMPT_b7d93069b6779ba4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ac794003f8c4c4bd_EOF'
+          cat << 'GH_AW_PROMPT_b7d93069b6779ba4_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -171,17 +171,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ac794003f8c4c4bd_EOF
+          GH_AW_PROMPT_b7d93069b6779ba4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ac794003f8c4c4bd_EOF'
+          cat << 'GH_AW_PROMPT_b7d93069b6779ba4_EOF'
           </system>
-          GH_AW_PROMPT_ac794003f8c4c4bd_EOF
-          cat << 'GH_AW_PROMPT_ac794003f8c4c4bd_EOF'
+          GH_AW_PROMPT_b7d93069b6779ba4_EOF
+          cat << 'GH_AW_PROMPT_b7d93069b6779ba4_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_ac794003f8c4c4bd_EOF
-          cat << 'GH_AW_PROMPT_ac794003f8c4c4bd_EOF'
+          GH_AW_PROMPT_b7d93069b6779ba4_EOF
+          cat << 'GH_AW_PROMPT_b7d93069b6779ba4_EOF'
           {{#runtime-import .github/workflows/github-mcp-guard-coverage-checker.md}}
-          GH_AW_PROMPT_ac794003f8c4c4bd_EOF
+          GH_AW_PROMPT_b7d93069b6779ba4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -358,12 +358,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_2a1cd4dc57e460eb_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_48416e25314a6dec_EOF'
           {"create_issue":{"expires":336,"labels":["guard","automation","security"],"max":1,"title_prefix":"[guard-coverage] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2a1cd4dc57e460eb_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_48416e25314a6dec_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_fb7c34546e93ccd7_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_d954e8038efb7b75_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[guard-coverage] \". Labels [\"guard\" \"automation\" \"security\"] will be automatically added."
@@ -371,8 +371,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_fb7c34546e93ccd7_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_0b488fecfc7dcaf7_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_d954e8038efb7b75_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_2270fdbd3934fabc_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -465,7 +465,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_0b488fecfc7dcaf7_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_2270fdbd3934fabc_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -531,7 +531,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_610596fbc89232d7_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_68a0bf8dc6f477b3_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -580,7 +580,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_610596fbc89232d7_EOF
+          GH_AW_MCP_CONFIG_68a0bf8dc6f477b3_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -767,6 +767,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/github-mcp-guard-coverage-checker.md
+++ b/.github/workflows/github-mcp-guard-coverage-checker.md
@@ -37,6 +37,8 @@ tools:
     - "*"
 
 timeout-minutes: 30
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/go-fan.lock.yml
+++ b/.github/workflows/go-fan.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6426f8f542385cdfca58e13802e3f2ce21358f8fd0b616a11a0ec0b46a0beaaa","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9701e40df5e4bcb658052d1c3fd2a1432ea7d9fe804048f321bad611c44f430f","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Go Fan"
 "on":
@@ -129,15 +129,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_05058f02b7071792_EOF'
+          cat << 'GH_AW_PROMPT_be7833561fc8edd1_EOF'
           <system>
-          GH_AW_PROMPT_05058f02b7071792_EOF
+          GH_AW_PROMPT_be7833561fc8edd1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_05058f02b7071792_EOF'
+          cat << 'GH_AW_PROMPT_be7833561fc8edd1_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -169,17 +169,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_05058f02b7071792_EOF
+          GH_AW_PROMPT_be7833561fc8edd1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_05058f02b7071792_EOF'
+          cat << 'GH_AW_PROMPT_be7833561fc8edd1_EOF'
           </system>
-          GH_AW_PROMPT_05058f02b7071792_EOF
-          cat << 'GH_AW_PROMPT_05058f02b7071792_EOF'
+          GH_AW_PROMPT_be7833561fc8edd1_EOF
+          cat << 'GH_AW_PROMPT_be7833561fc8edd1_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_05058f02b7071792_EOF
-          cat << 'GH_AW_PROMPT_05058f02b7071792_EOF'
+          GH_AW_PROMPT_be7833561fc8edd1_EOF
+          cat << 'GH_AW_PROMPT_be7833561fc8edd1_EOF'
           {{#runtime-import .github/workflows/go-fan.md}}
-          GH_AW_PROMPT_05058f02b7071792_EOF
+          GH_AW_PROMPT_be7833561fc8edd1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -356,12 +356,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_66db5b26fde20c41_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_0ec0ca3336429971_EOF'
           {"create_issue":{"expires":168,"labels":["go-fan","module-review"],"max":1,"title_prefix":"[go-fan] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_66db5b26fde20c41_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0ec0ca3336429971_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_f2c2f89b123fe175_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_17a1f2b978fec4c1_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[go-fan] \". Labels [\"go-fan\" \"module-review\"] will be automatically added."
@@ -369,8 +369,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_f2c2f89b123fe175_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_d3d86ee415499b16_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_17a1f2b978fec4c1_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_a34b8f3325e44c9c_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -463,7 +463,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_d3d86ee415499b16_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_a34b8f3325e44c9c_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -529,7 +529,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_0f15ae69f7126be7_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_3023df07cadf1b15_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -574,7 +574,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0f15ae69f7126be7_EOF
+          GH_AW_MCP_CONFIG_3023df07cadf1b15_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -783,6 +783,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/go-fan.md
+++ b/.github/workflows/go-fan.md
@@ -52,6 +52,8 @@ tools:
     - "cat specs/mods/*"
 
 timeout-minutes: 30
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/go-logger.lock.yml
+++ b/.github/workflows/go-logger.lock.yml
@@ -22,7 +22,7 @@
 #
 # Analyzes and enhances Go logging practices across the codebase for improved debugging and observability
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"00eb5f5646d2220f85ab60be1aa5ddc4b98001f022c43b6b93e9c01aeefa749e","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7ee210e918f9ed15c89aefc223565847fb2024151f7780fb5453152f6697faa5","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Go Logger Enhancement"
 "on":
@@ -126,20 +126,20 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF'
+          cat << 'GH_AW_PROMPT_e6d9eb783db46a1d_EOF'
           <system>
-          GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF
+          GH_AW_PROMPT_e6d9eb783db46a1d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF'
+          cat << 'GH_AW_PROMPT_e6d9eb783db46a1d_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF
+          GH_AW_PROMPT_e6d9eb783db46a1d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF'
+          cat << 'GH_AW_PROMPT_e6d9eb783db46a1d_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -169,14 +169,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF
+          GH_AW_PROMPT_e6d9eb783db46a1d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF'
+          cat << 'GH_AW_PROMPT_e6d9eb783db46a1d_EOF'
           </system>
-          GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF
-          cat << 'GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF'
+          GH_AW_PROMPT_e6d9eb783db46a1d_EOF
+          cat << 'GH_AW_PROMPT_e6d9eb783db46a1d_EOF'
           {{#runtime-import .github/workflows/go-logger.md}}
-          GH_AW_PROMPT_79e8e2cdf70cf3b9_EOF
+          GH_AW_PROMPT_e6d9eb783db46a1d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -355,12 +355,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_5b5f5dbd36bd2874_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_775b158e6cc63989_EOF'
           {"create_pull_request":{"draft":true,"labels":["enhancement","automation"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[log] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5b5f5dbd36bd2874_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_775b158e6cc63989_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c3764722afa406b8_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_53b9bb10e4d7fe85_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[log] \". Labels [\"enhancement\" \"automation\"] will be automatically added. PRs will be created as drafts."
@@ -368,8 +368,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_c3764722afa406b8_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_19ec6856346f867f_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_53b9bb10e4d7fe85_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_c39d0f06e29b1ed4_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -465,7 +465,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_19ec6856346f867f_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_c39d0f06e29b1ed4_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -531,7 +531,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_cb13017edc33fe42_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_51403ecee77121bd_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -576,7 +576,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_cb13017edc33fe42_EOF
+          GH_AW_MCP_CONFIG_51403ecee77121bd_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -794,6 +794,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/go-logger.md
+++ b/.github/workflows/go-logger.md
@@ -48,6 +48,8 @@ tools:
   cache-memory:
 
 timeout-minutes: 15
+features:
+  difc-proxy: true
 ---
 
 # Go Logger Enhancement

--- a/.github/workflows/gpl-dependency-checker.lock.yml
+++ b/.github/workflows/gpl-dependency-checker.lock.yml
@@ -22,7 +22,7 @@
 #
 # Daily automated checker that scans go.mod dependencies for GPL-licensed packages and creates issues to track their removal
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bf4c210536a2c39168fad2f766dff09fa8ed14f0a1db237e203dfbddc3e6e995","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"dbada371db5f9a516dd210175df9c74ef9721738692f707e39dd9fb7ce29b2b7","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "GPL Dependency Checker"
 "on":
@@ -127,15 +127,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_94b80cb613db87ca_EOF'
+          cat << 'GH_AW_PROMPT_cdf905d180ccf536_EOF'
           <system>
-          GH_AW_PROMPT_94b80cb613db87ca_EOF
+          GH_AW_PROMPT_cdf905d180ccf536_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_94b80cb613db87ca_EOF'
+          cat << 'GH_AW_PROMPT_cdf905d180ccf536_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_issue(max:3), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -167,14 +167,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_94b80cb613db87ca_EOF
+          GH_AW_PROMPT_cdf905d180ccf536_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_94b80cb613db87ca_EOF'
+          cat << 'GH_AW_PROMPT_cdf905d180ccf536_EOF'
           </system>
-          GH_AW_PROMPT_94b80cb613db87ca_EOF
-          cat << 'GH_AW_PROMPT_94b80cb613db87ca_EOF'
+          GH_AW_PROMPT_cdf905d180ccf536_EOF
+          cat << 'GH_AW_PROMPT_cdf905d180ccf536_EOF'
           {{#runtime-import .github/workflows/gpl-dependency-checker.md}}
-          GH_AW_PROMPT_94b80cb613db87ca_EOF
+          GH_AW_PROMPT_cdf905d180ccf536_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -358,12 +358,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_74b55a64f4421149_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_5ab8dc554f39d945_EOF'
           {"add_comment":{"max":2},"create_issue":{"labels":["license","compliance","dependencies","automation"],"max":3,"title_prefix":"[license] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_74b55a64f4421149_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5ab8dc554f39d945_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_d84d0be20a119cbf_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a014cdcb12630585_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added.",
@@ -372,8 +372,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_d84d0be20a119cbf_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_a9b587f3301818b2_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_a014cdcb12630585_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f8b9e09fb394c2b5_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -484,7 +484,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_a9b587f3301818b2_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f8b9e09fb394c2b5_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -550,7 +550,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_0cefe6ea075dc04c_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_db756496bc5b19f1_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -595,7 +595,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0cefe6ea075dc04c_EOF
+          GH_AW_MCP_CONFIG_db756496bc5b19f1_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -782,6 +782,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/gpl-dependency-checker.md
+++ b/.github/workflows/gpl-dependency-checker.md
@@ -42,6 +42,8 @@ tools:
   cache-memory:
 
 timeout-minutes: 20
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/guard-status-tracker.lock.yml
+++ b/.github/workflows/guard-status-tracker.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5645ae212d82a86b46e6ce60b1e8a8736b9a45d25839d26fb0cd401ae362ef15","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"24fea38357549af364654537aa04b998fb861709cc902f2295475405052bfd2b","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Guard Status Tracker"
 "on":
@@ -130,15 +130,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_01276534f9f199a3_EOF'
+          cat << 'GH_AW_PROMPT_3949447c481efcb1_EOF'
           <system>
-          GH_AW_PROMPT_01276534f9f199a3_EOF
+          GH_AW_PROMPT_3949447c481efcb1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_01276534f9f199a3_EOF'
+          cat << 'GH_AW_PROMPT_3949447c481efcb1_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -170,17 +170,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_01276534f9f199a3_EOF
+          GH_AW_PROMPT_3949447c481efcb1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_01276534f9f199a3_EOF'
+          cat << 'GH_AW_PROMPT_3949447c481efcb1_EOF'
           </system>
-          GH_AW_PROMPT_01276534f9f199a3_EOF
-          cat << 'GH_AW_PROMPT_01276534f9f199a3_EOF'
+          GH_AW_PROMPT_3949447c481efcb1_EOF
+          cat << 'GH_AW_PROMPT_3949447c481efcb1_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_01276534f9f199a3_EOF
-          cat << 'GH_AW_PROMPT_01276534f9f199a3_EOF'
+          GH_AW_PROMPT_3949447c481efcb1_EOF
+          cat << 'GH_AW_PROMPT_3949447c481efcb1_EOF'
           {{#runtime-import .github/workflows/guard-status-tracker.md}}
-          GH_AW_PROMPT_01276534f9f199a3_EOF
+          GH_AW_PROMPT_3949447c481efcb1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -358,12 +358,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_e2c7962e2fe7fb78_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_a3c15e5cc631729f_EOF'
           {"add_comment":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e2c7962e2fe7fb78_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a3c15e5cc631729f_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c39b0aa1f94137c2_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_4a45d111abd48cad_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added."
@@ -371,8 +371,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_c39b0aa1f94137c2_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_871ea64fb3c24398_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_4a45d111abd48cad_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_68b305e8bcadce14_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -450,7 +450,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_871ea64fb3c24398_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_68b305e8bcadce14_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -516,7 +516,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_e5668a11349ba9b9_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_61522fa839a6de2e_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -561,7 +561,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e5668a11349ba9b9_EOF
+          GH_AW_MCP_CONFIG_61522fa839a6de2e_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -748,6 +748,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/guard-status-tracker.md
+++ b/.github/workflows/guard-status-tracker.md
@@ -37,6 +37,8 @@ tools:
     - "*"
 
 timeout-minutes: 30
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/integrity-filtering-audit.lock.yml
+++ b/.github/workflows/integrity-filtering-audit.lock.yml
@@ -22,7 +22,7 @@
 #
 # Daily audit of recent agentic workflow runs in github/gh-aw to identify integrity filtering problems
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4372df686c9e1b69be968951f61209b2a07a861df36f6072478552d4a2f65a36","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f5140c3df01209f6bcb7a7b851f5231129a30579d365405657c132d2b0c91158","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Integrity Filtering Audit"
 "on":
@@ -126,14 +126,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_1b81a3ac89b6158d_EOF'
+          cat << 'GH_AW_PROMPT_edebfbc19f59186c_EOF'
           <system>
-          GH_AW_PROMPT_1b81a3ac89b6158d_EOF
+          GH_AW_PROMPT_edebfbc19f59186c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1b81a3ac89b6158d_EOF'
+          cat << 'GH_AW_PROMPT_edebfbc19f59186c_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -165,14 +165,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_1b81a3ac89b6158d_EOF
+          GH_AW_PROMPT_edebfbc19f59186c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1b81a3ac89b6158d_EOF'
+          cat << 'GH_AW_PROMPT_edebfbc19f59186c_EOF'
           </system>
-          GH_AW_PROMPT_1b81a3ac89b6158d_EOF
-          cat << 'GH_AW_PROMPT_1b81a3ac89b6158d_EOF'
+          GH_AW_PROMPT_edebfbc19f59186c_EOF
+          cat << 'GH_AW_PROMPT_edebfbc19f59186c_EOF'
           {{#runtime-import .github/workflows/integrity-filtering-audit.md}}
-          GH_AW_PROMPT_1b81a3ac89b6158d_EOF
+          GH_AW_PROMPT_edebfbc19f59186c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -325,12 +325,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_44987164b76def0a_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_0279e047e09070b5_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"labels":["integrity-audit","automation"],"max":1,"title_prefix":"[integrity-audit] "},"max_bot_mentions":1,"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_44987164b76def0a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0279e047e09070b5_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_4ead0a6f94d809b9_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7602569c8dd03e63_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[integrity-audit] \". Labels [\"integrity-audit\" \"automation\"] will be automatically added."
@@ -338,8 +338,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_4ead0a6f94d809b9_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_9260c84757f9d455_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_7602569c8dd03e63_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_19e042d35d69c5a2_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -432,7 +432,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_9260c84757f9d455_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_19e042d35d69c5a2_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -498,7 +498,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_7fe27539590d36c7_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_6c47d4ce10ea3590_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -545,7 +545,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7fe27539590d36c7_EOF
+          GH_AW_MCP_CONFIG_6c47d4ce10ea3590_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -722,6 +722,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/integrity-filtering-audit.md
+++ b/.github/workflows/integrity-filtering-audit.md
@@ -37,6 +37,8 @@ safe-outputs:
     max: 1
 
 timeout-minutes: 20
+features:
+  difc-proxy: true
 ---
 
 # Integrity Filtering Audit

--- a/.github/workflows/issue-monster.lock.yml
+++ b/.github/workflows/issue-monster.lock.yml
@@ -22,7 +22,7 @@
 #
 # The Cookie Monster of issues - assigns issues to Copilot agents one at a time
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"febb8f04f3745bb1208b8c8d929f3182e5dfaf7fa8bb31d2dfe2f025c73d8347","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6910b3670f2cc0b172138ec74956abb3b2cf09d93e6f4cf9c87431343acf47d5","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Issue Monster"
 "on":
@@ -133,14 +133,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_0533c940bd260587_EOF'
+          cat << 'GH_AW_PROMPT_90a316acca804d10_EOF'
           <system>
-          GH_AW_PROMPT_0533c940bd260587_EOF
+          GH_AW_PROMPT_90a316acca804d10_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0533c940bd260587_EOF'
+          cat << 'GH_AW_PROMPT_90a316acca804d10_EOF'
           <safe-output-tools>
           Tools: add_comment(max:3), assign_to_agent(max:3), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -172,14 +172,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0533c940bd260587_EOF
+          GH_AW_PROMPT_90a316acca804d10_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0533c940bd260587_EOF'
+          cat << 'GH_AW_PROMPT_90a316acca804d10_EOF'
           </system>
-          GH_AW_PROMPT_0533c940bd260587_EOF
-          cat << 'GH_AW_PROMPT_0533c940bd260587_EOF'
+          GH_AW_PROMPT_90a316acca804d10_EOF
+          cat << 'GH_AW_PROMPT_90a316acca804d10_EOF'
           {{#runtime-import .github/workflows/issue-monster.md}}
-          GH_AW_PROMPT_0533c940bd260587_EOF
+          GH_AW_PROMPT_90a316acca804d10_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -339,12 +339,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_266138f5e7b8c065_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_d75838c92ea09ed6_EOF'
           {"add_comment":{"max":3,"target":"*"},"assign_to_agent":{"allowed":["copilot"],"max":3,"target":"*"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_266138f5e7b8c065_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d75838c92ea09ed6_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_e432b1ae8f94dc6e_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_f5a65b9a7e8afe68_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 3 comment(s) can be added. Target: *.",
@@ -353,8 +353,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_e432b1ae8f94dc6e_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_c3a62293fe33e40c_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_f5a65b9a7e8afe68_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b37d2bc13bc3fc7f_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -457,7 +457,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_c3a62293fe33e40c_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_b37d2bc13bc3fc7f_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -523,7 +523,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_6c334e13e434fa89_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_20585b9ee5ab8efb_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -568,7 +568,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6c334e13e434fa89_EOF
+          GH_AW_MCP_CONFIG_20585b9ee5ab8efb_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -744,6 +744,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/issue-monster.md
+++ b/.github/workflows/issue-monster.md
@@ -253,6 +253,8 @@ safe-outputs:
     run-started: "🍪 ISSUE! ISSUE! [{workflow_name}]({run_url}) hungry for issues on this {event_type}! Om nom nom..."
     run-success: "🍪 YUMMY! [{workflow_name}]({run_url}) ate the issues! That was DELICIOUS! Me want MORE! 😋"
     run-failure: "🍪 Aww... [{workflow_name}]({run_url}) {status}. No cookie for monster today... 😢"
+features:
+  difc-proxy: true
 ---
 
 {{#runtime-import? .github/shared-instructions.md}}

--- a/.github/workflows/large-payload-tester.lock.yml
+++ b/.github/workflows/large-payload-tester.lock.yml
@@ -22,7 +22,7 @@
 #
 # Test the MCP Gateway's ability to handle large payloads
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7df534717c06d333959c43eec99005cf6ade1108154974b316906abcb983c0f2","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"56872504825a1c5550812e34e2b78ab769e4e9ff27b5832e084c835c99cf7641","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Large Payload Tester"
 "on":
@@ -130,14 +130,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_22a5247e42096105_EOF'
+          cat << 'GH_AW_PROMPT_8714972bfafdb266_EOF'
           <system>
-          GH_AW_PROMPT_22a5247e42096105_EOF
+          GH_AW_PROMPT_8714972bfafdb266_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_22a5247e42096105_EOF'
+          cat << 'GH_AW_PROMPT_8714972bfafdb266_EOF'
           <safe-output-tools>
           Tools: create_issue(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -169,14 +169,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_22a5247e42096105_EOF
+          GH_AW_PROMPT_8714972bfafdb266_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_22a5247e42096105_EOF'
+          cat << 'GH_AW_PROMPT_8714972bfafdb266_EOF'
           </system>
-          GH_AW_PROMPT_22a5247e42096105_EOF
-          cat << 'GH_AW_PROMPT_22a5247e42096105_EOF'
+          GH_AW_PROMPT_8714972bfafdb266_EOF
+          cat << 'GH_AW_PROMPT_8714972bfafdb266_EOF'
           {{#runtime-import .github/workflows/large-payload-tester.md}}
-          GH_AW_PROMPT_22a5247e42096105_EOF
+          GH_AW_PROMPT_8714972bfafdb266_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -335,12 +335,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_910a5f5b2f582c82_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_290d2e1dc5afcbc1_EOF'
           {"create_issue":{"close_older_issues":true,"labels":["mcp-gateway","test","automation"],"max":10,"title_prefix":"[large-payload-test] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_910a5f5b2f582c82_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_290d2e1dc5afcbc1_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_ee3168af8a0b5d32_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_bcd87086bcafc8e3_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 10 issue(s) can be created. Title will be prefixed with \"[large-payload-test] \". Labels [\"mcp-gateway\" \"test\" \"automation\"] will be automatically added."
@@ -348,8 +348,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_ee3168af8a0b5d32_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8f8b9c02853a1504_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_bcd87086bcafc8e3_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_eafb8ab89c593d5c_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -442,7 +442,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_8f8b9c02853a1504_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_eafb8ab89c593d5c_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -510,7 +510,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_d974a77b8064eb72_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_bab2f5bc9f0ebc30_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "filesystem": {
@@ -574,7 +574,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d974a77b8064eb72_EOF
+          GH_AW_MCP_CONFIG_bab2f5bc9f0ebc30_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/large-payload-tester.md
+++ b/.github/workflows/large-payload-tester.md
@@ -133,6 +133,8 @@ post-steps:
 
 
 timeout-minutes: 10
+features:
+  difc-proxy: true
 strict: false
 ---
 

--- a/.github/workflows/mcp-gateway-log-analyzer.lock.yml
+++ b/.github/workflows/mcp-gateway-log-analyzer.lock.yml
@@ -22,7 +22,7 @@
 #
 # Daily analysis of MCP Gateway logs from gh-aw repository workflows to identify bugs and issues
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6191727a10b64747fc711c4670a894ad5f79257e20bef1e5b803288325f618de","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"191925b6d50e69cdee786c06b85c22a62a692be60415c6cd6822773a7cb5337e","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "MCP Gateway Log Analyzer"
 "on":
@@ -126,14 +126,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_b5aa7b2b5a80a46a_EOF'
+          cat << 'GH_AW_PROMPT_1e8bb08785635fd1_EOF'
           <system>
-          GH_AW_PROMPT_b5aa7b2b5a80a46a_EOF
+          GH_AW_PROMPT_1e8bb08785635fd1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5aa7b2b5a80a46a_EOF'
+          cat << 'GH_AW_PROMPT_1e8bb08785635fd1_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -165,14 +165,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b5aa7b2b5a80a46a_EOF
+          GH_AW_PROMPT_1e8bb08785635fd1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5aa7b2b5a80a46a_EOF'
+          cat << 'GH_AW_PROMPT_1e8bb08785635fd1_EOF'
           </system>
-          GH_AW_PROMPT_b5aa7b2b5a80a46a_EOF
-          cat << 'GH_AW_PROMPT_b5aa7b2b5a80a46a_EOF'
+          GH_AW_PROMPT_1e8bb08785635fd1_EOF
+          cat << 'GH_AW_PROMPT_1e8bb08785635fd1_EOF'
           {{#runtime-import .github/workflows/mcp-gateway-log-analyzer.md}}
-          GH_AW_PROMPT_b5aa7b2b5a80a46a_EOF
+          GH_AW_PROMPT_1e8bb08785635fd1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -325,12 +325,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_ecc7cc96651b3742_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_5160f9b3440f73a8_EOF'
           {"create_issue":{"assignees":["lpcox"],"labels":["bug","mcp-gateway","automation"],"max":1,"title_prefix":"[mcp-gateway-logs] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_ecc7cc96651b3742_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5160f9b3440f73a8_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_e80d492a64c98c35_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_b6fed2bf18ffdc0c_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[mcp-gateway-logs] \". Labels [\"bug\" \"mcp-gateway\" \"automation\"] will be automatically added. Assignees [\"lpcox\"] will be automatically assigned."
@@ -338,8 +338,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_e80d492a64c98c35_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_3b932ed3136da732_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_b6fed2bf18ffdc0c_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ac699c2e81dd5a55_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -432,7 +432,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_3b932ed3136da732_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_ac699c2e81dd5a55_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -498,7 +498,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_d5d210b1cd22d624_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_4bca5248f322d907_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -543,7 +543,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d5d210b1cd22d624_EOF
+          GH_AW_MCP_CONFIG_4bca5248f322d907_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -720,6 +720,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/mcp-gateway-log-analyzer.md
+++ b/.github/workflows/mcp-gateway-log-analyzer.md
@@ -36,6 +36,8 @@ tools:
   bash: ["*"]
 
 timeout-minutes: 30
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/nightly-docs-reconciler.lock.yml
+++ b/.github/workflows/nightly-docs-reconciler.lock.yml
@@ -22,7 +22,7 @@
 #
 # Nightly workflow that tests and reconciles implementation against documentation to ensure README and quickstarts reflect current main branch
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f81ea0558e1c8b82c36efe587623358b0e6552fea3787662034ba30f477bc1ba","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c7258da6bdde47e6ff8b3865364025c5fe158ffedcbdd4d3c52fec7601eb039a","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Nightly Documentation Reconciler"
 "on":
@@ -126,14 +126,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_287c463d08d95aea_EOF'
+          cat << 'GH_AW_PROMPT_4880f1f7255bef6d_EOF'
           <system>
-          GH_AW_PROMPT_287c463d08d95aea_EOF
+          GH_AW_PROMPT_4880f1f7255bef6d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_287c463d08d95aea_EOF'
+          cat << 'GH_AW_PROMPT_4880f1f7255bef6d_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -165,14 +165,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_287c463d08d95aea_EOF
+          GH_AW_PROMPT_4880f1f7255bef6d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_287c463d08d95aea_EOF'
+          cat << 'GH_AW_PROMPT_4880f1f7255bef6d_EOF'
           </system>
-          GH_AW_PROMPT_287c463d08d95aea_EOF
-          cat << 'GH_AW_PROMPT_287c463d08d95aea_EOF'
+          GH_AW_PROMPT_4880f1f7255bef6d_EOF
+          cat << 'GH_AW_PROMPT_4880f1f7255bef6d_EOF'
           {{#runtime-import .github/workflows/nightly-docs-reconciler.md}}
-          GH_AW_PROMPT_287c463d08d95aea_EOF
+          GH_AW_PROMPT_4880f1f7255bef6d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -324,12 +324,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_d48dae0e8c18a819_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_8a7fbba2ee2860da_EOF'
           {"create_issue":{"expires":72,"labels":["documentation","maintenance","automated"],"max":1,"title_prefix":"📚 "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d48dae0e8c18a819_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8a7fbba2ee2860da_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a6fdc724339dfcfc_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_5cdc17c0902b7104_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"📚 \". Labels [\"documentation\" \"maintenance\" \"automated\"] will be automatically added."
@@ -337,8 +337,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_a6fdc724339dfcfc_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b620009370b90e8b_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_5cdc17c0902b7104_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_827fcff7514fb42d_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -431,7 +431,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_b620009370b90e8b_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_827fcff7514fb42d_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -497,7 +497,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_62e0487f20e0dad4_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_251298084f7f6848_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -542,7 +542,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_62e0487f20e0dad4_EOF
+          GH_AW_MCP_CONFIG_251298084f7f6848_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -718,6 +718,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/nightly-docs-reconciler.md
+++ b/.github/workflows/nightly-docs-reconciler.md
@@ -26,6 +26,8 @@ safe-outputs:
   missing-tool:
     create-issue: true
 timeout-minutes: 20
+features:
+  difc-proxy: true
 ---
 
 <!-- Edit the file linked below to modify the agent without recompilation. Feel free to move the entire markdown body to that file. -->

--- a/.github/workflows/nightly-schema-updater.lock.yml
+++ b/.github/workflows/nightly-schema-updater.lock.yml
@@ -22,7 +22,7 @@
 #
 # Nightly workflow that checks the latest gh-aw release and updates the MCP gateway schema validation URL to the most recent pinned version
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1624f8c8ec41138e8c7c13547c525007fa9b090bd34afe5000fbb8a1986c92d7","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5b836facf21bbd5f9b79e49d33aaf3c711b686da03466430ca0cce24aa3744ae","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Nightly Schema Updater"
 "on":
@@ -126,19 +126,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_55ef258d709209d8_EOF'
+          cat << 'GH_AW_PROMPT_41edefc3f2cf359f_EOF'
           <system>
-          GH_AW_PROMPT_55ef258d709209d8_EOF
+          GH_AW_PROMPT_41edefc3f2cf359f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_55ef258d709209d8_EOF'
+          cat << 'GH_AW_PROMPT_41edefc3f2cf359f_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_55ef258d709209d8_EOF
+          GH_AW_PROMPT_41edefc3f2cf359f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_55ef258d709209d8_EOF'
+          cat << 'GH_AW_PROMPT_41edefc3f2cf359f_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -168,14 +168,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_55ef258d709209d8_EOF
+          GH_AW_PROMPT_41edefc3f2cf359f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_55ef258d709209d8_EOF'
+          cat << 'GH_AW_PROMPT_41edefc3f2cf359f_EOF'
           </system>
-          GH_AW_PROMPT_55ef258d709209d8_EOF
-          cat << 'GH_AW_PROMPT_55ef258d709209d8_EOF'
+          GH_AW_PROMPT_41edefc3f2cf359f_EOF
+          cat << 'GH_AW_PROMPT_41edefc3f2cf359f_EOF'
           {{#runtime-import .github/workflows/nightly-schema-updater.md}}
-          GH_AW_PROMPT_55ef258d709209d8_EOF
+          GH_AW_PROMPT_41edefc3f2cf359f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -333,12 +333,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_cdebad20ba1ed7f5_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_6c04622f607356f6_EOF'
           {"create_pull_request":{"draft":false,"expires":168,"labels":["maintenance","automation","schema"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"🔄 "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_cdebad20ba1ed7f5_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_6c04622f607356f6_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_27334da46ca520d2_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_47f652fade8a6cc4_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"🔄 \". Labels [\"maintenance\" \"automation\" \"schema\"] will be automatically added."
@@ -346,8 +346,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_27334da46ca520d2_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_29f2de8cf3a18987_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_47f652fade8a6cc4_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_e612e13c801c3db0_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -443,7 +443,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_29f2de8cf3a18987_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_e612e13c801c3db0_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -509,7 +509,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_182fb526da503a72_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_57764436622349e1_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -554,7 +554,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_182fb526da503a72_EOF
+          GH_AW_MCP_CONFIG_57764436622349e1_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -730,6 +730,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/nightly-schema-updater.md
+++ b/.github/workflows/nightly-schema-updater.md
@@ -40,6 +40,8 @@ safe-outputs:
     create-issue: true
 
 timeout-minutes: 15
+features:
+  difc-proxy: true
 ---
 
 # Nightly Schema Updater 🔄

--- a/.github/workflows/nightly-workflow-compiler.lock.yml
+++ b/.github/workflows/nightly-workflow-compiler.lock.yml
@@ -22,7 +22,7 @@
 #
 # Nightly workflow that upgrades all workflows to the latest agentic workflow release (agent files, codemods, and compilations)
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"78e0fed9bac6ee061b425060100f14fa6a9c153616d2d2f161fc852b45eea9b1","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9be097135ff580f7f8855a41035fbd384c3904e2d6cd1da6aabf1ddefce57c73","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Nightly Workflow Upgrader"
 "on":
@@ -126,19 +126,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_d6028a42224dad4d_EOF'
+          cat << 'GH_AW_PROMPT_94b6a217b5a720cc_EOF'
           <system>
-          GH_AW_PROMPT_d6028a42224dad4d_EOF
+          GH_AW_PROMPT_94b6a217b5a720cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d6028a42224dad4d_EOF'
+          cat << 'GH_AW_PROMPT_94b6a217b5a720cc_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_d6028a42224dad4d_EOF
+          GH_AW_PROMPT_94b6a217b5a720cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_d6028a42224dad4d_EOF'
+          cat << 'GH_AW_PROMPT_94b6a217b5a720cc_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -168,14 +168,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_d6028a42224dad4d_EOF
+          GH_AW_PROMPT_94b6a217b5a720cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d6028a42224dad4d_EOF'
+          cat << 'GH_AW_PROMPT_94b6a217b5a720cc_EOF'
           </system>
-          GH_AW_PROMPT_d6028a42224dad4d_EOF
-          cat << 'GH_AW_PROMPT_d6028a42224dad4d_EOF'
+          GH_AW_PROMPT_94b6a217b5a720cc_EOF
+          cat << 'GH_AW_PROMPT_94b6a217b5a720cc_EOF'
           {{#runtime-import .github/workflows/nightly-workflow-compiler.md}}
-          GH_AW_PROMPT_d6028a42224dad4d_EOF
+          GH_AW_PROMPT_94b6a217b5a720cc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -327,12 +327,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_41f33c90e4151887_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_85e6c3a0076efecf_EOF'
           {"create_pull_request":{"draft":true,"expires":168,"labels":["agentic-workflows","automation","maintenance"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"🤖 "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_41f33c90e4151887_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_85e6c3a0076efecf_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_9b9da6957665c0a2_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_93c0bd27d79a9f63_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"🤖 \". Labels [\"agentic-workflows\" \"automation\" \"maintenance\"] will be automatically added. PRs will be created as drafts."
@@ -340,8 +340,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_9b9da6957665c0a2_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_a386ca7dd271df54_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_93c0bd27d79a9f63_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_c521fc31ceab825c_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -437,7 +437,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_a386ca7dd271df54_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_c521fc31ceab825c_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -503,7 +503,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_4ccc60f34e6633be_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_6267c9618450565b_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -548,7 +548,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4ccc60f34e6633be_EOF
+          GH_AW_MCP_CONFIG_6267c9618450565b_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -724,6 +724,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/nightly-workflow-compiler.md
+++ b/.github/workflows/nightly-workflow-compiler.md
@@ -26,6 +26,8 @@ safe-outputs:
   missing-tool:
     create-issue: true
 timeout-minutes: 25
+features:
+  difc-proxy: true
 ---
 
 <!-- Edit the file linked below to modify the agent without recompilation. Feel free to move the entire markdown body to that file. -->

--- a/.github/workflows/plan.lock.yml
+++ b/.github/workflows/plan.lock.yml
@@ -22,7 +22,7 @@
 #
 # Generates project plans and task breakdowns when invoked with /plan command in issues or PRs
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ff5ded2118438ec993c3d0059b63d8f4503aa1f0d2066ca16f99242652715d19","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b6100521f4947db97f15ebfb4c4c93e97a8b4511eb8793ebef19714387f834c0","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Plan Command"
 "on":
@@ -170,14 +170,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_500d0e735b625a88_EOF'
+          cat << 'GH_AW_PROMPT_eff19b1c48d14f74_EOF'
           <system>
-          GH_AW_PROMPT_500d0e735b625a88_EOF
+          GH_AW_PROMPT_eff19b1c48d14f74_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_500d0e735b625a88_EOF'
+          cat << 'GH_AW_PROMPT_eff19b1c48d14f74_EOF'
           <safe-output-tools>
           Tools: create_issue(max:5), close_discussion, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -209,17 +209,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_500d0e735b625a88_EOF
+          GH_AW_PROMPT_eff19b1c48d14f74_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_500d0e735b625a88_EOF'
+          cat << 'GH_AW_PROMPT_eff19b1c48d14f74_EOF'
           </system>
-          GH_AW_PROMPT_500d0e735b625a88_EOF
-          cat << 'GH_AW_PROMPT_500d0e735b625a88_EOF'
+          GH_AW_PROMPT_eff19b1c48d14f74_EOF
+          cat << 'GH_AW_PROMPT_eff19b1c48d14f74_EOF'
           {{#runtime-import .github/workflows/plan.md}}
-          GH_AW_PROMPT_500d0e735b625a88_EOF
+          GH_AW_PROMPT_eff19b1c48d14f74_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -382,12 +382,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_c9ace1f9720bf06b_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_0a4aefc1f7ad5fa5_EOF'
           {"close_discussion":{"max":1},"create_issue":{"labels":["task","ai-generated"],"max":5,"title_prefix":"[task] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c9ace1f9720bf06b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_0a4aefc1f7ad5fa5_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_12fb12123bb60133_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_0a2edac4750a37a3_EOF'
           {
             "description_suffixes": {
               "close_discussion": " CONSTRAINTS: Maximum 1 discussion(s) can be closed.",
@@ -396,8 +396,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_12fb12123bb60133_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_09c1f4fd84ec239f_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_0a2edac4750a37a3_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f934d90c1563b145_EOF'
           {
             "close_discussion": {
               "defaultMax": 1,
@@ -517,7 +517,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_09c1f4fd84ec239f_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f934d90c1563b145_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -583,7 +583,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_c353840004496ef3_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_6aa8ca47520bd7a4_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -628,7 +628,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c353840004496ef3_EOF
+          GH_AW_MCP_CONFIG_6aa8ca47520bd7a4_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -805,6 +805,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/plan.md
+++ b/.github/workflows/plan.md
@@ -28,6 +28,8 @@ safe-outputs:
   close-discussion:
     required-category: "Ideas"
 timeout-minutes: 10
+features:
+  difc-proxy: true
 ---
 
 # Planning Assistant

--- a/.github/workflows/repo-assist.lock.yml
+++ b/.github/workflows/repo-assist.lock.yml
@@ -35,7 +35,7 @@
 #
 # Source: githubnext/agentics/workflows/repo-assist.md@851905c06e905bf362a9f6cc54f912e3df747d55
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f52ac74dc05780c81f84ddd12a759522b88bddbdb5bf7f62c32bb675565595d4","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"35f634c41c3e5f33378cdead77b0100452f03857487e85e4b3d7ee89ca8f077f","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Repo Assist"
 "on":
@@ -212,21 +212,21 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_0f92ebb80efa20ed_EOF'
+          cat << 'GH_AW_PROMPT_bb0a8e439a805cd2_EOF'
           <system>
-          GH_AW_PROMPT_0f92ebb80efa20ed_EOF
+          GH_AW_PROMPT_bb0a8e439a805cd2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0f92ebb80efa20ed_EOF'
+          cat << 'GH_AW_PROMPT_bb0a8e439a805cd2_EOF'
           <safe-output-tools>
           Tools: add_comment(max:10), create_issue(max:4), update_issue, create_pull_request(max:4), add_labels(max:30), remove_labels(max:5), push_to_pull_request_branch(max:4), missing_tool, missing_data, noop
-          GH_AW_PROMPT_0f92ebb80efa20ed_EOF
+          GH_AW_PROMPT_bb0a8e439a805cd2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_0f92ebb80efa20ed_EOF'
+          cat << 'GH_AW_PROMPT_bb0a8e439a805cd2_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -256,17 +256,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0f92ebb80efa20ed_EOF
+          GH_AW_PROMPT_bb0a8e439a805cd2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_0f92ebb80efa20ed_EOF'
+          cat << 'GH_AW_PROMPT_bb0a8e439a805cd2_EOF'
           </system>
-          GH_AW_PROMPT_0f92ebb80efa20ed_EOF
-          cat << 'GH_AW_PROMPT_0f92ebb80efa20ed_EOF'
+          GH_AW_PROMPT_bb0a8e439a805cd2_EOF
+          cat << 'GH_AW_PROMPT_bb0a8e439a805cd2_EOF'
           {{#runtime-import .github/workflows/repo-assist.md}}
-          GH_AW_PROMPT_0f92ebb80efa20ed_EOF
+          GH_AW_PROMPT_bb0a8e439a805cd2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -396,6 +396,15 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Start DIFC proxy for pre-agent gh calls
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+        run: |
+          bash ${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh '{"allow-only":{"min-integrity":"merged","repos":["github/*"]}}' 'ghcr.io/github/gh-aw-mcpg:v0.2.9'
+      - name: Set GH_REPO for proxied steps
+        run: |
+          echo "GH_REPO=${GITHUB_REPOSITORY}" >> "$GITHUB_ENV"
       - env:
           GH_TOKEN: ${{ github.token }}
         name: Fetch repo data for task weighting
@@ -447,6 +456,10 @@ jobs:
           GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
           GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
         run: bash ${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh
+      - name: Stop DIFC proxy
+        if: always()
+        continue-on-error: true
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh
       - name: Download container images
         run: bash ${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh ghcr.io/github/gh-aw-firewall/agent:0.25.4 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.4 ghcr.io/github/gh-aw-firewall/squid:0.25.4 ghcr.io/github/gh-aw-mcpg:v0.2.9 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Write Safe Outputs Config
@@ -454,12 +467,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_f4cc586b3e9dff01_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_4273aa376bd7a4ff_EOF'
           {"add_comment":{"hide_older_comments":true,"max":10,"target":"*"},"add_labels":{"allowed":["bug","enhancement","help wanted","good first issue","spam","off topic","documentation","question","duplicate","wontfix","needs triage","needs investigation","breaking change","performance","security","refactor"],"max":30,"target":"*"},"create_issue":{"labels":["automation","repo-assist"],"max":4,"title_prefix":"[Repo Assist] "},"create_pull_request":{"draft":true,"labels":["automation","repo-assist"],"max":4,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_files_policy":"fallback-to-issue","protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Repo Assist] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"push_to_pull_request_branch":{"if_no_changes":"warn","max":4,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"target":"*","title_prefix":"[Repo Assist] "},"remove_labels":{"allowed":["bug","enhancement","help wanted","good first issue","spam","off topic","documentation","question","duplicate","wontfix","needs triage","needs investigation","breaking change","performance","security","refactor"],"max":5,"target":"*"},"update_issue":{"allow_body":true,"max":1,"target":"*","title_prefix":"[Repo Assist] "}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f4cc586b3e9dff01_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_4273aa376bd7a4ff_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_f22f5ec0b68ca38f_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_5d3de341f683b718_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 10 comment(s) can be added. Target: *.",
@@ -473,8 +486,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_f22f5ec0b68ca38f_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ee533ca2ec7f3ff3_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_5d3de341f683b718_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b82de7f38d155d32_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -733,7 +746,7 @@ jobs:
               "customValidation": "requiresOneOf:status,title,body"
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_ee533ca2ec7f3ff3_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_b82de7f38d155d32_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -799,7 +812,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_fc2a04b9dd5569e2_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_6348d25d92273cb6_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -844,7 +857,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fc2a04b9dd5569e2_EOF
+          GH_AW_MCP_CONFIG_6348d25d92273cb6_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1030,6 +1043,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/repo-assist.md
+++ b/.github/workflows/repo-assist.md
@@ -169,6 +169,8 @@ steps:
 
 source: githubnext/agentics/workflows/repo-assist.md@851905c06e905bf362a9f6cc54f912e3df747d55
 engine: copilot
+features:
+  difc-proxy: true
 ---
 
 # Repo Assist

--- a/.github/workflows/rust-guard-improver.lock.yml
+++ b/.github/workflows/rust-guard-improver.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4fa9aafa4e87ffe0dbdc80b870ea2c78141a4a1f8b1905ec4b438d0dc70b1a51","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e0cc3f099fbdc8fc7071d25f2ed2eb9a8cdd3fa4debc87a60b9588da91490119","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Rust Guard Improver"
 "on":
@@ -129,15 +129,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_b8801597e1998ed6_EOF'
+          cat << 'GH_AW_PROMPT_b9170c490febc33f_EOF'
           <system>
-          GH_AW_PROMPT_b8801597e1998ed6_EOF
+          GH_AW_PROMPT_b9170c490febc33f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b8801597e1998ed6_EOF'
+          cat << 'GH_AW_PROMPT_b9170c490febc33f_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -169,17 +169,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b8801597e1998ed6_EOF
+          GH_AW_PROMPT_b9170c490febc33f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b8801597e1998ed6_EOF'
+          cat << 'GH_AW_PROMPT_b9170c490febc33f_EOF'
           </system>
-          GH_AW_PROMPT_b8801597e1998ed6_EOF
-          cat << 'GH_AW_PROMPT_b8801597e1998ed6_EOF'
+          GH_AW_PROMPT_b9170c490febc33f_EOF
+          cat << 'GH_AW_PROMPT_b9170c490febc33f_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_b8801597e1998ed6_EOF
-          cat << 'GH_AW_PROMPT_b8801597e1998ed6_EOF'
+          GH_AW_PROMPT_b9170c490febc33f_EOF
+          cat << 'GH_AW_PROMPT_b9170c490febc33f_EOF'
           {{#runtime-import .github/workflows/rust-guard-improver.md}}
-          GH_AW_PROMPT_b8801597e1998ed6_EOF
+          GH_AW_PROMPT_b9170c490febc33f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -354,12 +354,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_ca52999935b598b8_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_ac1308a9b71eed7a_EOF'
           {"create_issue":{"expires":168,"labels":["rust-guard","refactor"],"max":1,"title_prefix":"[rust-guard] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_ca52999935b598b8_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ac1308a9b71eed7a_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c049006ec4537089_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_29cd85f3c940dfbe_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[rust-guard] \". Labels [\"rust-guard\" \"refactor\"] will be automatically added."
@@ -367,8 +367,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_c049006ec4537089_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_5d91703fe7850d21_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_29cd85f3c940dfbe_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_35169305278cc9eb_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -461,7 +461,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_5d91703fe7850d21_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_35169305278cc9eb_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -527,7 +527,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_fd186bd62f52e559_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_63cae03634bd6c5e_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -572,7 +572,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fd186bd62f52e559_EOF
+          GH_AW_MCP_CONFIG_63cae03634bd6c5e_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -759,6 +759,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/rust-guard-improver.md
+++ b/.github/workflows/rust-guard-improver.md
@@ -44,6 +44,8 @@ tools:
     - "*"
 
 timeout-minutes: 30
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/semantic-function-refactor.lock.yml
+++ b/.github/workflows/semantic-function-refactor.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d4ec82ff89ec2d0883ac0a009a29c6b126c5a22e4bd16a6fc664bb3ff6bac0ee","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a3aa29a128a3dadf459e6ff3a6f76e9be8e6a97c80967993453da3468f68273e","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Semantic Function Refactoring"
 "on":
@@ -130,14 +130,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_a1b1293730482963_EOF'
+          cat << 'GH_AW_PROMPT_8104cdf0c3f33c7a_EOF'
           <system>
-          GH_AW_PROMPT_a1b1293730482963_EOF
+          GH_AW_PROMPT_8104cdf0c3f33c7a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a1b1293730482963_EOF'
+          cat << 'GH_AW_PROMPT_8104cdf0c3f33c7a_EOF'
           <safe-output-tools>
           Tools: create_issue, close_issue(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -169,17 +169,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a1b1293730482963_EOF
+          GH_AW_PROMPT_8104cdf0c3f33c7a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a1b1293730482963_EOF'
+          cat << 'GH_AW_PROMPT_8104cdf0c3f33c7a_EOF'
           </system>
-          GH_AW_PROMPT_a1b1293730482963_EOF
-          cat << 'GH_AW_PROMPT_a1b1293730482963_EOF'
+          GH_AW_PROMPT_8104cdf0c3f33c7a_EOF
+          cat << 'GH_AW_PROMPT_8104cdf0c3f33c7a_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_a1b1293730482963_EOF
-          cat << 'GH_AW_PROMPT_a1b1293730482963_EOF'
+          GH_AW_PROMPT_8104cdf0c3f33c7a_EOF
+          cat << 'GH_AW_PROMPT_8104cdf0c3f33c7a_EOF'
           {{#runtime-import .github/workflows/semantic-function-refactor.md}}
-          GH_AW_PROMPT_a1b1293730482963_EOF
+          GH_AW_PROMPT_8104cdf0c3f33c7a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -333,12 +333,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_d57f16e295b1b7cb_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_45c6205064f35ae7_EOF'
           {"close_issue":{"max":10,"required_title_prefix":"[refactor] ","target":"*"},"create_issue":{"labels":["refactoring","code-quality","automated-analysis"],"max":1,"title_prefix":"[refactor] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d57f16e295b1b7cb_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_45c6205064f35ae7_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_e630304776c05513_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7d8655f98a0a7762_EOF'
           {
             "description_suffixes": {
               "close_issue": " CONSTRAINTS: Maximum 10 issue(s) can be closed. Target: *. Only issues with title prefix \"[refactor] \" can be closed.",
@@ -347,8 +347,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_e630304776c05513_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_efdd661cdba2747a_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_7d8655f98a0a7762_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_eeb50b9b7ac86dba_EOF'
           {
             "close_issue": {
               "defaultMax": 1,
@@ -459,7 +459,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_efdd661cdba2747a_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_eeb50b9b7ac86dba_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -525,7 +525,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_07b64dee979ce75e_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_7c6cac6274e496bd_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -570,7 +570,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_07b64dee979ce75e_EOF
+          GH_AW_MCP_CONFIG_7c6cac6274e496bd_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -746,6 +746,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/semantic-function-refactor.md
+++ b/.github/workflows/semantic-function-refactor.md
@@ -38,6 +38,8 @@ tools:
     - "*"
 
 timeout-minutes: 20
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/smoke-allowonly.lock.yml
+++ b/.github/workflows/smoke-allowonly.lock.yml
@@ -28,7 +28,7 @@
 #     - shared/mcp-pagination.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b3a28a5ac4f87c72343f8598b698fe59686912b599e7486b8c0df97079a8b6b1","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e6c8d1807eb214d1f9af9ce67de91b02bcd51fbd3fa59daa157cd3eb852317cb","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Smoke AllowOnly"
 "on":
@@ -170,16 +170,16 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_5168ac5dd9f64495_EOF'
+          cat << 'GH_AW_PROMPT_5c99c46b58bd2a9c_EOF'
           <system>
-          GH_AW_PROMPT_5168ac5dd9f64495_EOF
+          GH_AW_PROMPT_5c99c46b58bd2a9c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/agentic_workflows_guide.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5168ac5dd9f64495_EOF'
+          cat << 'GH_AW_PROMPT_5c99c46b58bd2a9c_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_issue, add_labels, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -211,23 +211,23 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5168ac5dd9f64495_EOF
+          GH_AW_PROMPT_5c99c46b58bd2a9c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5168ac5dd9f64495_EOF'
+          cat << 'GH_AW_PROMPT_5c99c46b58bd2a9c_EOF'
           </system>
-          GH_AW_PROMPT_5168ac5dd9f64495_EOF
-          cat << 'GH_AW_PROMPT_5168ac5dd9f64495_EOF'
+          GH_AW_PROMPT_5c99c46b58bd2a9c_EOF
+          cat << 'GH_AW_PROMPT_5c99c46b58bd2a9c_EOF'
           {{#runtime-import .github/workflows/shared/mcp-pagination.md}}
-          GH_AW_PROMPT_5168ac5dd9f64495_EOF
-          cat << 'GH_AW_PROMPT_5168ac5dd9f64495_EOF'
+          GH_AW_PROMPT_5c99c46b58bd2a9c_EOF
+          cat << 'GH_AW_PROMPT_5c99c46b58bd2a9c_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_5168ac5dd9f64495_EOF
-          cat << 'GH_AW_PROMPT_5168ac5dd9f64495_EOF'
+          GH_AW_PROMPT_5c99c46b58bd2a9c_EOF
+          cat << 'GH_AW_PROMPT_5c99c46b58bd2a9c_EOF'
           {{#runtime-import .github/workflows/shared/github-mcp-app.md}}
-          GH_AW_PROMPT_5168ac5dd9f64495_EOF
-          cat << 'GH_AW_PROMPT_5168ac5dd9f64495_EOF'
+          GH_AW_PROMPT_5c99c46b58bd2a9c_EOF
+          cat << 'GH_AW_PROMPT_5c99c46b58bd2a9c_EOF'
           {{#runtime-import .github/workflows/smoke-allowonly.md}}
-          GH_AW_PROMPT_5168ac5dd9f64495_EOF
+          GH_AW_PROMPT_5c99c46b58bd2a9c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -430,12 +430,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_c83f42198e8220a7_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_bb53e201cd159d91_EOF'
           {"add_comment":{"hide_older_comments":true,"max":2},"add_labels":{"allowed":["smoke-allowonly"]},"create_issue":{"close_older_issues":true,"expires":2,"group":true,"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c83f42198e8220a7_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_bb53e201cd159d91_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7a1858a03d6af5b6_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_447783dabfdea942_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added.",
@@ -445,8 +445,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_7a1858a03d6af5b6_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_eeba40e430ac3306_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_447783dabfdea942_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8e1bf46197d5d9e5_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -576,7 +576,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_eeba40e430ac3306_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_8e1bf46197d5d9e5_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -643,7 +643,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_3e0304444d82a2b3_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_44bd310e39e1908c_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "agenticworkflows": {
@@ -709,7 +709,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3e0304444d82a2b3_EOF
+          GH_AW_MCP_CONFIG_44bd310e39e1908c_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -912,6 +912,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/smoke-allowonly.md
+++ b/.github/workflows/smoke-allowonly.md
@@ -16,6 +16,8 @@ permissions:
 name: Smoke AllowOnly
 engine:
   id: copilot
+features:
+  difc-proxy: true
 strict: false
 imports:
   - shared/mcp-pagination.md

--- a/.github/workflows/smoke-copilot.lock.yml
+++ b/.github/workflows/smoke-copilot.lock.yml
@@ -29,7 +29,7 @@
 #     - shared/mcp-pagination.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6af3b7c52fcb5b0b7619f971a89f12bb1e46c53966016c97d5225a686ed76c40","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e07aa46dec4302a34030fa85383b4d0672431b1d2610bfc0357f475da65e911f","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Smoke Copilot"
 "on":
@@ -171,16 +171,16 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_0947623f0db7aad2_EOF'
+          cat << 'GH_AW_PROMPT_ab7634416755671b_EOF'
           <system>
-          GH_AW_PROMPT_0947623f0db7aad2_EOF
+          GH_AW_PROMPT_ab7634416755671b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/playwright_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0947623f0db7aad2_EOF'
+          cat << 'GH_AW_PROMPT_ab7634416755671b_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_issue, add_labels, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -212,26 +212,26 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0947623f0db7aad2_EOF
+          GH_AW_PROMPT_ab7634416755671b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0947623f0db7aad2_EOF'
+          cat << 'GH_AW_PROMPT_ab7634416755671b_EOF'
           </system>
-          GH_AW_PROMPT_0947623f0db7aad2_EOF
-          cat << 'GH_AW_PROMPT_0947623f0db7aad2_EOF'
+          GH_AW_PROMPT_ab7634416755671b_EOF
+          cat << 'GH_AW_PROMPT_ab7634416755671b_EOF'
           {{#runtime-import .github/workflows/shared/mcp-pagination.md}}
-          GH_AW_PROMPT_0947623f0db7aad2_EOF
-          cat << 'GH_AW_PROMPT_0947623f0db7aad2_EOF'
+          GH_AW_PROMPT_ab7634416755671b_EOF
+          cat << 'GH_AW_PROMPT_ab7634416755671b_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_0947623f0db7aad2_EOF
-          cat << 'GH_AW_PROMPT_0947623f0db7aad2_EOF'
+          GH_AW_PROMPT_ab7634416755671b_EOF
+          cat << 'GH_AW_PROMPT_ab7634416755671b_EOF'
           {{#runtime-import .github/workflows/shared/go-make.md}}
-          GH_AW_PROMPT_0947623f0db7aad2_EOF
-          cat << 'GH_AW_PROMPT_0947623f0db7aad2_EOF'
+          GH_AW_PROMPT_ab7634416755671b_EOF
+          cat << 'GH_AW_PROMPT_ab7634416755671b_EOF'
           {{#runtime-import .github/workflows/shared/github-mcp-app.md}}
-          GH_AW_PROMPT_0947623f0db7aad2_EOF
-          cat << 'GH_AW_PROMPT_0947623f0db7aad2_EOF'
+          GH_AW_PROMPT_ab7634416755671b_EOF
+          cat << 'GH_AW_PROMPT_ab7634416755671b_EOF'
           {{#runtime-import .github/workflows/smoke-copilot.md}}
-          GH_AW_PROMPT_0947623f0db7aad2_EOF
+          GH_AW_PROMPT_ab7634416755671b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -418,12 +418,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_5270bf99fbe0e42d_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_9df8ca4b2eaf3b1f_EOF'
           {"add_comment":{"hide_older_comments":true,"max":2},"add_labels":{"allowed":["smoke-copilot"]},"create_issue":{"close_older_issues":true,"expires":2,"group":true,"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5270bf99fbe0e42d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_9df8ca4b2eaf3b1f_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_f423332bbdd735d5_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_11ee5fde091963ba_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added.",
@@ -433,8 +433,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_f423332bbdd735d5_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_340ccec798b5a6d3_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_11ee5fde091963ba_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_6b8f24ba8e721fdd_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -564,7 +564,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_340ccec798b5a6d3_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_6b8f24ba8e721fdd_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -631,7 +631,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_c3a38ec817262fe0_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_928b8cb954c8f601_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -690,7 +690,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c3a38ec817262fe0_EOF
+          GH_AW_MCP_CONFIG_928b8cb954c8f601_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -877,6 +877,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/smoke-copilot.md
+++ b/.github/workflows/smoke-copilot.md
@@ -16,6 +16,8 @@ permissions:
 name: Smoke Copilot
 engine:
   id: copilot
+features:
+  difc-proxy: true
 strict: false
 imports:
   - shared/mcp-pagination.md

--- a/.github/workflows/smoke-proxy-github-script.lock.yml
+++ b/.github/workflows/smoke-proxy-github-script.lock.yml
@@ -26,7 +26,7 @@
 #   Imports:
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b6cb79282494d1421881c1558fd7b1a2e4b0be9e4c5b0556ab044c6a203e4738","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"70df5180f5a5e35197fbd9c15b5e3e634ffd7661a1568b506be2da4b392a7279","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Smoke: Proxy + github-script"
 "on":
@@ -166,16 +166,16 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_306e416d2071f32b_EOF'
+          cat << 'GH_AW_PROMPT_7c2553f227f10a28_EOF'
           <system>
-          GH_AW_PROMPT_306e416d2071f32b_EOF
+          GH_AW_PROMPT_7c2553f227f10a28_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/agentic_workflows_guide.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_306e416d2071f32b_EOF'
+          cat << 'GH_AW_PROMPT_7c2553f227f10a28_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -207,17 +207,17 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_306e416d2071f32b_EOF
+          GH_AW_PROMPT_7c2553f227f10a28_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_306e416d2071f32b_EOF'
+          cat << 'GH_AW_PROMPT_7c2553f227f10a28_EOF'
           </system>
-          GH_AW_PROMPT_306e416d2071f32b_EOF
-          cat << 'GH_AW_PROMPT_306e416d2071f32b_EOF'
+          GH_AW_PROMPT_7c2553f227f10a28_EOF
+          cat << 'GH_AW_PROMPT_7c2553f227f10a28_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_306e416d2071f32b_EOF
-          cat << 'GH_AW_PROMPT_306e416d2071f32b_EOF'
+          GH_AW_PROMPT_7c2553f227f10a28_EOF
+          cat << 'GH_AW_PROMPT_7c2553f227f10a28_EOF'
           {{#runtime-import .github/workflows/smoke-proxy-github-script.md}}
-          GH_AW_PROMPT_306e416d2071f32b_EOF
+          GH_AW_PROMPT_7c2553f227f10a28_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -338,6 +338,15 @@ jobs:
         run: bash ${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Start DIFC proxy for pre-agent gh calls
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+        run: |
+          bash ${RUNNER_TEMP}/gh-aw/actions/start_difc_proxy.sh '{"allow-only":{"min-integrity":"approved","repos":["github/gh-aw-mcpg"]}}' 'ghcr.io/github/gh-aw-mcpg:v0.2.9'
+      - name: Set GH_REPO for proxied steps
+        run: |
+          echo "GH_REPO=${GITHUB_REPOSITORY}" >> "$GITHUB_ENV"
       - name: Build MCP Gateway image
         run: "# Install Rust and WASM target if not present\nif ! command -v rustup &>/dev/null; then\n  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable\n  source \"$HOME/.cargo/env\"\nfi\nrustup target add wasm32-wasip1\n\n# Build the Rust WASM guard (required by Dockerfile)\ncd guards/github-guard/rust-guard\nbash build.sh\ncd ../../..\n\n# Build Docker image\ndocker build -t awmg-local:latest .\n"
       - env:
@@ -437,6 +446,10 @@ jobs:
           GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
           GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
         run: bash ${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh
+      - name: Stop DIFC proxy
+        if: always()
+        continue-on-error: true
+        run: bash ${RUNNER_TEMP}/gh-aw/actions/stop_difc_proxy.sh
       - name: Download container images
         run: bash ${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh alpine:latest ghcr.io/github/gh-aw-firewall/agent:0.25.4 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.4 ghcr.io/github/gh-aw-firewall/squid:0.25.4 ghcr.io/github/gh-aw-mcpg:v0.2.9 ghcr.io/github/github-mcp-server:v0.32.0 node:lts-alpine
       - name: Install gh-aw extension
@@ -468,12 +481,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_aa9e8a9be3aeb4b0_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_957329429d273379_EOF'
           {"add_comment":{"hide_older_comments":true,"max":2},"create_issue":{"close_older_issues":true,"expires":2,"group":true,"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_aa9e8a9be3aeb4b0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_957329429d273379_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_b7f2322ee0a23794_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c0db56817d5a847b_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added.",
@@ -482,8 +495,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_b7f2322ee0a23794_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ccbacaa712fb4947_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_c0db56817d5a847b_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8f538f1abb8df6ab_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -594,7 +607,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_ccbacaa712fb4947_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_8f538f1abb8df6ab_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -661,7 +674,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_8c3719646def6f33_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_17668e326a640cf6_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "agenticworkflows": {
@@ -727,7 +740,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8c3719646def6f33_EOF
+          GH_AW_MCP_CONFIG_17668e326a640cf6_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -932,6 +945,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/smoke-proxy-github-script.md
+++ b/.github/workflows/smoke-proxy-github-script.md
@@ -15,6 +15,8 @@ permissions:
 name: "Smoke: Proxy + github-script"
 engine:
   id: copilot
+features:
+  difc-proxy: true
 strict: false
 imports:
   - shared/reporting.md

--- a/.github/workflows/smoke-safeoutputs-discussions.lock.yml
+++ b/.github/workflows/smoke-safeoutputs-discussions.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/github-mcp-app.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7c8b89ac624b9231b6c60f69a15ce1bbd95c7a7380130fbb9439518ed1fd52d1","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f088a829adead52143eb9fa00661f6a86d1d17bb0508b7e78fbad8a53bb005a5","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Smoke Safe-Outputs Discussions"
 "on":
@@ -155,15 +155,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_965d37fe32127783_EOF'
+          cat << 'GH_AW_PROMPT_9461987177d86893_EOF'
           <system>
-          GH_AW_PROMPT_965d37fe32127783_EOF
+          GH_AW_PROMPT_9461987177d86893_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_965d37fe32127783_EOF'
+          cat << 'GH_AW_PROMPT_9461987177d86893_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_issue, create_discussion, update_discussion, close_discussion, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -195,20 +195,20 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_965d37fe32127783_EOF
+          GH_AW_PROMPT_9461987177d86893_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_965d37fe32127783_EOF'
+          cat << 'GH_AW_PROMPT_9461987177d86893_EOF'
           </system>
-          GH_AW_PROMPT_965d37fe32127783_EOF
-          cat << 'GH_AW_PROMPT_965d37fe32127783_EOF'
+          GH_AW_PROMPT_9461987177d86893_EOF
+          cat << 'GH_AW_PROMPT_9461987177d86893_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_965d37fe32127783_EOF
-          cat << 'GH_AW_PROMPT_965d37fe32127783_EOF'
+          GH_AW_PROMPT_9461987177d86893_EOF
+          cat << 'GH_AW_PROMPT_9461987177d86893_EOF'
           {{#runtime-import .github/workflows/shared/github-mcp-app.md}}
-          GH_AW_PROMPT_965d37fe32127783_EOF
-          cat << 'GH_AW_PROMPT_965d37fe32127783_EOF'
+          GH_AW_PROMPT_9461987177d86893_EOF
+          cat << 'GH_AW_PROMPT_9461987177d86893_EOF'
           {{#runtime-import .github/workflows/smoke-safeoutputs-discussions.md}}
-          GH_AW_PROMPT_965d37fe32127783_EOF
+          GH_AW_PROMPT_9461987177d86893_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -391,12 +391,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_ffed1d05ba45b963_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_f553f584e97cc40f_EOF'
           {"add_comment":{"hide_older_comments":true,"max":2,"target":"triggering"},"close_discussion":{"max":1,"required_labels":["smoke-test"]},"create_discussion":{"category":"general","close_older_discussions":true,"expires":168,"fallback_to_issue":true,"labels":["smoke-test"],"max":1,"title_prefix":"[smoke-safeoutputs] "},"create_issue":{"close_older_issues":true,"expires":2,"labels":["smoke-test","automated"],"max":1,"title_prefix":"[smoke-safeoutputs] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"update_discussion":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_ffed1d05ba45b963_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f553f584e97cc40f_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_2aff59dfcf4e6d8d_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_0f7cf7b3f9132d95_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added. Target: triggering.",
@@ -408,8 +408,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_2aff59dfcf4e6d8d_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_674de780e3da7db7_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_0f7cf7b3f9132d95_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_7634b42c780acc6a_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -596,7 +596,7 @@ jobs:
               "customValidation": "requiresOneOf:title,body"
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_674de780e3da7db7_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_7634b42c780acc6a_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -662,7 +662,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_3ddd85b5280d1fb0_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_46dad96443c3ff25_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -707,7 +707,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_3ddd85b5280d1fb0_EOF
+          GH_AW_MCP_CONFIG_46dad96443c3ff25_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -909,6 +909,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/smoke-safeoutputs-discussions.md
+++ b/.github/workflows/smoke-safeoutputs-discussions.md
@@ -17,6 +17,8 @@ permissions:
 name: Smoke Safe-Outputs Discussions
 engine:
   id: copilot
+features:
+  difc-proxy: true
 strict: false
 imports:
   - shared/reporting.md

--- a/.github/workflows/smoke-safeoutputs-issues.lock.yml
+++ b/.github/workflows/smoke-safeoutputs-issues.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/github-mcp-app.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"588905f577fc0e9a01b2a01773f3ed959d41682bb78ac483fd980c7ca4f886f3","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"de333dcb9f29d01cd4a41b08dcc4307deb78ea7555a1efbf1648c4d50480e2ad","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Smoke Safe-Outputs Issues"
 "on":
@@ -155,15 +155,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_479105dbac1f11ee_EOF'
+          cat << 'GH_AW_PROMPT_e4b9ff0136077fb4_EOF'
           <system>
-          GH_AW_PROMPT_479105dbac1f11ee_EOF
+          GH_AW_PROMPT_e4b9ff0136077fb4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_479105dbac1f11ee_EOF'
+          cat << 'GH_AW_PROMPT_e4b9ff0136077fb4_EOF'
           <safe-output-tools>
           Tools: create_issue(max:3), close_issue, update_issue, assign_milestone, link_sub_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -195,20 +195,20 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_479105dbac1f11ee_EOF
+          GH_AW_PROMPT_e4b9ff0136077fb4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_479105dbac1f11ee_EOF'
+          cat << 'GH_AW_PROMPT_e4b9ff0136077fb4_EOF'
           </system>
-          GH_AW_PROMPT_479105dbac1f11ee_EOF
-          cat << 'GH_AW_PROMPT_479105dbac1f11ee_EOF'
+          GH_AW_PROMPT_e4b9ff0136077fb4_EOF
+          cat << 'GH_AW_PROMPT_e4b9ff0136077fb4_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_479105dbac1f11ee_EOF
-          cat << 'GH_AW_PROMPT_479105dbac1f11ee_EOF'
+          GH_AW_PROMPT_e4b9ff0136077fb4_EOF
+          cat << 'GH_AW_PROMPT_e4b9ff0136077fb4_EOF'
           {{#runtime-import .github/workflows/shared/github-mcp-app.md}}
-          GH_AW_PROMPT_479105dbac1f11ee_EOF
-          cat << 'GH_AW_PROMPT_479105dbac1f11ee_EOF'
+          GH_AW_PROMPT_e4b9ff0136077fb4_EOF
+          cat << 'GH_AW_PROMPT_e4b9ff0136077fb4_EOF'
           {{#runtime-import .github/workflows/smoke-safeoutputs-issues.md}}
-          GH_AW_PROMPT_479105dbac1f11ee_EOF
+          GH_AW_PROMPT_e4b9ff0136077fb4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -390,12 +390,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_4e48febc0bc8c830_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_ac37a0a3583c473a_EOF'
           {"assign_milestone":{"allowed":["v1.0"],"max":1},"close_issue":{"max":1,"required_labels":["smoke-test"],"required_title_prefix":"[smoke-safeoutputs]"},"create_issue":{"close_older_issues":true,"expires":2,"labels":["smoke-test","automated"],"max":3,"title_prefix":"[smoke-safeoutputs] "},"link_sub_issue":{"max":1,"parent_title_prefix":"[smoke-safeoutputs]","sub_title_prefix":"[smoke-safeoutputs]"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"update_issue":{"allow_body":true,"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4e48febc0bc8c830_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ac37a0a3583c473a_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_e984435db09d16ac_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_e7f62406728f55d4_EOF'
           {
             "description_suffixes": {
               "assign_milestone": " CONSTRAINTS: Maximum 1 milestone assignment(s) can be made.",
@@ -407,8 +407,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_e984435db09d16ac_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f43e6463d4bdd8fd_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_e7f62406728f55d4_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_1655fd6fb7e5c3e7_EOF'
           {
             "assign_milestone": {
               "defaultMax": 1,
@@ -607,7 +607,7 @@ jobs:
               "customValidation": "requiresOneOf:status,title,body"
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_f43e6463d4bdd8fd_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_1655fd6fb7e5c3e7_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -673,7 +673,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_8dec5c10d151644a_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_f1218cfd4bb6dd2c_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -718,7 +718,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8dec5c10d151644a_EOF
+          GH_AW_MCP_CONFIG_f1218cfd4bb6dd2c_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -920,6 +920,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/smoke-safeoutputs-issues.md
+++ b/.github/workflows/smoke-safeoutputs-issues.md
@@ -16,6 +16,8 @@ permissions:
 name: Smoke Safe-Outputs Issues
 engine:
   id: copilot
+features:
+  difc-proxy: true
 strict: false
 imports:
   - shared/reporting.md

--- a/.github/workflows/smoke-safeoutputs-labels.lock.yml
+++ b/.github/workflows/smoke-safeoutputs-labels.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/github-mcp-app.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7fee3de86dec7aecb576a1a2d2a270b765d1dc552d9b919b19e8697091590ccf","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"934a821808185e9af92422095edd6ec58770f1bae86d3a2473642a00d64b6a94","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Smoke Safe-Outputs Labels"
 "on":
@@ -155,15 +155,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_bba0063152b38721_EOF'
+          cat << 'GH_AW_PROMPT_c063e4b1182b124f_EOF'
           <system>
-          GH_AW_PROMPT_bba0063152b38721_EOF
+          GH_AW_PROMPT_c063e4b1182b124f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bba0063152b38721_EOF'
+          cat << 'GH_AW_PROMPT_c063e4b1182b124f_EOF'
           <safe-output-tools>
           Tools: create_issue, add_labels(max:2), remove_labels, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -195,20 +195,20 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_bba0063152b38721_EOF
+          GH_AW_PROMPT_c063e4b1182b124f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bba0063152b38721_EOF'
+          cat << 'GH_AW_PROMPT_c063e4b1182b124f_EOF'
           </system>
-          GH_AW_PROMPT_bba0063152b38721_EOF
-          cat << 'GH_AW_PROMPT_bba0063152b38721_EOF'
+          GH_AW_PROMPT_c063e4b1182b124f_EOF
+          cat << 'GH_AW_PROMPT_c063e4b1182b124f_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_bba0063152b38721_EOF
-          cat << 'GH_AW_PROMPT_bba0063152b38721_EOF'
+          GH_AW_PROMPT_c063e4b1182b124f_EOF
+          cat << 'GH_AW_PROMPT_c063e4b1182b124f_EOF'
           {{#runtime-import .github/workflows/shared/github-mcp-app.md}}
-          GH_AW_PROMPT_bba0063152b38721_EOF
-          cat << 'GH_AW_PROMPT_bba0063152b38721_EOF'
+          GH_AW_PROMPT_c063e4b1182b124f_EOF
+          cat << 'GH_AW_PROMPT_c063e4b1182b124f_EOF'
           {{#runtime-import .github/workflows/smoke-safeoutputs-labels.md}}
-          GH_AW_PROMPT_bba0063152b38721_EOF
+          GH_AW_PROMPT_c063e4b1182b124f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -390,12 +390,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_4932e8fbcb7ae5cd_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_01b15ad805ba96c5_EOF'
           {"add_labels":{"allowed":["smoke-test","verified"],"max":2,"target":"triggering"},"create_issue":{"close_older_issues":true,"expires":2,"labels":["smoke-test","automated"],"max":1,"title_prefix":"[smoke-safeoutputs] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["smoke-test"],"max":1,"target":"triggering"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4932e8fbcb7ae5cd_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_01b15ad805ba96c5_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_bf7bcef8d1b9edeb_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_d33329ac78fa7d3f_EOF'
           {
             "description_suffixes": {
               "add_labels": " CONSTRAINTS: Maximum 2 label(s) can be added. Only these labels are allowed: [\"smoke-test\" \"verified\"]. Target: triggering.",
@@ -405,8 +405,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_bf7bcef8d1b9edeb_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_74ccad33ac2d5c6b_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_d33329ac78fa7d3f_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b21afd88aa4b65bd_EOF'
           {
             "add_labels": {
               "defaultMax": 5,
@@ -537,7 +537,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_74ccad33ac2d5c6b_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_b21afd88aa4b65bd_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -603,7 +603,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_88df286efbc3407b_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_8cc7a0dd27393b77_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -648,7 +648,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_88df286efbc3407b_EOF
+          GH_AW_MCP_CONFIG_8cc7a0dd27393b77_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -850,6 +850,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/smoke-safeoutputs-labels.md
+++ b/.github/workflows/smoke-safeoutputs-labels.md
@@ -16,6 +16,8 @@ permissions:
 name: Smoke Safe-Outputs Labels
 engine:
   id: copilot
+features:
+  difc-proxy: true
 strict: false
 imports:
   - shared/reporting.md

--- a/.github/workflows/smoke-safeoutputs-prs.lock.yml
+++ b/.github/workflows/smoke-safeoutputs-prs.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/github-mcp-app.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"bc7d148a1c4022718d1bc80a4bf7c97f8d87679ab8129a7dadbf1da69b754e65","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5fa3668693deed72e77fe762c2c528bad7e549e66551bbd966ff5101beddb11c","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Smoke Safe-Outputs PRs"
 "on":
@@ -155,21 +155,21 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_6ae5636a70bf94fe_EOF'
+          cat << 'GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF'
           <system>
-          GH_AW_PROMPT_6ae5636a70bf94fe_EOF
+          GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6ae5636a70bf94fe_EOF'
+          cat << 'GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF'
           <safe-output-tools>
           Tools: create_issue, create_pull_request, close_pull_request, update_pull_request, mark_pull_request_as_ready_for_review, add_reviewer, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_6ae5636a70bf94fe_EOF
+          GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_6ae5636a70bf94fe_EOF'
+          cat << 'GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -199,20 +199,20 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6ae5636a70bf94fe_EOF
+          GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6ae5636a70bf94fe_EOF'
+          cat << 'GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF'
           </system>
-          GH_AW_PROMPT_6ae5636a70bf94fe_EOF
-          cat << 'GH_AW_PROMPT_6ae5636a70bf94fe_EOF'
+          GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF
+          cat << 'GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_6ae5636a70bf94fe_EOF
-          cat << 'GH_AW_PROMPT_6ae5636a70bf94fe_EOF'
+          GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF
+          cat << 'GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF'
           {{#runtime-import .github/workflows/shared/github-mcp-app.md}}
-          GH_AW_PROMPT_6ae5636a70bf94fe_EOF
-          cat << 'GH_AW_PROMPT_6ae5636a70bf94fe_EOF'
+          GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF
+          cat << 'GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF'
           {{#runtime-import .github/workflows/smoke-safeoutputs-prs.md}}
-          GH_AW_PROMPT_6ae5636a70bf94fe_EOF
+          GH_AW_PROMPT_c6e2d1cc91aef8ee_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -394,12 +394,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_c770980c9ce882c5_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_7710d84203524a2c_EOF'
           {"add_reviewer":{"allowed":["copilot"],"max":1},"close_pull_request":{"max":1,"required_labels":["smoke-test"],"required_title_prefix":"[smoke-safeoutputs]"},"create_issue":{"close_older_issues":true,"expires":2,"labels":["smoke-test","automated"],"max":1,"title_prefix":"[smoke-safeoutputs] "},"create_pull_request":{"draft":true,"labels":["smoke-test"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[smoke-safeoutputs] "},"mark_pull_request_as_ready_for_review":{"max":1,"required_labels":["smoke-test"]},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_to_pull_request_branch":{"if_no_changes":"warn","max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"target":"triggering","title_prefix":"[smoke-safeoutputs]"},"update_pull_request":{"allow_body":false,"allow_title":true,"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c770980c9ce882c5_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_7710d84203524a2c_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_6bb39119e2529461_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a668ab11f1d3de15_EOF'
           {
             "description_suffixes": {
               "add_reviewer": " CONSTRAINTS: Maximum 1 reviewer(s) can be added.",
@@ -412,8 +412,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_6bb39119e2529461_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_6a387889e158f2cd_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_a668ab11f1d3de15_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_761ebc604fd05088_EOF'
           {
             "add_reviewer": {
               "defaultMax": 3,
@@ -651,7 +651,7 @@ jobs:
               "customValidation": "requiresOneOf:title,body"
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_6a387889e158f2cd_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_761ebc604fd05088_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -717,7 +717,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_592d5d184091c17f_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_813793be58aa314a_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -762,7 +762,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_592d5d184091c17f_EOF
+          GH_AW_MCP_CONFIG_813793be58aa314a_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -974,6 +974,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/smoke-safeoutputs-prs.md
+++ b/.github/workflows/smoke-safeoutputs-prs.md
@@ -16,6 +16,8 @@ permissions:
 name: Smoke Safe-Outputs PRs
 engine:
   id: copilot
+features:
+  difc-proxy: true
 strict: false
 imports:
   - shared/reporting.md

--- a/.github/workflows/smoke-safeoutputs-reviews.lock.yml
+++ b/.github/workflows/smoke-safeoutputs-reviews.lock.yml
@@ -27,7 +27,7 @@
 #     - shared/github-mcp-app.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"4fb26dd101809b914ac2d6dc64af1f443a8acdf38a29ba8771b05ab0c3033e2d","compiler_version":"v0.64.5","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9d2c2103436e34de5cbae2051ed1bba453b6b301fd6a2c582b4d767b71587963","compiler_version":"v0.64.5","agent_id":"copilot"}
 
 name: "Smoke Safe-Outputs Reviews"
 "on":
@@ -155,15 +155,15 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_879d1a36e18aee9b_EOF'
+          cat << 'GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF'
           <system>
-          GH_AW_PROMPT_879d1a36e18aee9b_EOF
+          GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_879d1a36e18aee9b_EOF'
+          cat << 'GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF'
           <safe-output-tools>
           Tools: create_issue, create_pull_request_review_comment(max:2), submit_pull_request_review, reply_to_pull_request_review_comment(max:2), resolve_pull_request_review_thread(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -195,20 +195,20 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_879d1a36e18aee9b_EOF
+          GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_879d1a36e18aee9b_EOF'
+          cat << 'GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF'
           </system>
-          GH_AW_PROMPT_879d1a36e18aee9b_EOF
-          cat << 'GH_AW_PROMPT_879d1a36e18aee9b_EOF'
+          GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF
+          cat << 'GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF'
           {{#runtime-import .github/workflows/shared/reporting.md}}
-          GH_AW_PROMPT_879d1a36e18aee9b_EOF
-          cat << 'GH_AW_PROMPT_879d1a36e18aee9b_EOF'
+          GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF
+          cat << 'GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF'
           {{#runtime-import .github/workflows/shared/github-mcp-app.md}}
-          GH_AW_PROMPT_879d1a36e18aee9b_EOF
-          cat << 'GH_AW_PROMPT_879d1a36e18aee9b_EOF'
+          GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF
+          cat << 'GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF'
           {{#runtime-import .github/workflows/smoke-safeoutputs-reviews.md}}
-          GH_AW_PROMPT_879d1a36e18aee9b_EOF
+          GH_AW_PROMPT_74db3ab7ebcd1ab3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -390,12 +390,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_52965496bab8849d_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_db49de1a6d7d0f15_EOF'
           {"create_issue":{"close_older_issues":true,"expires":2,"labels":["smoke-test","automated"],"max":1,"title_prefix":"[smoke-safeoutputs] "},"create_pull_request_review_comment":{"max":2,"side":"RIGHT","target":"triggering"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"reply_to_pull_request_review_comment":{"max":2},"resolve_pull_request_review_thread":{"max":2},"submit_pull_request_review":{"footer":"if-body","max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_52965496bab8849d_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_db49de1a6d7d0f15_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_61ca7e388bb654e7_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_7712a967b21663c7_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[smoke-safeoutputs] \". Labels [\"smoke-test\" \"automated\"] will be automatically added.",
@@ -407,8 +407,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_61ca7e388bb654e7_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_5c13c95601823d56_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_7712a967b21663c7_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_366b0491be40afa2_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -587,7 +587,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_5c13c95601823d56_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_366b0491be40afa2_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -653,7 +653,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_ddbe8464fbd59301_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_9f2b7d14aeb22a35_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -698,7 +698,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ddbe8464fbd59301_EOF
+          GH_AW_MCP_CONFIG_9f2b7d14aeb22a35_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -900,6 +900,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/smoke-safeoutputs-reviews.md
+++ b/.github/workflows/smoke-safeoutputs-reviews.md
@@ -16,6 +16,8 @@ permissions:
 name: Smoke Safe-Outputs Reviews
 engine:
   id: copilot
+features:
+  difc-proxy: true
 strict: false
 imports:
   - shared/reporting.md

--- a/.github/workflows/test-coverage-improver.lock.yml
+++ b/.github/workflows/test-coverage-improver.lock.yml
@@ -22,7 +22,7 @@
 #
 # Daily analyzer that finds complex, under-tested functions and generates comprehensive tests
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"425a7cf5c0a346ca984a71e9d75ac5607b38679299975ccde90bafa5064a4bcf","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f205d85bf90537cc03d1840a988c4bed5dcf8b3135e89bb44178c8959619825e","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Test Coverage Improver"
 "on":
@@ -126,20 +126,20 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_c564a85fddf8cf57_EOF'
+          cat << 'GH_AW_PROMPT_71d7bc844bcbb8f9_EOF'
           <system>
-          GH_AW_PROMPT_c564a85fddf8cf57_EOF
+          GH_AW_PROMPT_71d7bc844bcbb8f9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c564a85fddf8cf57_EOF'
+          cat << 'GH_AW_PROMPT_71d7bc844bcbb8f9_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_c564a85fddf8cf57_EOF
+          GH_AW_PROMPT_71d7bc844bcbb8f9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_c564a85fddf8cf57_EOF'
+          cat << 'GH_AW_PROMPT_71d7bc844bcbb8f9_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -169,14 +169,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c564a85fddf8cf57_EOF
+          GH_AW_PROMPT_71d7bc844bcbb8f9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c564a85fddf8cf57_EOF'
+          cat << 'GH_AW_PROMPT_71d7bc844bcbb8f9_EOF'
           </system>
-          GH_AW_PROMPT_c564a85fddf8cf57_EOF
-          cat << 'GH_AW_PROMPT_c564a85fddf8cf57_EOF'
+          GH_AW_PROMPT_71d7bc844bcbb8f9_EOF
+          cat << 'GH_AW_PROMPT_71d7bc844bcbb8f9_EOF'
           {{#runtime-import .github/workflows/test-coverage-improver.md}}
-          GH_AW_PROMPT_c564a85fddf8cf57_EOF
+          GH_AW_PROMPT_71d7bc844bcbb8f9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -357,12 +357,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_f2d81e5a08e9a4f2_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_39ff848a9d41e322_EOF'
           {"create_pull_request":{"draft":true,"labels":["testing","automation"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[test] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f2d81e5a08e9a4f2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_39ff848a9d41e322_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_4475a70ccf16b50e_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_c317d5140d671810_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[test] \". Labels [\"testing\" \"automation\"] will be automatically added. PRs will be created as drafts."
@@ -370,8 +370,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_4475a70ccf16b50e_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_195e52e9f89d052c_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_c317d5140d671810_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_35e64feb97cf7196_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -467,7 +467,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_195e52e9f89d052c_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_35e64feb97cf7196_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -533,7 +533,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_8e974123272ced9a_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_7a92a727561cb553_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -578,7 +578,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8e974123272ced9a_EOF
+          GH_AW_MCP_CONFIG_7a92a727561cb553_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -765,6 +765,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/test-coverage-improver.md
+++ b/.github/workflows/test-coverage-improver.md
@@ -47,6 +47,8 @@ tools:
   bash: ["*"]
 
 timeout-minutes: 45
+features:
+  difc-proxy: true
 strict: true
 ---
 

--- a/.github/workflows/test-improver.lock.yml
+++ b/.github/workflows/test-improver.lock.yml
@@ -22,7 +22,7 @@
 #
 # Daily analyzer that reviews test files and suggests improvements for better testify usage, increased coverage, and cleaner tests
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"726b529ee89f6c960f0e5ba788f63ece119408a85cf2a46832fd2af32fa79b28","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9ea7fef0b5dd204f69b840d74f203a8951fadf2a54bbeec987d774f504faf725","compiler_version":"v0.64.5","strict":true,"agent_id":"copilot"}
 
 name: "Test Improver"
 "on":
@@ -126,20 +126,20 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_a8d674ee1e87ab6f_EOF'
+          cat << 'GH_AW_PROMPT_113ddbf3f715bb82_EOF'
           <system>
-          GH_AW_PROMPT_a8d674ee1e87ab6f_EOF
+          GH_AW_PROMPT_113ddbf3f715bb82_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a8d674ee1e87ab6f_EOF'
+          cat << 'GH_AW_PROMPT_113ddbf3f715bb82_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_a8d674ee1e87ab6f_EOF
+          GH_AW_PROMPT_113ddbf3f715bb82_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_a8d674ee1e87ab6f_EOF'
+          cat << 'GH_AW_PROMPT_113ddbf3f715bb82_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -169,14 +169,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a8d674ee1e87ab6f_EOF
+          GH_AW_PROMPT_113ddbf3f715bb82_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a8d674ee1e87ab6f_EOF'
+          cat << 'GH_AW_PROMPT_113ddbf3f715bb82_EOF'
           </system>
-          GH_AW_PROMPT_a8d674ee1e87ab6f_EOF
-          cat << 'GH_AW_PROMPT_a8d674ee1e87ab6f_EOF'
+          GH_AW_PROMPT_113ddbf3f715bb82_EOF
+          cat << 'GH_AW_PROMPT_113ddbf3f715bb82_EOF'
           {{#runtime-import .github/workflows/test-improver.md}}
-          GH_AW_PROMPT_a8d674ee1e87ab6f_EOF
+          GH_AW_PROMPT_113ddbf3f715bb82_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -356,12 +356,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_b38abfb4b729fdb9_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_cb883709f1b20572_EOF'
           {"create_pull_request":{"draft":true,"labels":["testing","improvement","automation"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[test-improver] "},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_b38abfb4b729fdb9_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_cb883709f1b20572_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_f301728ba787e103_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_fe160aa399dddd18_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[test-improver] \". Labels [\"testing\" \"improvement\" \"automation\"] will be automatically added. PRs will be created as drafts."
@@ -369,8 +369,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_f301728ba787e103_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_0bc58d0ff539707f_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_fe160aa399dddd18_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_d2754b1099307d74_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -466,7 +466,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_0bc58d0ff539707f_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_d2754b1099307d74_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -532,7 +532,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_60423a7501e54fde_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_7182f81830cc6e91_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -577,7 +577,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_60423a7501e54fde_EOF
+          GH_AW_MCP_CONFIG_7182f81830cc6e91_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -797,6 +797,8 @@ jobs:
             /tmp/gh-aw/sandbox/agent/logs/
             /tmp/gh-aw/redacted-urls.log
             /tmp/gh-aw/mcp-logs/
+            /tmp/gh-aw/proxy-logs/
+            !/tmp/gh-aw/proxy-logs/proxy-tls/
             /tmp/gh-aw/agent-stdio.log
             /tmp/gh-aw/agent/
             /tmp/gh-aw/safeoutputs.jsonl

--- a/.github/workflows/test-improver.md
+++ b/.github/workflows/test-improver.md
@@ -51,6 +51,8 @@ tools:
     - "wc -l internal/**/*_test.go"
 
 timeout-minutes: 30
+features:
+  difc-proxy: true
 strict: true
 ---
 


### PR DESCRIPTION
## Summary

After [gh-aw PR #23471](https://github.com/github/gh-aw/pull/23471), proxy filtering is now opt-in via the `difc-proxy` feature flag. Without it, the compiler no longer injects the DIFC proxy into the gateway config, meaning guard policies (`min-integrity`, `allowed-repos`) have no effect at runtime.

## Changes

Added `features: { difc-proxy: true }` to all **28 workflows** that have `tools.github:` configured with `min-integrity` and `allowed-repos`.

Recompiled all 31 workflows with `gh aw compile` (0 errors, 1 pre-existing warning).

### Workflows NOT modified (no `tools.github:` config):
- `duplicate-code-detector.md` — uses `serena` only
- `ghcr-download-tracker.md` — uses `bash` + `cache-memory` only
- `release.md` — uses `bash` + `edit` only

## Testing

- Verified all 28 `.md` files contain `difc-proxy: true`
- All 31 workflows compile successfully
- Lock files updated with DIFC proxy injection