### PR TITLE
Make /etc/hosts write non-fatal for non-root container execution

### DIFF
--- a/run_containerized.sh
+++ b/run_containerized.sh
@@ -285,9 +285,11 @@ configure_host_dns() {
     # Add host.docker.internal mapping to /etc/hosts
     # Check if the entry already exists to avoid duplicates
     if ! grep -q "host.docker.internal" /etc/hosts 2>/dev/null; then
-        log_info "Adding host.docker.internal mapping to /etc/hosts"
-        echo "$HOST_IP   host.docker.internal" >> /etc/hosts
-        log_info "DNS mapping configured: $HOST_IP -> host.docker.internal"
+        if echo "$HOST_IP   host.docker.internal" >> /etc/hosts 2>/dev/null; then
+            log_info "DNS mapping configured: $HOST_IP -> host.docker.internal"
+        else
+            log_warn "Cannot write to /etc/hosts (running as non-root?); host.docker.internal mapping skipped"
+        fi
     else
         log_info "host.docker.internal already exists in /etc/hosts"
     fi

--- a/run_containerized.sh
+++ b/run_containerized.sh
@@ -285,7 +285,7 @@ configure_host_dns() {
     # Add host.docker.internal mapping to /etc/hosts
     # Check if the entry already exists to avoid duplicates
     if ! grep -q "host.docker.internal" /etc/hosts 2>/dev/null; then
-        if echo "$HOST_IP   host.docker.internal" >> /etc/hosts 2>/dev/null; then
+        if { echo "$HOST_IP   host.docker.internal" >> /etc/hosts; } 2>/dev/null; then
             log_info "DNS mapping configured: $HOST_IP -> host.docker.internal"
         else
             log_warn "Cannot write to /etc/hosts (running as non-root?); host.docker.internal mapping skipped"


### PR DESCRIPTION
## Context

Companion to [gh-aw#26658](https://github.com/github/gh-aw/pull/26658), which adds `--user $(id -u):$(id -g)` to the MCP gateway Docker run command so log files written via `/tmp` bind mounts are readable by downstream redaction and upload steps.

## Problem

`run_containerized.sh` runs with `set -e` and unconditionally writes to `/etc/hosts` (line 289):

```bash
echo "$HOST_IP   host.docker.internal" >> /etc/hosts
```

When the container runs as a non-root user, this write fails with EACCES, aborting the entire gateway startup.

## Fix

Wrap the `/etc/hosts` write in an if-else so failure produces a warning instead of aborting. With `--network host` (which the gateway always uses), the `host.docker.internal` mapping is unnecessary since `localhost` works directly.

## Changes

| File | Change |
|------|--------|
| `run_containerized.sh` | Make `/etc/hosts` write non-fatal; log warning on failure |

`make agent-finished` ✓