### PR TITLE
fix: increase HTTP backend connect timeout from 5s to 30s and make configurable

### DIFF
--- a/internal/config/config_core.go
+++ b/internal/config/config_core.go
@@ -41,6 +41,7 @@ const (
 	DefaultStartupTimeout    = 30   // seconds (per spec §4.1.3)
 	DefaultToolTimeout       = 60   // seconds (per spec §4.1.3)
 	DefaultKeepaliveInterval = 1500 // seconds (25 minutes) — keeps HTTP backend sessions alive
+	DefaultConnectTimeout    = 30   // seconds — per-transport timeout for HTTP backend connect
 )
 
 // Config represents the internal gateway configuration.
@@ -150,6 +151,15 @@ func (c *Config) GetAPIKey() string {
 	return c.Gateway.APIKey
 }
 
+// HTTPConnectTimeout returns the per-transport connect timeout as a Duration.
+// Returns DefaultConnectTimeout when the field is zero or negative.
+func (s *ServerConfig) HTTPConnectTimeout() time.Duration {
+	if s == nil || s.ConnectTimeout <= 0 {
+		return time.Duration(DefaultConnectTimeout) * time.Second
+	}
+	return time.Duration(s.ConnectTimeout) * time.Second
+}
+
 // AuthConfig configures upstream authentication for HTTP MCP servers.
 type AuthConfig struct {
 	// Type is the authentication type. Currently only "github-oidc" is supported.
@@ -198,6 +208,12 @@ type ServerConfig struct {
 
 	// Guard is the name of the guard to use for this server (requires DIFC)
 	Guard string `toml:"guard" json:"guard,omitempty"`
+
+	// ConnectTimeout is the per-transport timeout (in seconds) for connecting to HTTP backends.
+	// The gateway tries multiple transports in sequence (streamable HTTP → SSE → plain JSON-RPC);
+	// each attempt uses this timeout. Increase this for backends that are slow to initialize.
+	// Only applies to HTTP server types. Default: 30 seconds.
+	ConnectTimeout int `toml:"connect_timeout" json:"connect_timeout,omitempty"`
 }
 
 // GuardConfig represents a guard configuration for DIFC enforcement.

--- a/internal/config/config_core.go
+++ b/internal/config/config_core.go
@@ -209,10 +209,11 @@ type ServerConfig struct {
 	// Guard is the name of the guard to use for this server (requires DIFC)
 	Guard string `toml:"guard" json:"guard,omitempty"`
 
-	// ConnectTimeout is the per-transport timeout (in seconds) for connecting to HTTP backends.
-	// The gateway tries multiple transports in sequence (streamable HTTP → SSE → plain JSON-RPC);
-	// each attempt uses this timeout. Increase this for backends that are slow to initialize.
-	// Only applies to HTTP server types. Default: 30 seconds.
+	// ConnectTimeout is the timeout (in seconds) used for SDK-managed HTTP transport connect attempts.
+	// The gateway tries multiple transports in sequence (streamable HTTP → SSE → plain JSON-RPC).
+	// This timeout applies to the streamable HTTP and SSE connection attempts; the plain JSON-RPC
+	// fallback uses the HTTP client's request timeout instead. Increase this for backends that are
+	// slow to initialize. Only applies to HTTP server types. Default: 30 seconds.
 	ConnectTimeout int `toml:"connect_timeout" json:"connect_timeout,omitempty"`
 }
 

--- a/internal/config/config_core_test.go
+++ b/internal/config/config_core_test.go
@@ -114,6 +114,24 @@ func TestLoadFromFile_HTTPServerValid(t *testing.T) {
 	assert.Equal(t, "http://localhost:9090/mcp", server.URL)
 }
 
+// TestLoadFromFile_HTTPServerWithConnectTimeout verifies that connect_timeout
+// is parsed from TOML and returned correctly via HTTPConnectTimeout().
+func TestLoadFromFile_HTTPServerWithConnectTimeout(t *testing.T) {
+	path := writeTempTOML(t, `
+[servers.slowservice]
+type = "http"
+url = "http://localhost:9090/mcp"
+connect_timeout = 60
+`)
+	cfg, err := LoadFromFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	server, ok := cfg.Servers["slowservice"]
+	require.True(t, ok)
+	assert.Equal(t, 60, server.ConnectTimeout)
+	assert.Equal(t, 60*time.Second, server.HTTPConnectTimeout())
+}
+
 // TestLoadFromFile_AppliesGatewayDefaults verifies that when no [gateway] section
 // is present, default values are applied for port, startup timeout, and tool timeout.
 func TestLoadFromFile_AppliesGatewayDefaults(t *testing.T) {
@@ -466,6 +484,48 @@ func TestHTTPKeepaliveInterval(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.gateway.HTTPKeepaliveInterval()
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestHTTPConnectTimeout tests all branches of the ServerConfig.HTTPConnectTimeout method.
+func TestHTTPConnectTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		server   *ServerConfig
+		expected time.Duration
+	}{
+		{
+			name:     "nil receiver returns default",
+			server:   nil,
+			expected: time.Duration(DefaultConnectTimeout) * time.Second,
+		},
+		{
+			name:     "zero value returns default",
+			server:   &ServerConfig{},
+			expected: time.Duration(DefaultConnectTimeout) * time.Second,
+		},
+		{
+			name:     "negative value returns default",
+			server:   &ServerConfig{ConnectTimeout: -5},
+			expected: time.Duration(DefaultConnectTimeout) * time.Second,
+		},
+		{
+			name:     "positive value returns correct duration",
+			server:   &ServerConfig{ConnectTimeout: 60},
+			expected: 60 * time.Second,
+		},
+		{
+			name:     "default value returns 30 seconds",
+			server:   &ServerConfig{ConnectTimeout: DefaultConnectTimeout},
+			expected: time.Duration(DefaultConnectTimeout) * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.server.HTTPConnectTimeout()
 			assert.Equal(t, tt.expected, got)
 		})
 	}

--- a/internal/config/config_stdin.go
+++ b/internal/config/config_stdin.go
@@ -155,20 +155,21 @@ func (s *StdinServerConfig) UnmarshalJSON(data []byte) error {
 
 	// Known fields in the struct
 	knownFields := map[string]bool{
-		"type":           true,
-		"container":      true,
-		"entrypoint":     true,
-		"entrypointArgs": true,
-		"args":           true,
-		"mounts":         true,
-		"env":            true,
-		"url":            true,
-		"headers":        true,
-		"tools":          true,
-		"registry":       true,
-		"guard-policies": true,
-		"guard":          true,
-		"auth":           true,
+		"type":            true,
+		"container":       true,
+		"entrypoint":      true,
+		"entrypointArgs":  true,
+		"args":            true,
+		"mounts":          true,
+		"env":             true,
+		"url":             true,
+		"headers":         true,
+		"tools":           true,
+		"registry":        true,
+		"guard-policies":  true,
+		"guard":           true,
+		"auth":            true,
+		"connect_timeout": true,
 	}
 
 	// Store additional properties (fields not in the struct)

--- a/internal/config/config_stdin.go
+++ b/internal/config/config_stdin.go
@@ -123,6 +123,10 @@ type StdinServerConfig struct {
 	// Auth configures upstream authentication for HTTP MCP servers.
 	Auth *AuthConfig `json:"auth,omitempty"`
 
+	// ConnectTimeout is the per-transport timeout (in seconds) for connecting to HTTP backends.
+	// Only applies to HTTP server types. Default: 30 seconds.
+	ConnectTimeout *int `json:"connect_timeout,omitempty"`
+
 	// AdditionalProperties stores any extra fields for custom server types
 	// This allows custom schemas to define their own fields beyond the standard ones
 	AdditionalProperties map[string]interface{} `json:"-"`
@@ -412,6 +416,9 @@ func convertStdinServerConfig(name string, server *StdinServerConfig, customSche
 			Registry:      server.Registry,
 			GuardPolicies: server.GuardPolicies,
 			Guard:         server.Guard,
+		}
+		if server.ConnectTimeout != nil {
+			serverCfg.ConnectTimeout = *server.ConnectTimeout
 		}
 		if server.Auth != nil {
 			serverCfg.Auth = &AuthConfig{

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -135,7 +135,7 @@ func GetOrLaunch(l *Launcher, serverID string) (*mcp.Connection, error) {
 			}
 
 			// Create an HTTP connection
-			conn, err := mcp.NewHTTPConnection(l.ctx, serverID, serverCfg.URL, serverCfg.Headers, oidcProvider, oidcAudience, l.config.Gateway.HTTPKeepaliveInterval())
+			conn, err := mcp.NewHTTPConnection(l.ctx, serverID, serverCfg.URL, serverCfg.Headers, oidcProvider, oidcAudience, l.config.Gateway.HTTPKeepaliveInterval(), serverCfg.HTTPConnectTimeout())
 			if err != nil {
 				log.Printf("FAILED to create HTTP connection for server %q: %v", serverID, err)
 				logger.LogErrorWithServer(serverID, "backend", "Failed to create HTTP connection: %s, error=%v", serverID, err)

--- a/internal/mcp/connection.go
+++ b/internal/mcp/connection.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -203,13 +204,21 @@ func NewHTTPConnection(ctx context.Context, serverID, url string, headers map[st
 	logger.LogInfo("backend", "Creating HTTP MCP connection with transport fallback, url=%s, connectTimeout=%v", url, connectTimeout)
 	ctx, cancel := context.WithCancel(ctx)
 
-	// Create an HTTP client with appropriate timeouts
+	// Create an HTTP client with appropriate timeouts.
+	// Keep the existing overall request timeout, but also apply connectTimeout to
+	// the underlying HTTP transport so plain JSON-RPC fallback attempts honor the
+	// configured per-attempt connection timeout instead of waiting for the full
+	// client timeout.
 	httpClient := &http.Client{
 		Timeout: 120 * time.Second, // Overall request timeout
 		Transport: &http.Transport{
-			MaxIdleConns:        10,
-			IdleConnTimeout:     90 * time.Second,
-			TLSHandshakeTimeout: 10 * time.Second,
+			DialContext: (&net.Dialer{
+				Timeout: connectTimeout,
+			}).DialContext,
+			MaxIdleConns:          10,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: connectTimeout,
 		},
 	}
 

--- a/internal/mcp/connection.go
+++ b/internal/mcp/connection.go
@@ -70,6 +70,7 @@ type Connection struct {
 	httpSessionID     string            // Session ID returned by the HTTP backend
 	httpTransportType HTTPTransportType // Type of HTTP transport in use
 	keepAliveInterval time.Duration     // Keepalive interval for SDK transports (0 = disabled)
+	connectTimeout    time.Duration     // Per-transport connect timeout for SDK transports
 	// sessionMu protects the mutable session fields: httpSessionID, session, and client.
 	// Always use getHTTPSessionID() or getSDKSession() to read these fields; the
 	// reconnect functions (reconnectPlainJSON, reconnectSDKTransport) hold the full Lock.
@@ -194,8 +195,12 @@ func NewConnection(ctx context.Context, serverID, command string, args []string,
 // Authorization header from the headers map.
 //
 // This ensures compatibility with all types of HTTP MCP servers.
-func NewHTTPConnection(ctx context.Context, serverID, url string, headers map[string]string, oidcProvider *oidc.Provider, oidcAudience string, keepAlive time.Duration) (*Connection, error) {
-	logger.LogInfo("backend", "Creating HTTP MCP connection with transport fallback, url=%s", url)
+func NewHTTPConnection(ctx context.Context, serverID, url string, headers map[string]string, oidcProvider *oidc.Provider, oidcAudience string, keepAlive time.Duration, connectTimeout time.Duration) (*Connection, error) {
+	// Apply default connect timeout when not specified
+	if connectTimeout <= 0 {
+		connectTimeout = 30 * time.Second
+	}
+	logger.LogInfo("backend", "Creating HTTP MCP connection with transport fallback, url=%s, connectTimeout=%v", url, connectTimeout)
 	ctx, cancel := context.WithCancel(ctx)
 
 	// Create an HTTP client with appropriate timeouts
@@ -232,7 +237,7 @@ func NewHTTPConnection(ctx context.Context, serverID, url string, headers map[st
 
 	// Try 1: Streamable HTTP (2025-03-26 spec)
 	logConn.Printf("Attempting streamable HTTP transport for %s", url)
-	conn, err := tryStreamableHTTPTransport(ctx, cancel, serverID, url, headers, headerClient, keepAlive)
+	conn, err := tryStreamableHTTPTransport(ctx, cancel, serverID, url, headers, headerClient, keepAlive, connectTimeout)
 	if err == nil {
 		logger.LogInfo("backend", "Successfully connected using streamable HTTP transport, url=%s", url)
 		return conn, nil
@@ -241,7 +246,7 @@ func NewHTTPConnection(ctx context.Context, serverID, url string, headers map[st
 
 	// Try 2: SSE (2024-11-05 spec)
 	logConn.Printf("Attempting SSE transport for %s", url)
-	conn, err = trySSETransport(ctx, cancel, serverID, url, headers, headerClient, keepAlive)
+	conn, err = trySSETransport(ctx, cancel, serverID, url, headers, headerClient, keepAlive, connectTimeout)
 	if err == nil {
 		logger.LogWarn("backend", "⚠️  MCP over SSE (2024-11-05 spec) is DEPRECATED for url=%s. Please migrate to streamable HTTP transport (2025-03-26 spec).", url)
 		logger.LogInfo("backend", "Configured HTTP MCP server with SSE transport: %s", url)
@@ -366,7 +371,11 @@ func (c *Connection) reconnectSDKTransport() error {
 		return fmt.Errorf("cannot reconnect: unsupported transport type %s", c.httpTransportType)
 	}
 
-	connectCtx, cancel := context.WithTimeout(c.ctx, 10*time.Second)
+	timeout := c.connectTimeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	connectCtx, cancel := context.WithTimeout(c.ctx, timeout)
 	defer cancel()
 
 	session, err := client.Connect(connectCtx, transport, nil)

--- a/internal/mcp/connection_arguments_test.go
+++ b/internal/mcp/connection_arguments_test.go
@@ -159,7 +159,7 @@ func TestCallTool_ArgumentsPassed(t *testing.T) {
 			// Create connection
 			conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 				"Authorization": "test-token",
-			}, nil, "", 0)
+			}, nil, "", 0, 0)
 			require.NoError(t, err, "Failed to create HTTP connection")
 			defer conn.Close()
 
@@ -224,7 +224,7 @@ func TestCallTool_MissingArguments(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/internal/mcp/connection_stderr_test.go
+++ b/internal/mcp/connection_stderr_test.go
@@ -37,7 +37,7 @@ func TestConnection_SendRequest(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", srv.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/internal/mcp/connection_test.go
+++ b/internal/mcp/connection_test.go
@@ -43,7 +43,7 @@ func TestHTTPRequest_SessionIDHeader(t *testing.T) {
 	// Create an HTTP connection
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-auth-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err, "Failed to create HTTP connection")
 
 	// Create a context with session ID
@@ -80,7 +80,7 @@ func TestHTTPRequest_NoSessionID(t *testing.T) {
 	// Create an HTTP connection
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-auth-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err, "Failed to create HTTP connection")
 
 	// Send a request without session ID in context
@@ -118,7 +118,7 @@ func TestHTTPRequest_ConfiguredHeaders(t *testing.T) {
 	authToken := "configured-auth-token"
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": authToken,
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err, "Failed to create HTTP connection")
 
 	// Create a context with session ID
@@ -377,7 +377,7 @@ func TestHTTPRequest_ErrorResponses(t *testing.T) {
 			// Create connection with custom headers to use plain JSON transport
 			conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 				"Authorization": "test-token",
-			}, nil, "", 0)
+			}, nil, "", 0, 0)
 			if err != nil {
 				require.True(t, tt.expectError, "Unexpected error creating connection: %v", err)
 				if tt.errorSubstring != "" {
@@ -423,7 +423,7 @@ func TestConnection_IsHTTP(t *testing.T) {
 		"X-Custom":      "custom-value",
 	}
 
-	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, headers, nil, "", 0)
+	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, headers, nil, "", 0, 0)
 	require.NoError(t, err, "Failed to create HTTP connection")
 	defer conn.Close()
 
@@ -466,7 +466,7 @@ func TestHTTPConnection_InvalidURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewHTTPConnection(context.Background(), "test-server", tt.url, tt.headers, nil, "", 0)
+			_, err := NewHTTPConnection(context.Background(), "test-server", tt.url, tt.headers, nil, "", 0, 0)
 
 			if tt.expectError {
 				require.Error(t, err, "Expected an error but got none")
@@ -523,7 +523,7 @@ func TestNewHTTPConnectionStoresKeepalive(t *testing.T) {
 	headers := map[string]string{}
 	httpClient := &http.Client{}
 
-	conn := newHTTPConnection(ctx, cancel, client, nil, url, headers, httpClient, HTTPTransportStreamable, "test-server", keepAlive)
+	conn := newHTTPConnection(ctx, cancel, client, nil, url, headers, httpClient, HTTPTransportStreamable, "test-server", keepAlive, 0)
 
 	require.NotNil(t, conn)
 	assert.Equal(t, keepAlive, conn.keepAliveInterval,
@@ -610,7 +610,7 @@ func TestNewHTTPConnection(t *testing.T) {
 	headers := map[string]string{"Authorization": "test"}
 	httpClient := &http.Client{}
 
-	conn := newHTTPConnection(ctx, cancel, client, nil, url, headers, httpClient, HTTPTransportStreamable, "test-server", 0)
+	conn := newHTTPConnection(ctx, cancel, client, nil, url, headers, httpClient, HTTPTransportStreamable, "test-server", 0, 0)
 
 	require.NotNil(t, conn, "Connection should not be nil")
 	assert.Equal(t, client, conn.client, "Client should match")

--- a/internal/mcp/http_connection_test.go
+++ b/internal/mcp/http_connection_test.go
@@ -54,7 +54,7 @@ func TestNewHTTPConnection_WithCustomHeaders(t *testing.T) {
 		"X-Custom-Header": "custom-value",
 	}
 
-	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, customHeaders, nil, "", 0)
+	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, customHeaders, nil, "", 0, 0)
 	require.NoError(err, "Failed to create HTTP connection with custom headers")
 	require.NotNil(conn, "Connection should not be nil")
 	defer conn.Close()
@@ -112,7 +112,7 @@ func TestNewHTTPConnection_WithoutHeaders_FallbackSequence(t *testing.T) {
 	defer testServer.Close()
 
 	// Create connection without custom headers - streamable transport should succeed first
-	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, nil, nil, "", 0)
+	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, nil, nil, "", 0, 0)
 	require.NoError(err, "Connection should succeed")
 	require.NotNil(conn)
 	defer conn.Close()
@@ -134,7 +134,7 @@ func TestNewHTTPConnection_AllTransportsFail(t *testing.T) {
 	defer testServer.Close()
 
 	// Try to create connection without custom headers (will try all transports)
-	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, nil, nil, "", 0)
+	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, nil, nil, "", 0, 0)
 
 	// Should fail after trying all transports
 	require.Error(err, "Should fail when all transports fail")
@@ -161,7 +161,7 @@ func TestNewHTTPConnection_ContextCancellation(t *testing.T) {
 	cancel()
 
 	// Try to create connection with cancelled context
-	conn, err := NewHTTPConnection(ctx, "test-server", testServer.URL, map[string]string{"Auth": "token"}, nil, "", 0)
+	conn, err := NewHTTPConnection(ctx, "test-server", testServer.URL, map[string]string{"Auth": "token"}, nil, "", 0, 0)
 
 	// Should fail due to context cancellation
 	require.Error(err, "Should fail with cancelled context")
@@ -198,7 +198,7 @@ func TestNewHTTPConnection_InvalidURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			conn, err := NewHTTPConnection(context.Background(), "test-server", tt.url, tt.headers, nil, "", 0)
+			conn, err := NewHTTPConnection(context.Background(), "test-server", tt.url, tt.headers, nil, "", 0, 0)
 
 			if tt.expectError {
 				assert.Error(t, err, "Expected error for invalid URL")
@@ -273,7 +273,7 @@ func TestTryPlainJSONTransport_InitializeFailure(t *testing.T) {
 			// Try to create connection
 			conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 				"Authorization": "test-token",
-			}, nil, "", 0)
+			}, nil, "", 0, 0)
 
 			// Should fail with appropriate error
 			require.Error(t, err, "Should fail on initialization error")
@@ -306,7 +306,7 @@ data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","serverIn
 	// Create connection
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 
 	require.NoError(err, "Should successfully parse SSE-formatted initialize response")
 	require.NotNil(conn)
@@ -347,7 +347,7 @@ func TestHTTPConnection_NoSessionIDInResponse(t *testing.T) {
 	// Create connection
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 
 	require.NoError(err, "Should succeed even without session ID from server")
 	require.NotNil(conn)
@@ -393,7 +393,7 @@ func TestNewHTTPConnection_HeadersPropagation(t *testing.T) {
 		"X-Custom-2":    "value2",
 	}
 
-	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, customHeaders, nil, "", 0)
+	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, customHeaders, nil, "", 0, 0)
 	require.NoError(err)
 	require.NotNil(conn)
 	defer conn.Close()
@@ -440,7 +440,7 @@ func TestNewHTTPConnection_EmptyHeaders(t *testing.T) {
 	defer testServer.Close()
 
 	// Create connection with empty headers - should try SDK transports first
-	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{}, nil, "", 0)
+	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{}, nil, "", 0, 0)
 	require.NoError(err, "Should succeed with empty headers")
 	require.NotNil(conn)
 	defer conn.Close()
@@ -473,7 +473,7 @@ func TestNewHTTPConnection_NilHeaders(t *testing.T) {
 	defer testServer.Close()
 
 	// Create connection with nil headers (should try SDK transports first)
-	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, nil, nil, "", 0)
+	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, nil, nil, "", 0, 0)
 	require.NoError(err, "Should succeed with nil headers")
 	require.NotNil(conn)
 	defer conn.Close()
@@ -509,7 +509,7 @@ func TestNewHTTPConnection_HTTPClientTimeout(t *testing.T) {
 	// Create connection
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 
 	// Should succeed (delay is within timeout)
 	require.NoError(err, "Should succeed within timeout")
@@ -530,7 +530,7 @@ func TestNewHTTPConnection_ConnectionRefused(t *testing.T) {
 	// Try to create connection
 	conn, err := NewHTTPConnection(context.Background(), "test-server", unreachableURL, map[string]string{
 		"Authorization": "test",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 
 	// Should fail with connection error
 	require.Error(err, "Should fail with connection refused")
@@ -563,7 +563,7 @@ func TestNewHTTPConnection_GettersAfterCreation(t *testing.T) {
 		"X-Custom":      "custom-value",
 	}
 
-	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, customHeaders, nil, "", 0)
+	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, customHeaders, nil, "", 0, 0)
 	require.NoError(err)
 	require.NotNil(conn)
 	defer conn.Close()

--- a/internal/mcp/http_error_propagation_test.go
+++ b/internal/mcp/http_error_propagation_test.go
@@ -119,7 +119,7 @@ func TestHTTPErrorPropagation_Non200Status(t *testing.T) {
 			// Create connection with custom headers to use plain JSON transport
 			conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 				"Authorization": "test-token",
-			}, nil, "", 0)
+			}, nil, "", 0, 0)
 			require.NoError(t, err, "Failed to create connection")
 			defer conn.Close()
 
@@ -192,7 +192,7 @@ func TestHTTPErrorPropagation_JSONRPCError(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err, "Failed to create connection")
 	defer conn.Close()
 
@@ -275,7 +275,7 @@ func TestHTTPErrorPropagation_MixedContent(t *testing.T) {
 
 			conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 				"Authorization": "test-token",
-			}, nil, "", 0)
+			}, nil, "", 0, 0)
 			require.NoError(t, err, "Failed to create connection")
 			defer conn.Close()
 
@@ -344,7 +344,7 @@ func TestHTTPErrorPropagation_PreservesDetails(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err, "Failed to create connection")
 	defer conn.Close()
 

--- a/internal/mcp/http_transport.go
+++ b/internal/mcp/http_transport.go
@@ -190,13 +190,13 @@ func newMCPClient(log *logger.Logger, keepAlive time.Duration) *sdk.Client {
 // newHTTPConnection creates a new HTTP Connection struct with common fields.
 // keepAlive is passed through to store on the connection so that reconnectSDKTransport
 // can re-create the SDK client with the same keepalive setting.
-func newHTTPConnection(ctx context.Context, cancel context.CancelFunc, client *sdk.Client, session *sdk.ClientSession, url string, headers map[string]string, httpClient *http.Client, transportType HTTPTransportType, serverID string, keepAlive time.Duration) *Connection {
+func newHTTPConnection(ctx context.Context, cancel context.CancelFunc, client *sdk.Client, session *sdk.ClientSession, url string, headers map[string]string, httpClient *http.Client, transportType HTTPTransportType, serverID string, keepAlive time.Duration, connectTimeout time.Duration) *Connection {
 	// Extract session ID from SDK session if available
 	var sessionID string
 	if session != nil {
 		sessionID = session.ID()
 	}
-	logHTTP.Printf("Creating HTTP connection: serverID=%s, url=%s, transport=%s, headers=%d, keepAlive=%v", serverID, url, transportType, len(headers), keepAlive)
+	logHTTP.Printf("Creating HTTP connection: serverID=%s, url=%s, transport=%s, headers=%d, keepAlive=%v, connectTimeout=%v", serverID, url, transportType, len(headers), keepAlive, connectTimeout)
 	return &Connection{
 		client:            client,
 		session:           session,
@@ -210,6 +210,7 @@ func newHTTPConnection(ctx context.Context, cancel context.CancelFunc, client *s
 		httpTransportType: transportType,
 		httpSessionID:     sessionID,
 		keepAliveInterval: keepAlive,
+		connectTimeout:    connectTimeout,
 	}
 }
 
@@ -404,6 +405,7 @@ func trySDKTransport(
 	transportName string,
 	createTransport transportConnector,
 	keepAlive time.Duration,
+	connectTimeout time.Duration,
 ) (*Connection, error) {
 	// Create MCP client with logger and optional keepalive.
 	// When keepAlive > 0, periodic pings prevent session expiry on backends
@@ -413,9 +415,8 @@ func trySDKTransport(
 	// Create transport using the provided connector
 	transport := createTransport(url, httpClient)
 
-	// Try to connect with a timeout - this will fail if the server doesn't support this transport
-	// Use a short timeout to fail fast and try other transports
-	connectCtx, connectCancel := context.WithTimeout(ctx, 5*time.Second)
+	// Try to connect with the configured timeout
+	connectCtx, connectCancel := context.WithTimeout(ctx, connectTimeout)
 	defer connectCancel()
 
 	session, err := client.Connect(connectCtx, transport, nil)
@@ -423,7 +424,7 @@ func trySDKTransport(
 		return nil, fmt.Errorf("%s transport connect failed: %w", transportName, err)
 	}
 
-	conn := newHTTPConnection(ctx, cancel, client, session, url, headers, httpClient, transportType, serverID, keepAlive)
+	conn := newHTTPConnection(ctx, cancel, client, session, url, headers, httpClient, transportType, serverID, keepAlive, connectTimeout)
 
 	logger.LogInfo("backend", "%s transport connected successfully", transportName)
 	logConn.Printf("Connected with %s transport", transportName)
@@ -431,7 +432,7 @@ func trySDKTransport(
 }
 
 // tryStreamableHTTPTransport attempts to connect using the streamable HTTP transport (2025-03-26 spec)
-func tryStreamableHTTPTransport(ctx context.Context, cancel context.CancelFunc, serverID, url string, headers map[string]string, httpClient *http.Client, keepAlive time.Duration) (*Connection, error) {
+func tryStreamableHTTPTransport(ctx context.Context, cancel context.CancelFunc, serverID, url string, headers map[string]string, httpClient *http.Client, keepAlive time.Duration, connectTimeout time.Duration) (*Connection, error) {
 	return trySDKTransport(
 		ctx, cancel, serverID, url, headers, httpClient,
 		HTTPTransportStreamable,
@@ -444,11 +445,12 @@ func tryStreamableHTTPTransport(ctx context.Context, cancel context.CancelFunc, 
 			}
 		},
 		keepAlive,
+		connectTimeout,
 	)
 }
 
 // trySSETransport attempts to connect using the SSE transport (2024-11-05 spec)
-func trySSETransport(ctx context.Context, cancel context.CancelFunc, serverID, url string, headers map[string]string, httpClient *http.Client, keepAlive time.Duration) (*Connection, error) {
+func trySSETransport(ctx context.Context, cancel context.CancelFunc, serverID, url string, headers map[string]string, httpClient *http.Client, keepAlive time.Duration, connectTimeout time.Duration) (*Connection, error) {
 	return trySDKTransport(
 		ctx, cancel, serverID, url, headers, httpClient,
 		HTTPTransportSSE,
@@ -460,6 +462,7 @@ func trySSETransport(ctx context.Context, cancel context.CancelFunc, serverID, u
 			}
 		},
 		keepAlive,
+		connectTimeout,
 	)
 }
 

--- a/internal/mcp/http_transport_test.go
+++ b/internal/mcp/http_transport_test.go
@@ -687,7 +687,7 @@ func TestSendHTTPRequest_EnsuresToolCallArguments(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	defer conn.Close()
@@ -739,7 +739,7 @@ func TestSendHTTPRequest_SessionIDFromContext(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	defer conn.Close()
@@ -844,7 +844,7 @@ func TestSendHTTPRequest_NonToolsCallMethodDoesNotAddArguments(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	defer conn.Close()
@@ -968,7 +968,7 @@ func TestSendHTTPRequest_ReconnectsOnSessionNotFound(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	defer conn.Close()
@@ -1029,7 +1029,7 @@ func TestSendHTTPRequest_ReconnectFailure(t *testing.T) {
 
 	conn, err := NewHTTPConnection(context.Background(), "test-server", testServer.URL, map[string]string{
 		"Authorization": "test-token",
-	}, nil, "", 0)
+	}, nil, "", 0, 0)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	defer conn.Close()

--- a/internal/server/tool_registry.go
+++ b/internal/server/tool_registry.go
@@ -87,12 +87,18 @@ func (us *UnifiedServer) registerAllTools() error {
 func (us *UnifiedServer) registerAllToolsSequential(serverIDs []string) error {
 	logUnified.Printf("Registering tools sequentially from %d backends", len(serverIDs))
 
+	var failedServers []string
 	for _, serverID := range serverIDs {
 		logUnified.Printf("Registering tools from backend: %s", serverID)
 		if err := us.registerToolsFromBackend(serverID); err != nil {
-			logger.LogWarn("backend", "Failed to register tools from %s: %v", serverID, err)
-			// Continue with other backends
+			logger.LogError("backend", "Failed to register tools from %s: %v", serverID, err)
+			failedServers = append(failedServers, serverID)
 		}
+	}
+
+	if len(failedServers) > 0 {
+		logger.LogError("backend", "Tool registration incomplete: %d of %d backends failed: %v — agents will not see tools from these servers",
+			len(failedServers), len(serverIDs), failedServers)
 	}
 
 	logUnified.Printf("Tool registration complete: total tools=%d", len(us.tools))
@@ -131,15 +137,22 @@ func (us *UnifiedServer) registerAllToolsParallel(serverIDs []string) error {
 	// Collect and log results
 	successCount := 0
 	failureCount := 0
+	var failedServers []string
 	for result := range results {
 		if result.err != nil {
-			logger.LogWarnWithServer(result.serverID, "backend", "Failed to register tools from %s (took %v): %v", result.serverID, result.duration, result.err)
+			logger.LogErrorWithServer(result.serverID, "backend", "Failed to register tools from %s (took %v): %v", result.serverID, result.duration, result.err)
 			failureCount++
+			failedServers = append(failedServers, result.serverID)
 		} else {
 			logUnified.Printf("Successfully registered tools from %s (took %v)", result.serverID, result.duration)
 			logger.LogInfoWithServer(result.serverID, "backend", "Successfully registered tools from %s (took %v)", result.serverID, result.duration)
 			successCount++
 		}
+	}
+
+	if failureCount > 0 {
+		logger.LogError("backend", "Tool registration incomplete: %d of %d backends failed: %v — agents will not see tools from these servers",
+			failureCount, len(serverIDs), failedServers)
 	}
 
 	logger.LogInfo("backend", "Tool registration complete: %d succeeded, %d failed, total tools=%d", successCount, failureCount, len(us.tools))

--- a/test/integration/http_error_test.go
+++ b/test/integration/http_error_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
-	"time"
 
 	"github.com/github/gh-aw-mcpg/internal/config"
 	"github.com/github/gh-aw-mcpg/internal/launcher"
@@ -35,7 +35,7 @@ func TestHTTPError_ServerError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0, 0)
 	if err == nil {
 		conn.Close()
 		t.Fatal("Expected connection to fail due to 500 error, but it succeeded")
@@ -66,7 +66,7 @@ func TestHTTPError_ClientError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0, 0)
 	if err == nil {
 		conn.Close()
 		t.Fatal("Expected connection to fail due to 401 error, but it succeeded")
@@ -108,7 +108,7 @@ func TestHTTPError_ConnectionTimeout(t *testing.T) {
 	defer cancel()
 
 	startTime := time.Now()
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0, 0)
 	elapsed := time.Since(startTime)
 
 	if err == nil {
@@ -143,7 +143,7 @@ func TestHTTPError_ConnectionRefused(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", "http://"+addr, nil, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", "http://"+addr, nil, nil, "", 0, 0)
 	if err == nil {
 		conn.Close()
 		t.Fatal("Expected connection to fail due to connection refused, but it succeeded")
@@ -178,7 +178,7 @@ func TestHTTPError_DroppedConnection(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0, 0)
 	if err == nil {
 		conn.Close()
 		t.Fatal("Expected connection to fail due to dropped connection, but it succeeded")
@@ -210,7 +210,7 @@ func TestHTTPError_FirewallBlocking(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0, 0)
 	if err == nil {
 		conn.Close()
 		t.Fatal("Expected connection to fail due to firewall blocking, but it succeeded")
@@ -265,10 +265,11 @@ func TestHTTPError_IntermittentFailure(t *testing.T) {
 	defer mockServer.Close()
 
 	// First connection attempt should fail (all transports fail)
+	// Use short connect timeout so transport fallback happens quickly
 	ctx1, cancel1 := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel1()
 
-	conn1, err1 := mcp.NewHTTPConnection(ctx1, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn1, err1 := mcp.NewHTTPConnection(ctx1, "test-server", mockServer.URL, nil, nil, "", 0, 2*time.Second)
 	if err1 == nil {
 		conn1.Close()
 		t.Fatal("Expected first connection to fail, but it succeeded")
@@ -279,7 +280,7 @@ func TestHTTPError_IntermittentFailure(t *testing.T) {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel2()
 
-	conn2, err2 := mcp.NewHTTPConnection(ctx2, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn2, err2 := mcp.NewHTTPConnection(ctx2, "test-server", mockServer.URL, nil, nil, "", 0, 2*time.Second)
 	if err2 != nil {
 		t.Fatalf("Expected second connection to succeed, but it failed: %v (after %d requests total)", err2, requestCount)
 	}
@@ -370,7 +371,7 @@ func TestHTTPError_RequestFailure(t *testing.T) {
 
 	// Connect successfully
 	ctx := context.Background()
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, map[string]string{"X-Test": "test"}, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, map[string]string{"X-Test": "test"}, nil, "", 0, 0)
 	require.NoError(t, err, "Connection failed")
 	defer conn.Close()
 
@@ -410,7 +411,7 @@ func TestHTTPError_MalformedResponse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0, 0)
 	if err == nil {
 		conn.Close()
 		t.Fatal("Expected connection to fail due to malformed response, but it succeeded")
@@ -453,7 +454,7 @@ func TestHTTPError_NetworkPartition(t *testing.T) {
 	defer cancel()
 
 	startTime := time.Now()
-	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0)
+	conn, err := mcp.NewHTTPConnection(ctx, "test-server", mockServer.URL, nil, nil, "", 0, 0)
 	elapsed := time.Since(startTime)
 
 	if err == nil {


### PR DESCRIPTION
## Problem

When an HTTP MCP backend is slow to initialize (e.g. cold-starting LiteLLM proxy taking 21s), the gateway's hardcoded **5-second per-transport connect timeout** causes all three SDK transport attempts to fail. The tool registration silently drops the backend's tools and the agent starts without them.

From the issue logs:
```
[2026-04-13T16:37:36Z] [DEBUG] GetOrLaunch called for server: opslevel
[2026-04-13T16:37:57Z] [INFO]  Successfully registered tools from opslevel (took 21.213743169s)
```

The 21s is consumed by the transport fallback chain: streamable HTTP (5s timeout) → SSE (5s timeout) → plain JSON (~11s). If the backend only supports streamable HTTP, all three transports fail and tools are silently dropped.

## Fix

### 1. Configurable per-transport connect timeout (default 30s → was 5s)

New `connect_timeout` field on server config:

**TOML:**
```toml
[servers.opslevel]
type = "http"
url = "http://opslevel-proxy:8080/mcp"
connect_timeout = 60  # seconds per transport attempt
```

**JSON stdin:**
```json
{
  "mcpServers": {
    "opslevel": {
      "type": "http",
      "url": "http://opslevel-proxy:8080/mcp",
      "connect_timeout": 60
    }
  }
}
```

### 2. Better error visibility

- Failed backend tool registration promoted from **WARN → ERROR**
- Summary error log lists which backends failed and impact on agents:
  `Tool registration incomplete: 1 of 3 backends failed: [opslevel] — agents will not see tools from these servers`

### 3. Reconnect uses stored timeout

The connect timeout is stored on the Connection struct so `reconnectSDKTransport` reuses the same value instead of a hardcoded 10s.

## Changes

| File | Change |
|------|--------|
| `config_core.go` | Add `ConnectTimeout` field, `HTTPConnectTimeout()` helper, `DefaultConnectTimeout` constant |
| `config_stdin.go` | Add `ConnectTimeout` to `StdinServerConfig`, map it during conversion |
| `connection.go` | Add `connectTimeout` to `Connection`, apply default of 30s when ≤ 0 |
| `http_transport.go` | Pass configurable timeout through `trySDKTransport` and `newHTTPConnection` |
| `launcher.go` | Pass `serverCfg.HTTPConnectTimeout()` to `NewHTTPConnection` |
| `tool_registry.go` | Promote failed backends to ERROR, add summary log |
| Tests | Updated all `NewHTTPConnection` call sites with new parameter |

Fixes #3718