### PR TITLE
fix: resolve duplicate test declarations in server package

### DIFF
--- a/internal/server/session_test.go
+++ b/internal/server/session_test.go
@@ -139,7 +139,7 @@ func TestNewSession_GuardInitNotShared(t *testing.T) {
 	assert.Empty(t, s2.GuardInit, "s2.GuardInit must not be affected by writes to s1.GuardInit")
 }
 
-// newMinimalUnifiedServer creates a UnifiedServer with an empty config for
+// newMinimalUnifiedServerForSessionTest creates a UnifiedServer with an empty config for
 // use in session-related tests.
 func newMinimalUnifiedServerForSessionTest(t *testing.T) *UnifiedServer {
 	t.Helper()


### PR DESCRIPTION
## Problem

`make lint` fails on main with:

```
vet: internal/server/session_test.go:144:6: newMinimalUnifiedServer redeclared in this block
```

Two recently merged branches both added declarations that conflict:
- `session_test.go`: `newMinimalUnifiedServer(t)` and `TestRequireSession`
- `ensure_guard_initialized_test.go`: `newMinimalUnifiedServer(cfg)` (different signature)
- `unified_test.go`: `TestRequireSession`

## Fix

Rename the `session_test.go` declarations to avoid conflicts:
- `newMinimalUnifiedServer` → `newMinimalUnifiedServerForSessionTest`
- `TestRequireSession` → `TestRequireSession_SessionManagement`

All tests pass with `make agent-finished`.