### PR TITLE
Update stale features.difc-proxy references in workflow prompts

### DIFF
--- a/.github/workflows/integrity-filtering-audit.md
+++ b/.github/workflows/integrity-filtering-audit.md
@@ -161,7 +161,7 @@ When classifying a **direct API bypass** warning (W-1), record:
 - The blocked domain(s) and block count
 - The workflow name and run ID
 - The likely cause: misconfigured `network.allowed` list, agent prompt not
-  restricting tool use, or the workflow missing `features.difc-proxy: true`
+  restricting tool use, or the workflow not using `tools.github` for API access
 - Recommended fix: strengthen agent system prompt to use MCP Gateway tools
   exclusively; see `shared/mcp-api-routing.md` for reusable constraint language
 
@@ -215,8 +215,9 @@ domain(s), block count, workflow name, likely cause, and recommended fix]
 ### Recommendations
 
 [Actionable suggestions based on findings. For direct API bypass (W-1) findings,
-always include: 1) which workflow to investigate, 2) whether it has
-`features.difc-proxy: true`, 3) whether the agent prompt restricts tool use to
+always include: 1) which workflow to investigate, 2) whether it uses
+`tools.github` for API access (integrity proxy is built-in since v0.67.0),
+3) whether the agent prompt restricts tool use to
 MCP Gateway tools, and 4) a pointer to `shared/mcp-api-routing.md` for reusable
 constraint language to add to the workflow prompt.]
 ```

--- a/.github/workflows/shared/mcp-api-routing.md
+++ b/.github/workflows/shared/mcp-api-routing.md
@@ -51,5 +51,5 @@ APIs directly. Do NOT attempt to contact external AI services:
 Before making any API call, verify:
 1. ✅ Am I using a GitHub MCP server tool (not `curl`, `gh`, or HTTP fetch)?
 2. ✅ Is the target repository in the workflow's `allowed-repos` list?
-3. ✅ Is `features.difc-proxy: true` enabled in this workflow's configuration?
+3. ✅ Is `tools.github` configured in this workflow (integrity proxy is built-in since v0.67.0)?
 4. ✅ Am I NOT trying to contact any external AI service API?


### PR DESCRIPTION
Addresses post-merge review feedback from #3257.

The v0.65.3→v0.67.0 upgrade removed `features.difc-proxy` from workflow frontmatter, but 3 references to it remained in workflow prompt text (agent instructions). These told the agent to check for a config key that no longer exists.

## Changes

- **`integrity-filtering-audit.md`**: Updated audit guidance (2 references) to reference `tools.github` instead of `features.difc-proxy: true`
- **`shared/mcp-api-routing.md`**: Updated checklist item to reference `tools.github` configuration (integrity proxy is built-in since v0.67.0)