### PR TITLE
perf(rust-guard): eliminate wasted allocations in apply_tool_labels and project-item loop

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/response_paths.rs
+++ b/guards/github-guard/rust-guard/src/labels/response_paths.rs
@@ -7,6 +7,7 @@
 //! Returns JSON paths like `/items/0`, `/items/1` pointing to labeled objects
 //! in the response, rather than cloning the entire data.
 
+use std::borrow::Cow;
 use super::constants::{field_names, label_constants, scope_names};
 use super::extract_mcp_response;
 use super::helpers::*;
@@ -626,7 +627,15 @@ pub fn label_response_paths(
                     labeled_paths.push(PathLabelEntry {
                         path: make_item_path(&items_path, i),
                         labels: crate::ResourceLabels {
-                            description: format!("project-item:{}", item_type.to_lowercase()),
+                            description: {
+                                let type_lower: Cow<'_, str> = match item_type {
+                                    "ISSUE" => Cow::Borrowed("issue"),
+                                    "PULL_REQUEST" => Cow::Borrowed("pull_request"),
+                                    "DRAFT_ISSUE" => Cow::Borrowed("draft_issue"),
+                                    other => Cow::Owned(other.to_lowercase()),
+                                };
+                                format!("project-item:{}", type_lower)
+                            },
                             secrecy: secrecy.into(),
                             integrity: integrity.into(),
                         },

--- a/guards/github-guard/rust-guard/src/labels/tool_rules.rs
+++ b/guards/github-guard/rust-guard/src/labels/tool_rules.rs
@@ -10,8 +10,8 @@ use super::constants::{field_names, scope_names, SENSITIVE_FILE_KEYWORDS, SENSIT
 use super::helpers::{
     author_association_floor_from_str,
     elevate_via_collaborator_permission, ensure_integrity_baseline,
-    extract_number_as_string, extract_repo_info, extract_repo_info_from_search_query,
-    format_repo_id, is_any_trusted_actor, is_default_branch_commit_context,
+    extract_number_as_string, extract_repo_info_from_search_query,
+    format_repo_id, get_string_field, is_any_trusted_actor, is_default_branch_commit_context,
     is_default_branch_ref, max_integrity,
     merged_integrity, policy_private_scope_label, private_user_label, project_github_label,
     reader_integrity, writer_integrity, PolicyContext,
@@ -122,7 +122,8 @@ pub fn apply_tool_labels(
     mut desc: String,
     ctx: &PolicyContext,
 ) -> (Vec<String>, Vec<String>, String) {
-    let (owner, repo, _) = extract_repo_info(tool_args);
+    let owner = get_string_field(tool_args, field_names::OWNER);
+    let repo = get_string_field(tool_args, field_names::REPO);
     let mut baseline_scope: Cow<'_, str> = Cow::Borrowed(repo_id);
     let repo_private = if owner.is_empty() || repo.is_empty() {
         None


### PR DESCRIPTION
- Replace `extract_repo_info(tool_args)` with direct `get_string_field` calls in `apply_tool_labels`, avoiding a `format!(\"{}/{}\")` allocation that was immediately discarded on every tool invocation.

- Replace unconditional `to_lowercase()` with a static match for known project item types (`ISSUE`, `PULL_REQUEST`, `DRAFT_ISSUE`), avoiding a heap allocation per item in the common case.

Closes #6674