### PR TITLE
refactor: deduplicate logger mutex and withLock via lockable embedding

### DIFF
--- a/internal/logger/file_logger.go
+++ b/internal/logger/file_logger.go
@@ -10,9 +10,9 @@ import (
 
 // FileLogger manages logging to a file with fallback to stdout
 type FileLogger struct {
+	lockable
 	logFile     *os.File
 	logger      *log.Logger
-	mu          sync.Mutex
 	logDir      string
 	fileName    string
 	useFallback bool
@@ -54,12 +54,6 @@ func InitFileLogger(logDir, fileName string) error {
 	logger, err := initLogger(logDir, fileName, os.O_APPEND, setupFileLogger, handleFileLoggerError)
 	initGlobalLogger(&globalLoggerMu, &globalFileLogger, logger)
 	return err
-}
-
-// withLock acquires fl.mu, executes fn, then releases fl.mu.
-// Use this in methods that return an error to avoid repeating the lock/unlock preamble.
-func (fl *FileLogger) withLock(fn func() error) error {
-	return withMutexLock(&fl.mu, fn)
 }
 
 // Close closes the log file

--- a/internal/logger/global_helpers.go
+++ b/internal/logger/global_helpers.go
@@ -16,9 +16,29 @@ package logger
 
 import "sync"
 
+// lockable provides a mutex and a withLock helper method. Embed this struct
+// in logger types that need a sync.Mutex plus a withLock convenience method
+// to eliminate the repeated per-type withLock boilerplate.
+//
+// Usage:
+//
+//	type MyLogger struct {
+//	    lockable
+//	    // other fields...
+//	}
+//
+// The embedded mu field and withLock method are promoted, so callers can write
+// myLogger.mu.Lock() and myLogger.withLock(fn) directly.
+type lockable struct {
+	mu sync.Mutex
+}
+
+// withLock acquires l.mu, executes fn, then releases l.mu.
+func (l *lockable) withLock(fn func() error) error {
+	return withMutexLock(&l.mu, fn)
+}
+
 // withMutexLock acquires mu, calls fn, and releases mu.
-// This is the single implementation of the per-type withLock pattern
-// used by FileLogger, JSONLLogger, MarkdownLogger, and ToolsLogger.
 func withMutexLock(mu *sync.Mutex, fn func() error) error {
 	mu.Lock()
 	defer mu.Unlock()
@@ -121,4 +141,23 @@ func closeGlobalLogger[T closableLogger](mu *sync.RWMutex, logger *T) error {
 		return err
 	}
 	return nil
+}
+
+// CloseAllLoggers closes all global loggers in a single call.
+// Returns the first error encountered, but attempts to close every logger.
+func CloseAllLoggers() error {
+	closers := []func() error{
+		CloseGlobalLogger,
+		CloseJSONLLogger,
+		CloseMarkdownLogger,
+		CloseToolsLogger,
+		CloseServerFileLogger,
+	}
+	var firstErr error
+	for _, fn := range closers {
+		if err := fn(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }

--- a/internal/logger/global_helpers.go
+++ b/internal/logger/global_helpers.go
@@ -27,8 +27,9 @@ import "sync"
 //	    // other fields...
 //	}
 //
-// The embedded mu field and withLock method are promoted, so callers can write
-// myLogger.mu.Lock() and myLogger.withLock(fn) directly.
+// The embedded withLock method is promoted, so code in this package can write
+// myLogger.withLock(fn) directly. The embedded mu field is also promoted, but
+// because it is unexported it is only directly accessible within the logger package.
 type lockable struct {
 	mu sync.Mutex
 }

--- a/internal/logger/jsonl_logger.go
+++ b/internal/logger/jsonl_logger.go
@@ -12,8 +12,8 @@ import (
 
 // JSONLLogger manages logging RPC messages to a JSONL file (one JSON object per line)
 type JSONLLogger struct {
+	lockable
 	logFile  *os.File
-	mu       sync.Mutex
 	logDir   string
 	fileName string
 	encoder  *json.Encoder
@@ -65,12 +65,6 @@ func InitJSONLLogger(logDir, fileName string) error {
 		initGlobalLogger(&globalJSONLMu, &globalJSONLLogger, logger)
 	}
 	return err
-}
-
-// withLock acquires jl.mu, executes fn, then releases jl.mu.
-// Use this in methods that return an error to avoid repeating the lock/unlock preamble.
-func (jl *JSONLLogger) withLock(fn func() error) error {
-	return withMutexLock(&jl.mu, fn)
 }
 
 // Close closes the JSONL log file

--- a/internal/logger/markdown_logger.go
+++ b/internal/logger/markdown_logger.go
@@ -11,8 +11,8 @@ import (
 
 // MarkdownLogger manages logging to a markdown file for GitHub workflow previews
 type MarkdownLogger struct {
+	lockable
 	logFile     *os.File
-	mu          sync.Mutex
 	logDir      string
 	fileName    string
 	useFallback bool
@@ -66,12 +66,6 @@ func (ml *MarkdownLogger) initializeFile() error {
 		ml.initialized = true
 	}
 	return nil
-}
-
-// withLock acquires ml.mu, executes fn, then releases ml.mu.
-// Use this in methods that return an error to avoid repeating the lock/unlock preamble.
-func (ml *MarkdownLogger) withLock(fn func() error) error {
-	return withMutexLock(&ml.mu, fn)
 }
 
 // Close closes the log file and writes the closing details tag

--- a/internal/logger/tools_logger.go
+++ b/internal/logger/tools_logger.go
@@ -27,10 +27,10 @@ type ToolsData struct {
 
 // ToolsLogger manages logging of MCP server tools to a JSON file
 type ToolsLogger struct {
+	lockable
 	logDir      string
 	fileName    string
 	data        *ToolsData
-	mu          sync.Mutex
 	useFallback bool
 }
 
@@ -79,12 +79,6 @@ func InitToolsLogger(logDir, fileName string) error {
 	logger, err := initLogger(logDir, fileName, os.O_TRUNC, setupToolsLogger, handleToolsLoggerError)
 	initGlobalLogger(&globalToolsMu, &globalToolsLogger, logger)
 	return err
-}
-
-// withLock acquires tl.mu, executes fn, then releases tl.mu.
-// Use this in methods that return an error to avoid repeating the lock/unlock preamble.
-func (tl *ToolsLogger) withLock(fn func() error) error {
-	return withMutexLock(&tl.mu, fn)
 }
 
 // LogTools logs the tools for a specific server


### PR DESCRIPTION
## Summary

Extracts the repeated `mu sync.Mutex` + `withLock` pattern into a shared `lockable` struct in `global_helpers.go`, then embeds it in all four logger types:

- **FileLogger** — removed standalone `withLock` method
- **JSONLLogger** — removed standalone `withLock` method  
- **MarkdownLogger** — removed standalone `withLock` method
- **ToolsLogger** — removed standalone `withLock` method

Also adds `CloseAllLoggers()` convenience function that closes every global logger in a single call.

`ServerFileLogger` is intentionally excluded — it uses `sync.RWMutex` (read-write lock) rather than `sync.Mutex`.

## Changes

| File | Change |
|------|--------|
| `global_helpers.go` | Added `lockable` struct + `CloseAllLoggers()` |
| `file_logger.go` | Embed `lockable`, remove `withLock` |
| `jsonl_logger.go` | Embed `lockable`, remove `withLock` |
| `markdown_logger.go` | Embed `lockable`, remove `withLock` |
| `tools_logger.go` | Embed `lockable`, remove `withLock` |

## Sub-issue resolution

- **#3686 / #3736** (withLock dedup): Fixed by this PR
- **#3687** (level dispatch quartet): Already addressed by existing `logFuncs` map in `global_helpers.go`
- **#3688** (CloseXxxLogger wrappers): 1-line wrappers around generic `closeGlobalLogger` — minimal dedup value
- **#3738** (write-and-sync): Different locking strategies (`Mutex` vs `RWMutex`) make dedup impractical

Fixes #3685
Fixes #3735