### PR TITLE
fix: mark ORDER_HIGH_TO_LOW as test-only to fix dead_code error

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/constants.rs
+++ b/guards/github-guard/rust-guard/src/labels/constants.rs
@@ -28,6 +28,7 @@ pub mod policy_integrity {
     pub const APPROVED: &str = "approved";
     pub const MERGED: &str = "merged";
 
+    #[cfg(test)]
     pub const ORDER_HIGH_TO_LOW: [&str; 4] = [MERGED, APPROVED, UNAPPROVED, NONE];
     /// Low-to-high order joined with `|`, ready for use in error messages.
     pub const ORDER_LOW_TO_HIGH_PIPED: &str = "none|unapproved|approved|merged";


### PR DESCRIPTION
The Rust guard constant `ORDER_HIGH_TO_LOW` is only used in the test module but was declared unconditionally, causing a `dead_code` error with `-D warnings` in release builds (CI docker job failure).

Fix: annotate with `#[cfg(test)]` so it's only compiled in test builds.

Fixes the docker job failure in: https://github.com/github/gh-aw-mcpg/actions/runs/25843873997/job/75935158560