### PR TITLE
Fix integration tests broken by logging consolidation

### DIFF
--- a/test/integration/difc_config_test.go
+++ b/test/integration/difc_config_test.go
@@ -294,8 +294,8 @@ func TestDIFCModeFilterViaEnv(t *testing.T) {
 	err := cmd.Start()
 	require.NoError(t, err, "Failed to start gateway")
 
-	ok := waitForStderr(&stderr, "Guards enforcement", 5*time.Second)
-	require.Truef(t, ok, "timeout waiting for gateway stderr to contain %q within %s; stderr:\n%s", "Guards enforcement", 5*time.Second, stderr.String())
+	ok := waitForStderr(&stderr, "Starting MCPG", 5*time.Second)
+	require.Truef(t, ok, "timeout waiting for gateway stderr to contain %q within %s; stderr:\n%s", "Starting MCPG", 5*time.Second, stderr.String())
 
 	cmd.Process.Kill()
 	cmd.Wait()
@@ -304,8 +304,8 @@ func TestDIFCModeFilterViaEnv(t *testing.T) {
 	t.Logf("STDERR: %s", stderrStr)
 
 	// Verify gateway starts with filter mode configuration accepted
-	// Without a guard policy or WASM guard, DIFC is not auto-enabled
-	assert.Contains(t, stderrStr, "Guards enforcement disabled", "Guards should be disabled without a policy")
+	// Without a guard policy or WASM guard, DIFC is not auto-enabled — noop guard is registered
+	assert.Contains(t, stderrStr, "[DIFC] Registered guard 'noop'", "Noop guard should be registered without a policy")
 	t.Log("✓ Guards filter mode env var accepted via MCP_GATEWAY_GUARDS_MODE=filter")
 }
 
@@ -346,8 +346,8 @@ func TestDIFCModePropagateViaEnv(t *testing.T) {
 	err := cmd.Start()
 	require.NoError(t, err, "Failed to start gateway")
 
-	ok := waitForStderr(&stderr, "Guards enforcement", 5*time.Second)
-	require.Truef(t, ok, "timeout waiting for gateway stderr to contain %q within %s; stderr:\n%s", "Guards enforcement", 5*time.Second, stderr.String())
+	ok := waitForStderr(&stderr, "Starting MCPG", 5*time.Second)
+	require.Truef(t, ok, "timeout waiting for gateway stderr to contain %q within %s; stderr:\n%s", "Starting MCPG", 5*time.Second, stderr.String())
 
 	cmd.Process.Kill()
 	cmd.Wait()
@@ -356,8 +356,8 @@ func TestDIFCModePropagateViaEnv(t *testing.T) {
 	t.Logf("STDERR: %s", stderrStr)
 
 	// Verify gateway starts with propagate mode configuration accepted
-	// Without a guard policy or WASM guard, DIFC is not auto-enabled
-	assert.Contains(t, stderrStr, "Guards enforcement disabled", "Guards should be disabled without a policy")
+	// Without a guard policy or WASM guard, DIFC is not auto-enabled — noop guard is registered
+	assert.Contains(t, stderrStr, "[DIFC] Registered guard 'noop'", "Noop guard should be registered without a policy")
 	t.Log("✓ Guards propagate mode env var accepted via MCP_GATEWAY_GUARDS_MODE=propagate")
 }
 
@@ -412,8 +412,8 @@ func TestFullDIFCConfigFromJSON(t *testing.T) {
 	err := cmd.Start()
 	require.NoError(t, err, "Failed to start gateway")
 
-	ok := waitForStderr(&stderr, "Guards enforcement", 5*time.Second)
-	require.Truef(t, ok, "timeout waiting for gateway stderr to contain %q within %s; stderr:\n%s", "Guards enforcement", 5*time.Second, stderr.String())
+	ok := waitForStderr(&stderr, "Starting MCPG", 5*time.Second)
+	require.Truef(t, ok, "timeout waiting for gateway stderr to contain %q within %s; stderr:\n%s", "Starting MCPG", 5*time.Second, stderr.String())
 
 	// Try health check
 	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
@@ -435,6 +435,6 @@ func TestFullDIFCConfigFromJSON(t *testing.T) {
 	// Verify configuration was loaded — WASM guard fails to load (no file), all servers get noop
 	assert.Contains(t, stderrStr, "server1", "Should contain server1")
 	assert.Contains(t, stderrStr, "server2", "Should contain server2")
-	assert.Contains(t, stderrStr, "Guards enforcement disabled", "Guards should be disabled when all guards fall back to noop")
+	assert.Contains(t, stderrStr, "[DIFC] Registered guard 'noop'", "Noop guard should be registered when all guards fall back to noop")
 	t.Log("✓ Full guards configuration loaded successfully")
 }

--- a/test/integration/playwright_test.go
+++ b/test/integration/playwright_test.go
@@ -199,17 +199,19 @@ func TestPlaywrightMCPServer(t *testing.T) {
 
 	// Test 3: Verify tools were registered (this confirms draft-07 schemas work)
 	// The main goal is to ensure the gateway doesn't panic when loading playwright tools
-	// Looking at the server logs, we can see if tools were registered successfully
 	t.Run("ToolsRegistered", func(t *testing.T) {
-		// The fact that the server started and we reached this point means
-		// the playwright tools with draft-07 schemas were processed without panicking
-		stderrStr := stderr.String()
+		// Verify via health endpoint that the playwright server was registered
+		resp, err := http.Get(serverURL + "/health")
+		require.NoError(t, err, "Health check failed")
+		defer resp.Body.Close()
 
-		// Check that tools were registered
-		if !strings.Contains(stderrStr, "tools from playwright") &&
-			!strings.Contains(stderrStr, "Registered tool: playwright-browser_close") {
-			t.Fatal("Expected playwright tools to be registered in server logs")
-		}
+		var health map[string]interface{}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&health))
+
+		servers, ok := health["servers"].(map[string]interface{})
+		require.True(t, ok, "Health response should contain servers map")
+		_, hasPlaywright := servers["playwright"]
+		require.True(t, hasPlaywright, "Health response should contain playwright server")
 
 		t.Log("✓ Playwright tools registered successfully (draft-07 schemas handled correctly)")
 	})


### PR DESCRIPTION
## Summary

Fixes 4 integration test failures caused by the logging consolidation in commit 66398ee, which moved operational log messages from stderr to the file/debug logger.

### Root Cause

Commit `66398ee` ("Consolidate dual logging") changed:
- `log.Printf("Guards enforcement...")` → `logger.LogInfo("startup", ...)` (file-only, not stderr)
- `log.Printf("Registered tool:...")` → `logUnified.Printf(...)` (debug-only, not stderr unless `DEBUG` is set)

Integration tests run the binary and read stderr — they can't see file-only or debug-only messages.

### Changes

**`test/integration/difc_config_test.go`** (3 tests):
- `waitForStderr` now waits for `"Starting MCPG"` (still on stderr via `root.go`) instead of `"Guards enforcement"`
- Assertions changed from `"Guards enforcement disabled"` to `"[DIFC] Registered guard 'noop'"` (still on stderr via `guard_init.go`)

**`test/integration/playwright_test.go`** (1 test):
- `ToolsRegistered` subtest now verifies playwright server registration via the `/health` endpoint instead of grepping stderr for tool log messages

### Testing

`make agent-finished` passes — all unit and integration tests green.