### PR TITLE
fix: use json.Marshal in WriteJSONResponse to avoid trailing newline

### DIFF
--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -12,5 +12,9 @@ import (
 func WriteJSONResponse(w http.ResponseWriter, statusCode int, body interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(body)
+	data, err := json.Marshal(body)
+	if err != nil {
+		return
+	}
+	w.Write(data)
 }


### PR DESCRIPTION
## Problem

Commit f9f875b refactored two sites in `internal/proxy/handler.go` to use `httputil.WriteJSONResponse` instead of manual `w.Write` calls. However, `WriteJSONResponse` used `json.NewEncoder(w).Encode(body)`, which [always appends a trailing newline](https://pkg.go.dev/encoding/json#Encoder.Encode). This caused 8 proxy tests to fail:

- `TestWriteEmptyResponse` (6 subtests)
- `TestHandleWithDIFC_LabelResponseError_CoarseBlocked`
- `TestHandleWithDIFC_NoFineGrainedLabels_CoarseBlocked`

All failures showed the same pattern: expected `"[]"` but got `"[]\n"`.

## Fix

Switch `WriteJSONResponse` from `json.NewEncoder(w).Encode(body)` to `json.Marshal(body)` + `w.Write(data)`, which produces clean JSON without a trailing newline. This is the standard approach for HTTP JSON responses.

## Verification

`make agent-finished` passes — all unit and integration tests green.