### PR TITLE
fix(tracing): append /v1/traces to OTLP endpoint per spec

### DIFF
--- a/internal/tracing/provider.go
+++ b/internal/tracing/provider.go
@@ -69,11 +69,21 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 // resolveEndpoint returns the OTLP endpoint from config.
 // CLI flags set the config value using env vars as defaults, so config already
 // reflects the correct precedence: CLI flag > env var > config file.
+//
+// Per the OpenTelemetry specification, OTEL_EXPORTER_OTLP_ENDPOINT is a base URL
+// and SDKs must append the signal path (/v1/traces for traces). Since we use
+// WithEndpointURL (which takes the URL as-is), we append /v1/traces here when
+// it is not already present.
 func resolveEndpoint(cfg *config.TracingConfig) string {
-	if cfg != nil {
-		return cfg.Endpoint
+	if cfg == nil || cfg.Endpoint == "" {
+		return ""
 	}
-	return ""
+	endpoint := cfg.Endpoint
+	// Append /v1/traces if not already present (OTEL spec compliance)
+	if !strings.HasSuffix(endpoint, "/v1/traces") {
+		endpoint = strings.TrimRight(endpoint, "/") + "/v1/traces"
+	}
+	return endpoint
 }
 
 // resolveServiceName returns the service name from config.

--- a/internal/tracing/resolve_endpoint_test.go
+++ b/internal/tracing/resolve_endpoint_test.go
@@ -1,0 +1,63 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/github/gh-aw-mcpg/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveEndpoint_AppendsV1Traces(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{
+			name:     "base URL without path",
+			endpoint: "https://o123.ingest.us.sentry.io/api/456/envelope",
+			want:     "https://o123.ingest.us.sentry.io/api/456/envelope/v1/traces",
+		},
+		{
+			name:     "base URL with trailing slash",
+			endpoint: "https://o123.ingest.us.sentry.io/api/456/envelope/",
+			want:     "https://o123.ingest.us.sentry.io/api/456/envelope/v1/traces",
+		},
+		{
+			name:     "already has /v1/traces",
+			endpoint: "https://o123.ingest.us.sentry.io/api/456/envelope/v1/traces",
+			want:     "https://o123.ingest.us.sentry.io/api/456/envelope/v1/traces",
+		},
+		{
+			name:     "simple localhost endpoint",
+			endpoint: "http://localhost:4318",
+			want:     "http://localhost:4318/v1/traces",
+		},
+		{
+			name:     "localhost with trailing slash",
+			endpoint: "http://localhost:4318/",
+			want:     "http://localhost:4318/v1/traces",
+		},
+		{
+			name:     "empty endpoint",
+			endpoint: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.TracingConfig{Endpoint: tt.endpoint}
+			if tt.endpoint == "" {
+				cfg = &config.TracingConfig{}
+			}
+			got := resolveEndpoint(cfg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveEndpoint_NilConfig(t *testing.T) {
+	got := resolveEndpoint(nil)
+	assert.Equal(t, "", got)
+}


### PR DESCRIPTION
## Problem

The OTEL spec requires SDKs to append signal-specific paths (`/v1/traces` for traces) to the base `OTEL_EXPORTER_OTLP_ENDPOINT` URL. However, the Go SDK's `WithEndpointURL()` uses the URL as-is without appending, unlike the JS SDK which auto-appends.

This mismatch meant that when `/v1/traces` was manually added to the shared endpoint secret to make mcpg work, the JS framework got 404s because it auto-appended again → `/v1/traces/v1/traces`.

## Fix

`resolveEndpoint()` now appends `/v1/traces` to the configured endpoint if not already present, aligning behavior with the JS SDK and OTEL spec. This allows both Go (mcpg) and JS (framework) exporters to share the same base endpoint URL without path conflicts.

## Changes

- `internal/tracing/provider.go` — `resolveEndpoint()` appends `/v1/traces` per OTEL spec
- `internal/tracing/resolve_endpoint_test.go` — Unit tests covering all cases

## After Merge

Once released, remove `/v1/traces` from the `GH_AW_OTEL_SENTRY_ENDPOINT` secret so both JS and Go exporters use the same base URL.