### PR TITLE
fix(proxy): use RecordSpanError for DIFC access-denied spans

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
@@ -186,8 +185,9 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	case difc.CoarseDenied:
 		// Write blocked
 		logHandler.Printf("[DIFC] Phase 2: BLOCKED %s %s — %s", r.Method, path, evalResult.Reason)
-		difcSpan.SetStatus(codes.Error, "access denied: "+evalResult.Reason)
-		writeDIFCForbidden(w, fmt.Sprintf("DIFC policy violation: %s", evalResult.Reason))
+		deniedErr := fmt.Errorf("DIFC policy violation: %s", evalResult.Reason)
+		tracing.RecordSpanError(difcSpan, deniedErr, "access denied: "+evalResult.Reason)
+		writeDIFCForbidden(w, deniedErr.Error())
 		return
 	}
 


### PR DESCRIPTION
Replace direct `SetStatus` call with `tracing.RecordSpanError` helper in the proxy `CoarseDenied` branch. This ensures proxy DIFC denial traces include the `RecordError` event with stack trace, consistent with all other enforcement paths in `server/unified.go`.

Closes #6666