### PR TITLE
fix: Docker build fails with no space left on device

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Rust build artifacts (500MB+)
+guards/github-guard/rust-guard/target/
+
+# Test directories
+test/
+.github/
+
+# Git metadata
+.git/
+
+# Build artifacts
+awmg
+mcpg
+*.test
+*.out
+coverage.*
+
+# Runtime/dev files
+.env
+.env.*
+.DS_Store
+.serena/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN go mod download
 
 # Copy source code
 COPY . .
-RUN go mod tidy
 
 # Build argument for version (defaults to "dev")
 ARG VERSION=dev


### PR DESCRIPTION
## Problem

`make test-container-proxy` fails on all 8 tests because the Docker build runs out of disk space:

```
[builder 6/7] RUN go mod tidy
-> unzip gonum.org/v1/gonum@v0.17.0: no space left on device
```

Two issues:

1. **`go mod tidy` in Dockerfile** downloads all transitive test dependencies (gonum 500MB+ via OpenTelemetry → gRPC chain), exhausting Docker's disk
2. **No `.dockerignore`** — `COPY . .` copies 521MB of Rust `target/` build artifacts into the build context

## Fix

- **Remove `go mod tidy` from Dockerfile**: `go.mod`/`go.sum` are already committed tidy, so `go mod download` + `go build` is sufficient. CI and linting already enforce tidy modules.

- **Add `.dockerignore`**: Excludes Rust `target/`, `.git/`, test directories, and build artifacts from the Docker build context.

## Verification

All 8 container proxy tests pass after the fix (7 PASS, 1 SKIP on macOS):
```
--- PASS: TestContainerProxyBuildAndStart
--- PASS: TestContainerProxyTLSCertificates
--- PASS: TestContainerProxyAuthForwarding
--- PASS: TestContainerProxyGuardAutoDetect
--- PASS: TestContainerProxyDIFCEnforcement
--- PASS: TestContainerProxyLogs
--- PASS: TestContainerProxyUntrustedTLS
--- SKIP: TestContainerProxyGhCLI (macOS CA trust)
```

`make agent-finished` also passes.