### PR TITLE
refactor(config): extract shared validateServerAuth to deduplicate auth validation

### DIFF
--- a/internal/config/config_core.go
+++ b/internal/config/config_core.go
@@ -346,18 +346,12 @@ func LoadFromFile(path string) (*Config, error) {
 	}
 
 	// Validate auth configs (e.g. fail-fast for missing OIDC env vars).
-	// This ensures parity with the JSON stdin path which calls validateAuthConfig
+	// This ensures parity with the JSON stdin path which calls validateServerAuth
 	// via convertStdinServerConfig → validateServerConfigWithCustomSchemas.
 	for name, serverCfg := range cfg.Servers {
-		if serverCfg.Auth != nil {
-			// Auth is only supported on HTTP servers, matching validateStandardServerConfig behavior.
-			if serverCfg.Type != "http" {
-				return nil, fmt.Errorf("server '%s': auth is only supported for HTTP servers (type: \"http\")", name)
-			}
-			jsonPath := fmt.Sprintf("servers.%s", name)
-			if err := validateAuthConfig(serverCfg.Auth, name, jsonPath); err != nil {
-				return nil, err
-			}
+		jsonPath := fmt.Sprintf("servers.%s", name)
+		if err := validateServerAuth(serverCfg.Auth, serverCfg.Type, name, jsonPath); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -250,7 +250,12 @@ func validateServerAuth(auth *AuthConfig, serverType, name, jsonPath string) err
 		return nil
 	}
 	if serverType != "http" {
-		return fmt.Errorf("server '%s': auth is only supported for HTTP servers (type: \"http\")", name)
+		logValidateServerFailed(name, fmt.Sprintf("auth is set on non-HTTP server type: %s", serverType))
+		return rules.UnsupportedField(
+			"auth",
+			fmt.Sprintf("server type %q", serverType),
+			jsonPath,
+			"Remove the auth configuration or change the server type to \"http\"")
 	}
 	return validateAuthConfig(auth, name, jsonPath)
 }

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -215,9 +215,8 @@ func validateStandardServerConfig(name string, server *StdinServerConfig, jsonPa
 		}
 
 		// auth is only valid on HTTP servers
-		if server.Auth != nil {
-			logValidateServerFailed(name, "auth field is not supported for stdio servers")
-			return rules.UnsupportedField("auth", "auth is only supported for HTTP servers (type: \"http\")", jsonPath, "Remove the 'auth' field from the stdio server configuration, or change the server type to 'http'")
+		if err := validateServerAuth(server.Auth, server.Type, name, jsonPath); err != nil {
+			return err
 		}
 	}
 
@@ -232,16 +231,28 @@ func validateStandardServerConfig(name string, server *StdinServerConfig, jsonPa
 			return rules.UnsupportedField("mounts", "mounts are only supported for stdio (containerized) servers", jsonPath, "Remove the 'mounts' field from HTTP server configuration; mounts only apply to stdio servers")
 		}
 
-		// Validate auth field if present
-		if server.Auth != nil {
-			if err := validateAuthConfig(server.Auth, name, jsonPath); err != nil {
-				return err
-			}
+		// Validate auth config if present
+		if err := validateServerAuth(server.Auth, server.Type, name, jsonPath); err != nil {
+			return err
 		}
 	}
 
 	logValidateServerPassed(name)
 	return nil
+}
+
+// validateServerAuth validates the auth configuration on any server type,
+// rejecting auth on non-HTTP servers and delegating to validateAuthConfig
+// for HTTP servers. This is shared by both the TOML (LoadFromFile) and
+// JSON stdin (validateStandardServerConfig) paths.
+func validateServerAuth(auth *AuthConfig, serverType, name, jsonPath string) error {
+	if auth == nil {
+		return nil
+	}
+	if serverType != "http" {
+		return fmt.Errorf("server '%s': auth is only supported for HTTP servers (type: \"http\")", name)
+	}
+	return validateAuthConfig(auth, name, jsonPath)
 }
 
 // validateAuthConfig validates the auth configuration for an HTTP server.


### PR DESCRIPTION
Fixes #3561

## Problem

Auth validation logic was duplicated between the TOML path (`LoadFromFile` in `config_core.go`) and the JSON stdin path (`validateStandardServerConfig` in `validation.go`). Both independently checked that auth is only on HTTP servers, then called `validateAuthConfig`.

## Solution

Extracted a shared `validateServerAuth(auth, serverType, name, jsonPath)` helper that:
1. Returns nil if auth is nil (no-op)
2. Rejects auth on non-HTTP servers with a consistent error message
3. Delegates to `validateAuthConfig` for HTTP servers

Both paths now call this single helper instead of duplicating the logic.

## Changes

| File | Before | After |
|------|--------|-------|
| `config_core.go` | 8-line inline loop body | 1-line `validateServerAuth` call |
| `validation.go` (stdio) | Separate `rules.UnsupportedField` error | Shared helper |
| `validation.go` (http) | Inline `validateAuthConfig` call | Shared helper |

All existing tests pass unchanged.