### PR TITLE
Fix lint: update test for removed lookupEnrichmentToken

### DIFF
--- a/internal/server/collaborator_permission_test.go
+++ b/internal/server/collaborator_permission_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/github/gh-aw-mcpg/internal/envutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -287,7 +288,7 @@ func TestLookupEnrichmentToken(t *testing.T) {
 			for k, v := range tc.envVars {
 				t.Setenv(k, v)
 			}
-			result := lookupEnrichmentToken()
+			result := envutil.LookupGitHubToken()
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/internal/strutil/truncate_test.go
+++ b/internal/strutil/truncate_test.go
@@ -149,10 +149,10 @@ func TestTruncateWithSuffix(t *testing.T) {
 
 func TestTruncateRunes(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		maxRunes  int
-		expected  string
+		name     string
+		input    string
+		maxRunes int
+		expected string
 	}{
 		{
 			name:     "ASCII string within limit",


### PR DESCRIPTION
Commit `5c9c6c2` inlined `lookupEnrichmentToken()` → `envutil.LookupGitHubToken()` in `unified.go` but left the test in `collaborator_permission_test.go` referencing the deleted function, breaking `go vet`.

Updates the test to call `envutil.LookupGitHubToken()` directly.

`make agent-finished` passes.