### PR TITLE
feat(tracing): align span attributes with gen_ai semantic conventions

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -143,7 +142,7 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	// Start a DIFC pipeline span covering all phases for this request
 	ctx, difcSpan := h.GetTracer().Start(ctx, "proxy.difc_pipeline",
 		oteltrace.WithAttributes(
-			attribute.String("tool.name", toolName),
+			tracing.GenAIToolName.String(toolName),
 			semconv.URLPathKey.String(r.URL.Path),
 		),
 		oteltrace.WithSpanKind(oteltrace.SpanKindInternal),
@@ -200,7 +199,7 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	fwdCtx, fwdSpan := h.GetTracer().Start(ctx, "proxy.backend.forward",
 		oteltrace.WithAttributes(
 			semconv.URLPathKey.String(path),
-			attribute.String("tool.name", toolName),
+			tracing.GenAIToolName.String(toolName),
 		),
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 	)

--- a/internal/server/http_helpers.go
+++ b/internal/server/http_helpers.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/github/gh-aw-mcpg/internal/auth"
@@ -153,9 +152,9 @@ func WithOTELTracing(next http.Handler, tag string) http.Handler {
 		next.ServeHTTP(w, r)
 		sessionID := SessionIDFromContext(r.Context())
 		span := oteltrace.SpanFromContext(r.Context())
-		span.SetAttributes(attribute.String("session.id", auth.TruncateSessionID(sessionID)))
+		span.SetAttributes(tracing.GenAIConversationID.String(auth.TruncateSessionID(sessionID)))
 	})
-	return tracing.WrapHTTPHandler(enriched, "gateway.request", attribute.String("gateway.tag", tag))
+	return tracing.WrapHTTPHandler(enriched, "gateway.request", tracing.GatewayTag.String(tag))
 }
 
 // applyIfConfigured wraps handler with middleware(key, handler) when key is non-empty.

--- a/internal/server/unified.go
+++ b/internal/server/unified.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -380,12 +379,12 @@ func (us *UnifiedServer) callBackendTool(ctx context.Context, serverID, toolName
 	}
 
 	// Start an OTEL span for the full tool call lifecycle (spans all phases 0–6)
-	// Attribute names follow MCP Gateway Specification §4.1.3.6
+	// Attribute names follow the OpenTelemetry gen_ai semantic conventions
 	ctx, toolSpan := us.GetTracer().Start(ctx, "mcp.tool_call",
 		oteltrace.WithAttributes(
-			attribute.String("mcp.server", serverID),
-			attribute.String("mcp.method", "tools/call"),
-			attribute.String("mcp.tool", toolName),
+			tracing.GenAIAgentID.String(serverID),
+			tracing.MCPMethod.String("tools/call"),
+			tracing.GenAIToolName.String(toolName),
 		),
 		oteltrace.WithSpanKind(oteltrace.SpanKindInternal),
 	)
@@ -487,8 +486,8 @@ func (us *UnifiedServer) callBackendTool(ctx context.Context, serverID, toolName
 	// **Phase 3: Execute the backend call**
 	execCtx, execSpan := us.GetTracer().Start(ctx, "gateway.backend.execute",
 		oteltrace.WithAttributes(
-			attribute.String("tool.name", toolName),
-			attribute.String("server.id", serverID),
+			tracing.GenAIToolName.String(toolName),
+			tracing.GenAIAgentID.String(serverID),
 		),
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 	)
@@ -519,7 +518,7 @@ func (us *UnifiedServer) callBackendTool(ctx context.Context, serverID, toolName
 	// Inspect the tool result for rate-limit indicators from the GitHub MCP server.
 	if rateLimited, resetAt := isRateLimitToolResult(backendResult); rateLimited {
 		cb.RecordRateLimit(resetAt)
-		execSpan.SetAttributes(attribute.Bool("rate_limit.hit", true))
+		execSpan.SetAttributes(tracing.RateLimitHit.Bool(true))
 		httpStatusCode = 429
 		// Preserve the original backend error text so the agent sees the actual upstream
 		// rate-limit details. ErrCircuitOpen is only returned when cb.Allow() rejects

--- a/internal/tracing/genai_attrs.go
+++ b/internal/tracing/genai_attrs.go
@@ -1,0 +1,37 @@
+// Package tracing provides OpenTelemetry OTLP trace export for the MCP Gateway.
+// This file defines gen_ai semantic convention attribute keys per
+// https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
+package tracing
+
+import "go.opentelemetry.io/otel/attribute"
+
+// GenAI semantic convention attribute keys.
+// These follow the OpenTelemetry gen_ai specification (development stability).
+const (
+	// GenAIToolName is the name of the tool utilized by the agent.
+	GenAIToolName = attribute.Key("gen_ai.tool.name")
+
+	// GenAIOperationName is the name of the operation being performed.
+	GenAIOperationName = attribute.Key("gen_ai.operation.name")
+
+	// GenAIConversationID is the unique identifier for a conversation (session).
+	GenAIConversationID = attribute.Key("gen_ai.conversation.id")
+
+	// GenAIAgentName is the human-readable name of the GenAI agent.
+	GenAIAgentName = attribute.Key("gen_ai.agent.name")
+
+	// GenAIAgentID is the unique identifier of the GenAI agent (server ID).
+	GenAIAgentID = attribute.Key("gen_ai.agent.id")
+)
+
+// MCP-specific attribute keys (no gen_ai equivalent in the spec).
+const (
+	// MCPMethod is the JSON-RPC method name (e.g. "tools/call").
+	MCPMethod = attribute.Key("mcp.method")
+
+	// RateLimitHit indicates a rate limit was triggered.
+	RateLimitHit = attribute.Key("rate_limit.hit")
+
+	// GatewayTag is the routing mode tag (unified/routed).
+	GatewayTag = attribute.Key("gateway.tag")
+)


### PR DESCRIPTION
## Summary

Aligns the gateway's OTel span attributes with the [OpenTelemetry gen_ai semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/).

## Attribute Mapping

| Before | After | Rationale |
|--------|-------|-----------|
| `mcp.tool` / `tool.name` | `gen_ai.tool.name` | Standard tool name attribute |
| `mcp.server` / `server.id` | `gen_ai.agent.id` | Server ID maps to agent identifier |
| `session.id` | `gen_ai.conversation.id` | Session maps to conversation |
| `mcp.method` | `mcp.method` | Kept — no gen_ai equivalent |
| `gateway.tag` | `gateway.tag` | Kept — gateway-specific |
| `rate_limit.hit` | `rate_limit.hit` | Kept — no gen_ai equivalent |

## Changes

- **`internal/tracing/genai_attrs.go`** — New file defining typed attribute key constants per the gen_ai spec
- **`internal/server/unified.go`** — `mcp.tool_call` and `gateway.backend.execute` spans use gen_ai keys
- **`internal/server/http_helpers.go`** — `gateway.request` span uses `gen_ai.conversation.id`
- **`internal/proxy/handler.go`** — Proxy spans use `gen_ai.tool.name`

## Why

Using standard gen_ai attribute names enables better integration with observability platforms (Sentry, Honeycomb, Datadog) that have built-in gen_ai dashboards and correlations.