### PR TITLE
rust-guard: add issue_write_ff_remote_mcp_issue_fields to WRITE_OPERATIONS and tool_rules

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/tool_rules.rs
+++ b/guards/github-guard/rust-guard/src/labels/tool_rules.rs
@@ -556,6 +556,7 @@ pub fn apply_tool_labels(
         // Issue/PR writes
         "create_issue"
         | "issue_write"
+        | "issue_write_ff_remote_mcp_issue_fields"
         | "sub_issue_write"
         | "add_issue_comment"
         | "create_pull_request"

--- a/guards/github-guard/rust-guard/src/labels/tool_rules.rs
+++ b/guards/github-guard/rust-guard/src/labels/tool_rules.rs
@@ -906,6 +906,37 @@ mod tests {
     }
 
     #[test]
+    fn apply_tool_labels_issue_write_ff_matches_issue_write() {
+        let ctx = default_ctx();
+        let tool_args = serde_json::json!({ "owner": "github", "repo": "copilot", "issue_number": 42 });
+        let repo_id = "github/copilot";
+
+        let issue_write_labels = super::apply_tool_labels(
+            "issue_write",
+            &tool_args,
+            repo_id,
+            vec![],
+            vec![],
+            String::new(),
+            &ctx,
+        );
+        let issue_write_ff_labels = super::apply_tool_labels(
+            "issue_write_ff_remote_mcp_issue_fields",
+            &tool_args,
+            repo_id,
+            vec![],
+            vec![],
+            String::new(),
+            &ctx,
+        );
+
+        assert_eq!(
+            issue_write_ff_labels, issue_write_labels,
+            "issue_write FF variant must match issue_write labels and description"
+        );
+    }
+
+    #[test]
     fn apply_tool_labels_release_management_is_repo_scoped_write() {
         let ctx = default_ctx();
         let tool_args = serde_json::json!({ "owner": "github", "repo": "copilot", "tag_name": "v1.0.0" });

--- a/guards/github-guard/rust-guard/src/tools.rs
+++ b/guards/github-guard/rust-guard/src/tools.rs
@@ -85,6 +85,7 @@ pub const READ_WRITE_OPERATIONS: &[&str] = &[
     "update_pull_request_branch",
     "pull_request_review_write",
     "issue_write",
+    "issue_write_ff_remote_mcp_issue_fields", // feature-flag variant of issue_write
     "sub_issue_write",
     "update_gist",
     // Pre-emptive entries for anticipated future MCP tools (no equivalent tool today)

--- a/guards/github-guard/rust-guard/src/tools.rs
+++ b/guards/github-guard/rust-guard/src/tools.rs
@@ -400,6 +400,21 @@ mod tests {
     }
 
     #[test]
+    fn test_issue_write_ff_remote_mcp_issue_fields_is_read_write_operation() {
+        let op = "issue_write_ff_remote_mcp_issue_fields";
+        assert!(
+            is_read_write_operation(op),
+            "{} must be classified as a read-write operation",
+            op
+        );
+        assert!(
+            !is_write_operation(op),
+            "{} should not be in WRITE_OPERATIONS (it is in READ_WRITE_OPERATIONS)",
+            op
+        );
+    }
+
+    #[test]
     fn test_sub_issue_management_tools_are_read_write_operations() {
         for op in &["add_sub_issue", "remove_sub_issue", "reprioritize_sub_issue"] {
             assert!(


### PR DESCRIPTION
Add the feature-flag variant of `issue_write` to the guard's write classification list and tool labeling rules. This ensures DIFC enforcement applies to the FF variant the same as the standard `issue_write` tool.

Closes #6663