### PR TITLE
fix: add github/gh-aw to log analyzer allowed-repos

### DIFF
--- a/.github/workflows/mcp-gateway-log-analyzer.lock.yml
+++ b/.github/workflows/mcp-gateway-log-analyzer.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1633b152ae856f1ab5fc9ef7e6928dcfac634a79178ed1adaf0a6a4ff9dddad8","compiler_version":"v0.68.2","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6451028c203b3d62d93edd3d316be813c353ff3a9a569600c37aafdf3a0c1e80","compiler_version":"v0.68.2","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_MCP_MULTIREPO_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"19c436149e80e5be4f0adbd9cdeb391acea5fa91","version":"v0.68.2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0","digest":"sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28","pinned_image":"ghcr.io/github/github-mcp-server:v0.32.0@sha256:2763823c63bcca718ce53850a1d7fcf2f501ec84028394f1b63ce7e9f4f9be28"},{"image":"node:lts-alpine","digest":"sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b","pinned_image":"node:lts-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -165,14 +165,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_aa40090b2420fb64_EOF'
+          cat << 'GH_AW_PROMPT_4f8ab27711fd0f4f_EOF'
           <system>
-          GH_AW_PROMPT_aa40090b2420fb64_EOF
+          GH_AW_PROMPT_4f8ab27711fd0f4f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_aa40090b2420fb64_EOF'
+          cat << 'GH_AW_PROMPT_4f8ab27711fd0f4f_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -204,12 +204,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_aa40090b2420fb64_EOF
+          GH_AW_PROMPT_4f8ab27711fd0f4f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_aa40090b2420fb64_EOF'
+          cat << 'GH_AW_PROMPT_4f8ab27711fd0f4f_EOF'
           </system>
           {{#runtime-import .github/workflows/mcp-gateway-log-analyzer.md}}
-          GH_AW_PROMPT_aa40090b2420fb64_EOF
+          GH_AW_PROMPT_4f8ab27711fd0f4f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -377,9 +377,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c281c14bfbe2c5d0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3078f09a118eb2e7_EOF'
           {"create_issue":{"assignees":["lpcox"],"labels":["bug","mcp-gateway","automation"],"max":1,"title_prefix":"[mcp-gateway-logs] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c281c14bfbe2c5d0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3078f09a118eb2e7_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -572,7 +572,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_01fc08d2e1b9a483_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_f59ae26ea0815a67_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -588,9 +588,10 @@ jobs:
                   "allow-only": {
                     "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
                     "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
-                    "min-integrity": "unapproved",
+                    "min-integrity": "none",
                     "repos": [
-                      "github/gh-aw-mcpg"
+                      "github/gh-aw-mcpg",
+                      "github/gh-aw"
                     ],
                     "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
@@ -605,7 +606,8 @@ jobs:
                 "guard-policies": {
                   "write-sink": {
                     "accept": [
-                      "private:github/gh-aw-mcpg"
+                      "private:github/gh-aw-mcpg",
+                      "private:github/gh-aw"
                     ]
                   }
                 }
@@ -618,7 +620,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_01fc08d2e1b9a483_EOF
+          GH_AW_MCP_CONFIG_f59ae26ea0815a67_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/mcp-gateway-log-analyzer.md
+++ b/.github/workflows/mcp-gateway-log-analyzer.md
@@ -32,8 +32,8 @@ safe-outputs:
 tools:
   github:
     toolsets: [default, actions]
-    allowed-repos: ["github/gh-aw-mcpg"]
-    min-integrity: unapproved
+    allowed-repos: ["github/gh-aw-mcpg", "github/gh-aw"]
+    min-integrity: none
     github-token: ${{ secrets.GH_AW_MCP_MULTIREPO_TOKEN }}
   bash: ["*"]
 


### PR DESCRIPTION
## Problem

The MCP Gateway Log Analyzer workflow failed ([#3836](https://github.com/github/gh-aw-mcpg/issues/3836)) because the agent couldn't access `github/gh-aw` resources due to two configuration issues:

1. **`allowed-repos` missing `gh-aw`** — The workflow's purpose is to analyze logs from `github/gh-aw` workflow runs, but only `github/gh-aw-mcpg` was in the allowed-repos list
2. **`min-integrity: unapproved` too restrictive** — Resources in `gh-aw` have lower integrity levels, causing the guard to filter all MCP tool calls targeting that repo

The agent reported:
> All GitHub MCP tool calls targeting github/gh-aw are filtered by integrity policy: "Resource has lower integrity than agent requires."

## Fix

- Add `github/gh-aw` to `allowed-repos` so the agent can access the target repo
- Lower `min-integrity` to `none` — appropriate since the workflow is read-only log analysis (no code modifications)
- Recompile lock file

## Verification

- `gh aw compile mcp-gateway-log-analyzer` succeeds
- `make agent-finished` passes all checks

Closes #3836