### PR TITLE
fix: flush tracing spans on /close endpoint shutdown

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -398,6 +398,11 @@ func run(cmd *cobra.Command, args []string) error {
 	// in-flight requests before exiting (spec 5.1.3)
 	unifiedServer.SetHTTPShutdown(httpServer.Shutdown)
 
+	// Register exit function so /close handler cancels context instead of calling
+	// os.Exit(0). This allows deferred cleanup (TracerProvider.Shutdown) to flush
+	// buffered spans before the process terminates.
+	unifiedServer.SetExitFunc(cancel)
+
 	// Build net.Listener — optionally wrapping with TLS (ASI-07 Phase 1).
 	// Plain HTTP is still used when no TLS certificate is configured (backward compatible).
 	// Validate that TLS flags are consistent: cert+key must both be provided together,

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -85,8 +85,15 @@ func handleClose(unifiedServer *UnifiedServer) http.Handler {
 					// Fallback: brief delay to ensure response is sent when no shutdown fn is set
 					time.Sleep(100 * time.Millisecond)
 				}
-				logger.LogInfo("shutdown", "Gateway process exiting with status 0")
-				os.Exit(0)
+				// Prefer exitFunc (context cancellation) so deferred cleanup
+				// (e.g. TracerProvider.Shutdown) runs before the process exits.
+				if exitFn := unifiedServer.GetExitFunc(); exitFn != nil {
+					logger.LogInfo("shutdown", "Gateway process exiting via context cancellation")
+					exitFn()
+				} else {
+					logger.LogInfo("shutdown", "Gateway process exiting with status 0")
+					os.Exit(0)
+				}
 			}()
 		}
 	})

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/github/gh-aw-mcpg/internal/config"
 	"github.com/github/gh-aw-mcpg/internal/launcher"
@@ -159,6 +160,57 @@ func TestHandleClose_SuccessfulShutdown(t *testing.T) {
 
 	// Verify shutdown state
 	assert.True(unifiedServer.IsShutdown())
+}
+
+// TestHandleClose_InvokesExitFuncInProductionMode tests that /close invokes
+// the configured exit func after draining HTTP requests when not in test mode.
+func TestHandleClose_InvokesExitFuncInProductionMode(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	ctx := context.Background()
+	mockLauncher := launcher.New(ctx, &config.Config{})
+
+	unifiedServer := &UnifiedServer{
+		launcher:  mockLauncher,
+		sysServer: NewSysServer([]string{}),
+		ctx:       ctx,
+		testMode:  false, // Ensure ShouldExit() is true and goroutine path runs
+	}
+
+	httpShutdownCalled := make(chan struct{}, 1)
+	exitCalled := make(chan struct{}, 1)
+
+	unifiedServer.SetHTTPShutdown(func(context.Context) error {
+		httpShutdownCalled <- struct{}{}
+		return nil
+	})
+	unifiedServer.SetExitFunc(func() {
+		exitCalled <- struct{}{}
+	})
+
+	handler := handleClose(unifiedServer)
+
+	req := httptest.NewRequest(http.MethodPost, "/close", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Assert response returns immediately and correctly
+	assert.Equal(http.StatusOK, rec.Code)
+
+	// Assert goroutine performed HTTP drain first
+	select {
+	case <-httpShutdownCalled:
+	case <-time.After(2 * time.Second):
+		require.Fail("expected HTTP shutdown function to be called")
+	}
+
+	// Assert exit func branch is invoked (instead of os.Exit fallback)
+	select {
+	case <-exitCalled:
+	case <-time.After(2 * time.Second):
+		require.Fail("expected exit function to be called")
+	}
 }
 
 // TestHandleClose_Idempotency tests that multiple close requests are idempotent

--- a/internal/server/unified.go
+++ b/internal/server/unified.go
@@ -110,6 +110,7 @@ type UnifiedServer struct {
 	shutdownMu     sync.RWMutex
 	shutdownOnce   sync.Once
 	httpShutdownFn func(context.Context) error // Called during /close to drain in-flight HTTP requests
+	exitFunc       func()                      // Called during /close instead of os.Exit(0); allows deferred cleanup (e.g. tracing flush)
 
 	// Testing support - when true, skips os.Exit() call
 	testMode bool
@@ -808,6 +809,19 @@ func (us *UnifiedServer) SetHTTPShutdown(fn func(context.Context) error) {
 // GetHTTPShutdown returns the HTTP shutdown function, or nil if not set
 func (us *UnifiedServer) GetHTTPShutdown() func(context.Context) error {
 	return us.httpShutdownFn
+}
+
+// SetExitFunc sets the function to call when the /close endpoint wants to
+// terminate the process. This replaces the default os.Exit(0) so that deferred
+// cleanup (e.g. TracerProvider.Shutdown for flushing spans) can run via the
+// normal return path.
+func (us *UnifiedServer) SetExitFunc(fn func()) {
+	us.exitFunc = fn
+}
+
+// GetExitFunc returns the exit function, or nil if not set.
+func (us *UnifiedServer) GetExitFunc() func() {
+	return us.exitFunc
 }
 
 // IsDIFCEnabled returns whether DIFC is enabled


### PR DESCRIPTION
## Problem

The `/close` endpoint calls `os.Exit(0)` after draining HTTP requests. In Go, `os.Exit` does **not** run deferred functions. This means `TracerProvider.Shutdown()` (which flushes buffered OTLP spans) never executes, so mcpg gateway spans are silently dropped and never appear in the trace collector.

This explains why mcpg `gateway.request` spans (with correct trace IDs from the BaseContext fix in v0.3.13) were not appearing in Sentry despite being created with the right parent trace context.

## Fix

Instead of `os.Exit(0)`, the `/close` handler now calls an `exitFunc` that cancels the root signal context. This unblocks the normal shutdown path in `root.go`:

1. `/close` drains in-flight HTTP requests (existing behavior)
2. `exitFunc()` → `cancel()` on the signal context
3. `<-ctx.Done()` unblocks in root.go
4. `httpServer.Shutdown()` called (idempotent, already drained)
5. Function returns → `defer shutdownTracingProviderWithTimeout()` runs
6. `TracerProvider.Shutdown()` flushes all buffered spans to collector ✅

Falls back to `os.Exit(0)` if no `exitFunc` is registered (backward compatible).

## Testing

- All unit and integration tests pass (`make agent-finished`)
- The `SetExitFunc`/`GetExitFunc` pattern mirrors the existing `SetHTTPShutdown`/`GetHTTPShutdown` API