### PR TITLE
Fix TestFullDIFCConfigFromJSON timeout waiting for backend connections

### DIFF
--- a/test/integration/difc_config_test.go
+++ b/test/integration/difc_config_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -412,19 +411,15 @@ func TestFullDIFCConfigFromJSON(t *testing.T) {
 	err := cmd.Start()
 	require.NoError(t, err, "Failed to start gateway")
 
-	ok := waitForStderr(&stderr, "Starting MCPG", 5*time.Second)
-	require.Truef(t, ok, "timeout waiting for gateway stderr to contain %q within %s; stderr:\n%s", "Starting MCPG", 5*time.Second, stderr.String())
+	// Wait for guard registration (appears before the blocking registerAllTools
+	// backend connections that may take 30+ seconds for Docker containers).
+	// "Starting MCPG" only prints after NewUnified returns, which blocks on
+	// backend connections — too slow for this test's DIFC-config-only assertions.
+	ok := waitForStderr(&stderr, "[DIFC] Registered guard", 5*time.Second)
+	require.Truef(t, ok, "timeout waiting for DIFC guard registration within %s; stderr:\n%s", 5*time.Second, stderr.String())
 
-	// Try health check
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
-	if err == nil {
-		defer resp.Body.Close()
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-		var health map[string]interface{}
-		json.NewDecoder(resp.Body).Decode(&health)
-		t.Logf("Health response: %+v", health)
-	}
+	// Brief pause to let remaining sequential guard registrations flush to stderr
+	time.Sleep(300 * time.Millisecond)
 
 	cmd.Process.Kill()
 	cmd.Wait()


### PR DESCRIPTION
## Problem

`TestFullDIFCConfigFromJSON` fails with a 5s timeout waiting for `"Starting MCPG"` in stderr:

```
Error: Should be true
Messages: timeout waiting for gateway stderr to contain "Starting MCPG" within 5s
```

## Root Cause

`"Starting MCPG in ROUTED/UNIFIED mode"` only prints **after** `NewUnified()` returns. `NewUnified()` blocks on `registerAllTools()` which tries to connect to all backends — including a Docker container (`test/server1:latest`) with a **30s launch timeout**. The test's 5s deadline expires while waiting for Docker to fail.

## Fix

The test's assertions only verify DIFC guard registration output, which appears **before** the blocking backend connections. Changed the wait string from `"Starting MCPG"` to `"[DIFC] Registered guard"`, added a 300ms flush delay, and removed the health check (which requires full startup).

## Changes

| File | Change |
|------|--------|
| `test/integration/difc_config_test.go` | Wait for guard registration instead of full startup; remove health check and unused `encoding/json` import |

`make agent-finished` ✓