### PR TITLE
fix: skip playwright integration test on Docker network failures

### DIFF
--- a/test/integration/playwright_test.go
+++ b/test/integration/playwright_test.go
@@ -388,7 +388,14 @@ CMD ["node", "mock-mcp-server.js"]
 	buildCmd := exec.Command("docker", "build", "-t", imageName, tmpDir)
 	buildOutput, err := buildCmd.CombinedOutput()
 	if err != nil {
-		t.Logf("Build output:\n%s", string(buildOutput))
+		outputStr := string(buildOutput)
+		t.Logf("Build output:\n%s", outputStr)
+		// Skip if the failure is due to network issues (can't pull base image)
+		if strings.Contains(outputStr, "failed to resolve source metadata") ||
+			strings.Contains(outputStr, "i/o timeout") ||
+			strings.Contains(outputStr, "connection refused") {
+			t.Skipf("Skipping test: Docker build failed due to network issues: %v", err)
+		}
 		t.Fatalf("Failed to build test image: %v", err)
 	}
 


### PR DESCRIPTION
When Docker can't pull the base image (e.g., registry timeout through a proxy), `TestPlaywrightWithLocalDockerfile` now skips gracefully instead of fatally failing.

The test already skips when Docker isn't available — this extends that pattern to handle network connectivity issues during `docker build`.