### PR TITLE
fix: increase integration test timeouts for Docker image pulls in CI

### DIFF
--- a/test/integration/binary_test.go
+++ b/test/integration/binary_test.go
@@ -848,7 +848,7 @@ func TestBinaryInvocation_LogFileCreation(t *testing.T) {
 	defer os.Remove(configFile)
 
 	// Start the server process with custom log directory
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
 	port := "13006"
@@ -873,9 +873,9 @@ func TestBinaryInvocation_LogFileCreation(t *testing.T) {
 		}
 	}()
 
-	// Wait for server to start
+	// Wait for server to start — allow time for Docker image pulls in CI
 	serverURL := "http://127.0.0.1:" + port
-	if !waitForServer(t, serverURL+"/health", 5*time.Second) {
+	if !waitForServer(t, serverURL+"/health", 40*time.Second) {
 		t.Logf("STDOUT: %s", stdout.String())
 		t.Logf("STDERR: %s", stderr.String())
 		t.Fatal("Server did not start in time")
@@ -996,7 +996,7 @@ func TestBinaryInvocation_LogDirEnvironmentVariable(t *testing.T) {
 	defer os.Remove(configFile)
 
 	// Start the server process with MCP_GATEWAY_LOG_DIR environment variable (no --log-dir flag)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 
 	port := "13007"
@@ -1023,9 +1023,9 @@ func TestBinaryInvocation_LogDirEnvironmentVariable(t *testing.T) {
 		}
 	}()
 
-	// Wait for server to start
+	// Wait for server to start — allow time for Docker image pulls in CI
 	serverURL := "http://127.0.0.1:" + port
-	if !waitForServer(t, serverURL+"/health", 5*time.Second) {
+	if !waitForServer(t, serverURL+"/health", 40*time.Second) {
 		t.Logf("STDOUT: %s", stdout.String())
 		t.Logf("STDERR: %s", stderr.String())
 		t.Fatal("Server did not start in time")

--- a/test/integration/difc_config_test.go
+++ b/test/integration/difc_config_test.go
@@ -228,7 +228,7 @@ func TestDIFCConfigWithGuards(t *testing.T) {
 		}
 	}`, port)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, binary, "--config-stdin", "--log-dir", logDir)
@@ -242,9 +242,9 @@ func TestDIFCConfigWithGuards(t *testing.T) {
 	err := cmd.Start()
 	require.NoError(t, err, "Failed to start gateway")
 
-	// Wait for full startup — ensures all servers are processed and log files flushed
-	ok := waitForStderr(&stderr, "Starting MCPG", 15*time.Second)
-	require.Truef(t, ok, "timeout waiting for gateway startup within %s; stderr:\n%s", 15*time.Second, stderr.String())
+	// Wait for full startup — allows time for Docker image pulls in CI
+	ok := waitForStderr(&stderr, "Starting MCPG", 50*time.Second)
+	require.Truef(t, ok, "timeout waiting for gateway startup within %s; stderr:\n%s", 50*time.Second, stderr.String())
 
 	// Try health check
 	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))


### PR DESCRIPTION
## Problem

`TestBinaryInvocation_LogFileCreation` and `TestDIFCConfigWithGuards` fail in CI because Docker images (`alpine:latest`, `mcp/playwright:latest`) are not pre-pulled, and the time to pull them exceeds the short test timeouts (5s and 15s respectively).

See: https://github.com/github/gh-aw-mcpg/actions/runs/25325915594/job/74247185258

## Root Cause

`NewUnified()` calls `registerAllTools()` which launches Docker containers and waits for them to connect. The HTTP listener only starts AFTER `NewUnified` returns, so `/health` isn't available until all backends finish connecting (or timeout). In CI, Docker image pulls add 15-30s, exceeding the test timeouts.

## Fix

Increase timeouts to accommodate Docker pulls in CI:
- `TestBinaryInvocation_LogFileCreation`: 5s → 40s (context 10s → 45s)
- `TestBinaryInvocation_LogDirEnvironmentVariable`: 5s → 40s (context 10s → 45s)
- `TestDIFCConfigWithGuards`: 15s → 50s (context 30s → 60s)

These timeouts are generous enough for slow CI environments while still catching real startup failures.