### PR TITLE
fix: update auth validation test assertions to match new error format

### DIFF
--- a/internal/config/config_core_test.go
+++ b/internal/config/config_core_test.go
@@ -399,7 +399,7 @@ audience = "https://example.com"
 	require.Error(t, err)
 	assert.Nil(t, cfg)
 	assert.Contains(t, err.Error(), "auth")
-	assert.Contains(t, err.Error(), "HTTP")
+	assert.Contains(t, err.Error(), "Remove the auth configuration or change the server type to \"http\"")
 }
 
 // TestLoadFromFile_NegativePayloadSizeThresholdRejected verifies that TOML configs with

--- a/internal/config/config_stdin_test.go
+++ b/internal/config/config_stdin_test.go
@@ -287,7 +287,7 @@ func TestConvertStdinServerConfig_ValidationError(t *testing.T) {
 					Type: "github-oidc",
 				},
 			},
-			errorContains: "auth is only supported for HTTP servers",
+			errorContains: "server type \"stdio\"",
 		},
 	}
 
@@ -320,7 +320,7 @@ func TestConvertStdinServerConfig_StdioWithAuth(t *testing.T) {
 	var valErr *rules.ValidationError
 	require.True(t, errors.As(err, &valErr), "expected a *rules.ValidationError, got %T: %v", err, err)
 	assert.Equal(t, "auth", valErr.Field)
-	assert.Contains(t, valErr.Message, "auth is only supported for HTTP servers")
+	assert.Contains(t, valErr.Message, "server type \"stdio\"")
 	assert.Contains(t, valErr.JSONPath, "mcpServers.my-server")
 	assert.NotEmpty(t, valErr.Suggestion)
 }

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -991,7 +991,7 @@ func TestValidateAuthConfig(t *testing.T) {
 				},
 			},
 			shouldErr: true,
-			errMsg:    "auth is only supported for HTTP servers",
+			errMsg:    "server type \"stdio\"",
 		},
 		{
 			name: "unknown auth type is rejected",


### PR DESCRIPTION
## Problem

PR #3764 refactored auth validation into a shared `validateServerAuth` helper that uses `rules.UnsupportedField` for structured errors. This changed the error message format from the old `"auth is only supported for HTTP servers"` to a structured `"server type \"stdio\""` with a suggestion.

Four tests were not updated to match the new format:

- `TestLoadFromFile_AuthOnNonHTTPServerRejected` — expected `"HTTP"`
- `TestConvertStdinServerConfig_ValidationError/stdio_with_auth_block` — expected old message
- `TestConvertStdinServerConfig_StdioWithAuth` — expected old message in `valErr.Message`
- `TestValidateAuthConfig/auth_on_stdio_server_is_rejected` — expected old message

## Fix

Updated all 4 assertions to match the actual structured error messages from `rules.UnsupportedField`.