### PR TITLE
fix: register flag completion functions for config, log-dir, payload-dir, env

### DIFF
--- a/internal/cmd/flags.go
+++ b/internal/cmd/flags.go
@@ -57,11 +57,19 @@ func registerAllFlags(cmd *cobra.Command) {
 
 // registerFlagCompletions registers custom completion functions for flags
 func registerFlagCompletions(cmd *cobra.Command) {
-	// File and directory completions using idiomatic cobra helpers
-	cmd.MarkFlagFilename("config", "toml")
-	cmd.MarkFlagDirname("log-dir")
-	cmd.MarkFlagDirname("payload-dir")
-	cmd.MarkFlagFilename("env", "env")
+	// File and directory completions
+	cmd.RegisterFlagCompletionFunc("config", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"toml"}, cobra.ShellCompDirectiveFilterFileExt
+	})
+	cmd.RegisterFlagCompletionFunc("log-dir", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	})
+	cmd.RegisterFlagCompletionFunc("payload-dir", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveFilterDirs
+	})
+	cmd.RegisterFlagCompletionFunc("env", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"env"}, cobra.ShellCompDirectiveFilterFileExt
+	})
 
 	// Enum completions for DIFC flags
 	cmd.RegisterFlagCompletionFunc("guards-mode", cobra.FixedCompletions(


### PR DESCRIPTION
## Problem

`TestRegisterFlagCompletions` fails because `MarkFlagFilename`/`MarkFlagDirname` set flag annotations but don't register completion functions retrievable via Cobra's `GetFlagCompletionFunc()`.

## Fix

Replace annotation-based helpers with explicit `RegisterFlagCompletionFunc` calls that return the same directives (`ShellCompDirectiveFilterFileExt` for file flags, `ShellCompDirectiveFilterDirs` for directory flags). This makes completions both functional and testable.

## Changes

- `internal/cmd/flags.go`: Switch 4 flags from `MarkFlagFilename`/`MarkFlagDirname` to `RegisterFlagCompletionFunc`

## Verification

`make agent-finished` passes with all checks green.