### PR TITLE
Fix search_repositories query parameter URL encoding

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -324,7 +324,7 @@ func (r *restBackendCaller) CallTool(ctx context.Context, toolName string, args 
 		if pp, ok := argsMap["perPage"].(float64); ok {
 			perPage = fmt.Sprintf("%d", int(pp))
 		}
-		apiPath = fmt.Sprintf("/search/repositories?q=%s&per_page=%s", query, perPage)
+		apiPath = fmt.Sprintf("/search/repositories?q=%s&per_page=%s", url.QueryEscape(query), perPage)
 
 	case "get_collaborator_permission":
 		owner, _ := argsMap["owner"].(string)


### PR DESCRIPTION
## Problem

`TestRestBackendCaller_SearchRepositories_APIError` was failing because the `search_repositories` case in `restBackendCaller.CallTool` was not URL-encoding the query parameter before embedding it in the API path.

Queries containing spaces or special characters (e.g. `language:go stars:>1000`) produced malformed HTTP request URIs, causing the upstream server to reject them with HTTP 400 instead of the expected status code.

## Fix

Use `url.QueryEscape()` to properly encode the query value before building the API path.

## Verification

`make agent-finished` passes — all unit and integration tests green.