### PR TITLE
fix: remove make-immutable job from release workflow

### DIFF
--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"232e03b049b1bff1cd877f77a14e240e8fb8053d6b08791c7cc81d8ac491930a","compiler_version":"v0.71.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"67217db96408a516fda636ee4335724a64ce71aeae7b1a0c4f631ab81c3fd668","compiler_version":"v0.71.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions-rust-lang/setup-rust-toolchain","sha":"a0b538fa0b742a6aa35d6e2c169b4bd06d225a98","version":"a0b538fa0b742a6aa35d6e2c169b4bd06d225a98"},{"repo":"actions/checkout","sha":"34e114876b0b11c390a56381ad16ebd13914f8d5","version":"v4"},{"repo":"actions/checkout","sha":"93cb6efe18208431cddfb8368fd83d5badbf9bfd","version":"v5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"actions/upload-artifact","sha":"330a01c490aca151604b8cf639adc76d48f6c5d4","version":"v5"},{"repo":"anchore/sbom-action","sha":"fbfd9c6c189226748411491745178e0c2017392d","version":"v0.20.10"},{"repo":"docker/build-push-action","sha":"10e90e3645eae34f1e60eeb005ba3a3d33f178e8","version":"v6"},{"repo":"docker/login-action","sha":"c94ce9fb468520275223c153574b00df6fe4bcc9","version":"v3"},{"repo":"docker/setup-buildx-action","sha":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f","version":"v3"},{"repo":"docker/setup-qemu-action","sha":"c7c53464625b32c7a7e944ae62b3e17d2b600130","version":"v3"},{"repo":"github/gh-aw-actions/setup","sha":"49157453228f9641824955e35cbeccbca74ee0fd","version":"v0.71.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.30","digest":"sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.2.30@sha256:e950e6d39f003862d33bfb8d4eb93e242d919cf6ca874b90728e5e0ea7434c6f"},{"image":"ghcr.io/github/github-mcp-server:v1.0.0","digest":"sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.0@sha256:d2550953f8050bc5a1c8f80d1678766f66f60bbfbcd953fdeaf661fe4269bd95"},{"image":"node:lts-alpine","digest":"sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b","pinned_image":"node:lts-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Build, test, and release MCP Gateway binary and Docker image, generate release highlights, and make the release immutable
+# Build, test, and release MCP Gateway binary and Docker image, and generate release highlights
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -200,19 +200,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e06737bd4f7df3bc_EOF'
+          cat << 'GH_AW_PROMPT_b49c67329bab2792_EOF'
           <system>
-          GH_AW_PROMPT_e06737bd4f7df3bc_EOF
+          GH_AW_PROMPT_b49c67329bab2792_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e06737bd4f7df3bc_EOF'
+          cat << 'GH_AW_PROMPT_b49c67329bab2792_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
-          GH_AW_PROMPT_e06737bd4f7df3bc_EOF
+          GH_AW_PROMPT_b49c67329bab2792_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
-          cat << 'GH_AW_PROMPT_e06737bd4f7df3bc_EOF'
+          cat << 'GH_AW_PROMPT_b49c67329bab2792_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -242,12 +242,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e06737bd4f7df3bc_EOF
+          GH_AW_PROMPT_b49c67329bab2792_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e06737bd4f7df3bc_EOF'
+          cat << 'GH_AW_PROMPT_b49c67329bab2792_EOF'
           </system>
           {{#runtime-import .github/workflows/release.md}}
-          GH_AW_PROMPT_e06737bd4f7df3bc_EOF
+          GH_AW_PROMPT_b49c67329bab2792_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -327,7 +327,6 @@ jobs:
       - create-tag
       - docker
       - generate-sbom
-      - make-immutable
       - release
       - test
     runs-on: ubuntu-latest
@@ -438,9 +437,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_50908281e951a9f8_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_049198a5a04130c0_EOF'
           {"create_issue":{"labels":["release"],"max":1,"title_prefix":"[release]"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_50908281e951a9f8_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_049198a5a04130c0_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -639,7 +638,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_1f105d1343559baf_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8c92f8b6b660aaec_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -680,7 +679,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1f105d1343559baf_EOF
+          GH_AW_MCP_CONFIG_8c92f8b6b660aaec_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -883,7 +882,6 @@ jobs:
       - create-tag
       - docker
       - generate-sbom
-      - make-immutable
       - release
       - safe_outputs
       - test
@@ -1188,34 +1186,6 @@ jobs:
           gh release upload "$RELEASE_TAG" sbom.spdx.json sbom.cdx.json --clobber
           echo "✓ SBOM files attached to release"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
-
-  make-immutable:
-    needs:
-      - generate-sbom
-      - release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Configure GH_HOST for enterprise compatibility
-        id: ghes-host-config
-        shell: bash
-        run: |
-          # Derive GH_HOST from GITHUB_SERVER_URL so the gh CLI targets the correct
-          # GitHub instance (GHES/GHEC). On github.com this is a harmless no-op.
-          GH_HOST="${GITHUB_SERVER_URL#https://}"
-          GH_HOST="${GH_HOST#http://}"
-          echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
-      - name: Make release immutable
-        run: |
-          echo "Making release $RELEASE_TAG immutable..."
-          gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --make-immutable
-          echo "✓ Release $RELEASE_TAG is now immutable and cannot be modified"
-        env:
-          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
 

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -1,6 +1,6 @@
 ---
 name: Release
-description: Build, test, and release MCP Gateway binary and Docker image, generate release highlights, and make the release immutable
+description: Build, test, and release MCP Gateway binary and Docker image, and generate release highlights
 on:
   roles:
     - admin
@@ -361,25 +361,6 @@ jobs:
           gh release upload "$RELEASE_TAG" sbom.spdx.json sbom.cdx.json --clobber
           echo "✓ SBOM files attached to release"
 
-  # Make the release immutable after all assets (binaries + SBOM) are uploaded.
-  # This prevents any future modification or deletion of the release for security.
-  # `release` is listed explicitly in `needs` to access `needs.release.outputs.release_tag`.
-  make-immutable:
-    needs: ["generate-sbom", "release"]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Make release immutable
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
-        run: |
-          echo "Making release $RELEASE_TAG immutable..."
-          gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --make-immutable
-          echo "✓ Release $RELEASE_TAG is now immutable and cannot be modified"
-
 steps:
   - name: Setup environment and fetch release data
     env:
@@ -605,7 +586,7 @@ Supported platforms: `linux/amd64`, `linux/arm64`
 
 ## Output Format
 
-**NOTE**: The release will be marked as immutable by the `make-immutable` workflow job after its configured dependencies complete (`generate-sbom` and `release`). `make-immutable` runs concurrently with the agent — it does not wait for the agent to finish. Do not attempt to update the release body as that would conflict with the immutability workflow. Instead, print the generated highlights to stdout so they appear in the workflow run logs.
+**NOTE**: Print the generated highlights to stdout so they appear in the workflow run logs.
 
 After running through steps 1–4 above, print the complete highlights markdown to stdout:
 


### PR DESCRIPTION
## Summary

Removes the `make-immutable` job from the release workflow. The `gh release edit --make-immutable` flag does not exist in any current `gh` CLI version, causing this job to fail on every release (see [run #24866719394](https://github.com/github/gh-aw-mcpg/actions/runs/24866719394/job/72804833591)).

The GitHub REST API also does not yet support setting `immutable` via PATCH, and no GraphQL mutation exists for it.

## Changes

- Removed `make-immutable` job definition (lines 364-381)
- Updated workflow description to remove immutability reference
- Simplified agent NOTE to remove immutability instructions
- Recompiled lock file

Can be re-added once the `gh` CLI or API supports release immutability.