### PR TITLE
fix: use array format with x-sentry-auth header for Sentry OTLP

### DIFF
--- a/.github/workflows/smoke-otel-tracing.lock.yml
+++ b/.github/workflows/smoke-otel-tracing.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8eabcbeba21f9afc1610d1af73e775183ad4152cfe47718912d0daa08440f940","compiler_version":"v0.74.4","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0258e8d37d41708be15bdd6f0785b0d82b973c1a5f067aa88b6272efaa1d5e91","compiler_version":"v0.74.4","agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_OTEL_SENTRY_AUTHORIZATION","GH_AW_OTEL_SENTRY_ENDPOINT","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.11"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b","pinned_image":"node:lts-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -77,8 +77,8 @@ run-name: "Smoke OTel Tracing"
 env:
   OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.GH_AW_OTEL_SENTRY_ENDPOINT }}
   OTEL_SERVICE_NAME: gh-aw.smoke-otel-tracing
-  OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.GH_AW_OTEL_SENTRY_AUTHORIZATION }}
-  GH_AW_OTLP_ENDPOINTS: '[{"url":"${{ secrets.GH_AW_OTEL_SENTRY_ENDPOINT }}","headers":"${{ secrets.GH_AW_OTEL_SENTRY_AUTHORIZATION }}"}]'
+  OTEL_EXPORTER_OTLP_HEADERS: x-sentry-auth=${{ secrets.GH_AW_OTEL_SENTRY_AUTHORIZATION }}
+  GH_AW_OTLP_ENDPOINTS: '[{"url":"${{ secrets.GH_AW_OTEL_SENTRY_ENDPOINT }}","headers":"x-sentry-auth=${{ secrets.GH_AW_OTEL_SENTRY_AUTHORIZATION }}"}]'
 
 jobs:
   activation:
@@ -201,21 +201,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a3191931b8284eb0_EOF'
+          cat << 'GH_AW_PROMPT_7cb3b0a191530c4a_EOF'
           <system>
-          GH_AW_PROMPT_a3191931b8284eb0_EOF
+          GH_AW_PROMPT_7cb3b0a191530c4a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a3191931b8284eb0_EOF'
+          cat << 'GH_AW_PROMPT_7cb3b0a191530c4a_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_a3191931b8284eb0_EOF
+          GH_AW_PROMPT_7cb3b0a191530c4a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a3191931b8284eb0_EOF'
+          cat << 'GH_AW_PROMPT_7cb3b0a191530c4a_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -244,13 +244,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a3191931b8284eb0_EOF
+          GH_AW_PROMPT_7cb3b0a191530c4a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a3191931b8284eb0_EOF'
+          cat << 'GH_AW_PROMPT_7cb3b0a191530c4a_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/go-make.md}}
           {{#runtime-import .github/workflows/smoke-otel-tracing.md}}
-          GH_AW_PROMPT_a3191931b8284eb0_EOF
+          GH_AW_PROMPT_7cb3b0a191530c4a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -485,9 +485,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_56c052ea6e97b7e6_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a8281f50a019787f_EOF'
           {"create_issue":{"close_older_issues":true,"expires":168,"group":true,"labels":["smoke-test","otel","tracing","automation"],"max":1,"title_prefix":"[smoke-otel-tracing] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_56c052ea6e97b7e6_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a8281f50a019787f_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -695,7 +695,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_bd99e7db0e987954_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_35b8ce15410373a7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -741,7 +741,7 @@ jobs:
               }
             }
           }
-          GH_AW_MCP_CONFIG_bd99e7db0e987954_EOF
+          GH_AW_MCP_CONFIG_35b8ce15410373a7_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/smoke-otel-tracing.md
+++ b/.github/workflows/smoke-otel-tracing.md
@@ -11,8 +11,10 @@ permissions:
 
 observability:
   otlp:
-    endpoint: ${{ secrets.GH_AW_OTEL_SENTRY_ENDPOINT }}
-    headers: ${{ secrets.GH_AW_OTEL_SENTRY_AUTHORIZATION }}
+    endpoint:
+      - url: ${{ secrets.GH_AW_OTEL_SENTRY_ENDPOINT }}
+        headers:
+          x-sentry-auth: ${{ secrets.GH_AW_OTEL_SENTRY_AUTHORIZATION }}
 
 engine:
   id: copilot


### PR DESCRIPTION
Switch from flat object format to array format with explicit `x-sentry-auth` header name, matching what Sentry's OTLP endpoint expects.

Previously we used the object format which passes headers as `OTEL_EXPORTER_OTLP_HEADERS` (flat key=value string). The framework sends this as an `Authorization` header, but Sentry requires `x-sentry-auth: sentry sentry_key=...`.

The array format lets us specify the exact header name. Set `GH_AW_OTEL_SENTRY_AUTHORIZATION` to: `sentry sentry_key=<public_key>`