### PR TITLE
perf: add wazero compilation cache and wasm guard improvements

### DIFF
--- a/internal/guard/wasm.go
+++ b/internal/guard/wasm.go
@@ -31,8 +31,13 @@ type WasmGuardOptions struct {
 	// Stderr is the writer for WASM stderr output. Defaults to os.Stderr if nil.
 	Stderr io.Writer
 	// CompilationCache overrides the process-level compilation cache.
-	// If nil, the shared globalCompilationCache is used.
+	// If nil and DisableCompilationCache is false, the shared globalCompilationCache is used.
 	CompilationCache wazero.CompilationCache
+	// DisableCompilationCache, when true, prevents any compilation cache from being used
+	// even if a global or per-instance cache is available. This can be useful to avoid
+	// unbounded memory growth when many distinct WASM binaries are loaded over the
+	// lifetime of a long-lived process.
+	DisableCompilationCache bool
 }
 
 // WasmGuard implements Guard interface by executing a WASM module in-process
@@ -88,17 +93,15 @@ func NewWasmGuardFromBytes(ctx context.Context, name string, wasmBytes []byte, b
 func NewWasmGuardWithOptions(ctx context.Context, name string, wasmBytes []byte, backend BackendCaller, opts *WasmGuardOptions) (*WasmGuard, error) {
 	logWasm.Printf("Creating WASM guard from bytes: name=%s, size=%d", name, len(wasmBytes))
 
-	// Select compilation cache: use injected cache if provided, else shared global.
-	cache := globalCompilationCache
-	if opts != nil && opts.CompilationCache != nil {
-		cache = opts.CompilationCache
+	// Select compilation cache: explicit opt-out, injected cache, or shared global.
+	runtimeConfig := wazero.NewRuntimeConfigCompiler().WithCloseOnContextDone(true)
+	if opts != nil && opts.DisableCompilationCache {
+		// Caller explicitly disabled caching
+	} else if opts != nil && opts.CompilationCache != nil {
+		runtimeConfig = runtimeConfig.WithCompilationCache(opts.CompilationCache)
+	} else {
+		runtimeConfig = runtimeConfig.WithCompilationCache(globalCompilationCache)
 	}
-
-	// Create WASM runtime with explicit compiler config and context-based cancellation
-	// WithCloseOnContextDone enables request-scoped timeouts to propagate into guard execution
-	runtimeConfig := wazero.NewRuntimeConfigCompiler().
-		WithCloseOnContextDone(true).
-		WithCompilationCache(cache)
 	runtime := wazero.NewRuntimeWithConfig(ctx, runtimeConfig)
 
 	// Instantiate WASI

--- a/internal/guard/wasm_test.go
+++ b/internal/guard/wasm_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -19,7 +20,12 @@ import (
 
 func TestMain(m *testing.M) {
 	code := m.Run()
-	globalCompilationCache.Close(context.Background())
+	if err := globalCompilationCache.Close(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to close global compilation cache: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+	}
 	os.Exit(code)
 }
 
@@ -1095,22 +1101,63 @@ func TestWasmGuardCompilationCache(t *testing.T) {
 	})
 
 	t.Run("custom cache is used when provided via options", func(t *testing.T) {
-		customCache := wazero.NewCompilationCache()
-		defer customCache.Close(context.Background())
+		ctx := context.Background()
+
+		// Use a disk-backed cache in a temp dir so we can observe that it was used.
+		cacheDir := t.TempDir()
+		customCache, err := wazero.NewCompilationCacheWithDir(cacheDir)
+		require.NoError(t, err)
+		defer customCache.Close(ctx)
 
 		opts := &WasmGuardOptions{
 			CompilationCache: customCache,
 		}
 
 		// Instantiation will fail (minimal WASM), but the code path
-		// that selects the cache runs before module compilation.
-		ctx := context.Background()
-		_, _ = NewWasmGuardWithOptions(ctx, "cache-test", minimalGuardWasm, &mockBackendCaller{}, opts)
+		// that selects the cache runs before module compilation, which
+		// should populate the disk-backed cache.
+		_, err = NewWasmGuardWithOptions(ctx, "cache-test", minimalGuardWasm, &mockBackendCaller{}, opts)
+		require.Error(t, err)
+
+		entries, readErr := os.ReadDir(cacheDir)
+		require.NoError(t, readErr)
+		assert.NotEmpty(t, entries, "expected compilation artifacts in custom cache directory")
 	})
 
 	t.Run("global cache is used when options cache is nil", func(t *testing.T) {
 		ctx := context.Background()
+
+		// Swap in a disk-backed global cache pointing at a temp dir so we can
+		// observe that the global cache path is actually exercised.
+		cacheDir := t.TempDir()
+		tmpCache, err := wazero.NewCompilationCacheWithDir(cacheDir)
+		require.NoError(t, err)
+
+		origCache := globalCompilationCache
+		globalCompilationCache = tmpCache
+		defer func() {
+			globalCompilationCache = origCache
+			tmpCache.Close(ctx)
+		}()
+
 		// nil opts → global cache path
-		_, _ = NewWasmGuardWithOptions(ctx, "cache-test", minimalGuardWasm, &mockBackendCaller{}, nil)
+		_, err = NewWasmGuardWithOptions(ctx, "cache-test", minimalGuardWasm, &mockBackendCaller{}, nil)
+		require.Error(t, err)
+
+		entries, readErr := os.ReadDir(cacheDir)
+		require.NoError(t, readErr)
+		assert.NotEmpty(t, entries, "expected compilation artifacts in global cache directory")
+	})
+
+	t.Run("cache is disabled when DisableCompilationCache is true", func(t *testing.T) {
+		ctx := context.Background()
+
+		opts := &WasmGuardOptions{
+			DisableCompilationCache: true,
+		}
+
+		// Should still work (fail on minimal WASM) but without caching
+		_, err := NewWasmGuardWithOptions(ctx, "no-cache-test", minimalGuardWasm, &mockBackendCaller{}, opts)
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Problem

Go Fan report (#2829) identified several improvement opportunities in the wazero/WASM guard implementation: missing compilation cache, inconsistent `Close()` error handling, undocumented buffer retry protocol, and a redundant function export check.

## Changes

All 6 findings addressed:

### High Priority
| # | Finding | Change |
|---|---------|--------|
| 1 | No compilation cache — each `WasmGuard` re-JITs the WASM binary | Added `globalCompilationCache` (package-level, goroutine-safe) shared across all instances |
| 2 | No way to inject custom cache | Added `CompilationCache` field to `WasmGuardOptions` |

### Medium Priority
| # | Finding | Change |
|---|---------|--------|
| 3 | No `TestMain` for cache lifecycle | Added `TestMain` that closes the global cache after tests |

### Low Priority (Quick Wins)
| # | Finding | Change |
|---|---------|--------|
| 4 | `Close()` swallows module errors, only returns runtime errors | Use `errors.Join` to surface both |
| 5 | Buffer retry protocol (`-2` error code, adaptive growth) is undocumented | Added strategy comment block in `callWasmFunction` |
| 6 | `ExportedFunction("label_agent")` checked redundantly in `LabelAgent` | Removed — already verified at construction + inside `callWasmFunction` |

## Files Changed

| File | Change |
|------|--------|
| `internal/guard/wasm.go` | Cache, Close() fix, strategy comment, remove redundant check |
| `internal/guard/wasm_test.go` | TestMain + 3 cache tests |

## Testing

`make agent-finished` passes. All changes are backward-compatible — existing callers that pass `nil` opts automatically benefit from the shared cache.

Closes #2829