### PR TITLE
fix: update guard policy override test to match []string repos type

### DIFF
--- a/internal/config/guard_policy_override_test.go
+++ b/internal/config/guard_policy_override_test.go
@@ -100,7 +100,7 @@ func TestResolveGuardPolicyOverride(t *testing.T) {
 		require.NotNil(t, policy)
 		assert.Equal(t, "cli", source)
 		require.NotNil(t, policy.AllowOnly)
-		assert.Equal(t, "myorg/myrepo", policy.AllowOnly.Repos)
+		assert.Equal(t, []string{"myorg/myrepo"}, policy.AllowOnly.Repos)
 		assert.Equal(t, "approved", policy.AllowOnly.MinIntegrity)
 	})
 


### PR DESCRIPTION
## Problem

`TestResolveGuardPolicyOverride/cli_changed_with_owner_and_repo_builds_scoped_policy` fails because `BuildAllowOnlyPolicy` returns `[]string{"myorg/myrepo"}` for owner+repo scoped policies, but the test asserted against a plain string `"myorg/myrepo"`.

## Fix

One-line fix: update the assertion to expect `[]string{"myorg/myrepo"}` instead of `"myorg/myrepo"`.

## Verification

`make agent-finished` passes — all checks green.