### PR TITLE
Fix gofmt alignment in jwt_expiry_test.go

### DIFF
--- a/internal/oidc/jwt_expiry_test.go
+++ b/internal/oidc/jwt_expiry_test.go
@@ -122,9 +122,9 @@ func TestExtractJWTExpiry_MissingExpClaim(t *testing.T) {
 // other than 3 (separated by ".") are rejected with a descriptive error.
 func TestExtractJWTExpiry_WrongPartCount(t *testing.T) {
 	tests := []struct {
-		name        string
-		token       string
-		wantParts   int
+		name      string
+		token     string
+		wantParts int
 	}{
 		{"one part", "headeronly", 1},
 		{"two parts", "header.payload", 2},


### PR DESCRIPTION
## Summary

Fix struct field alignment in `TestExtractJWTExpiry_WrongPartCount` test table to satisfy `gofmt`.

`make agent-finished` formats code with `gofmt` and this file had misaligned struct tags that were caught during the format step.

## Changes

- `internal/oidc/jwt_expiry_test.go`: Corrected struct field alignment (whitespace-only change)