### PR TITLE
fix(proxy): passthrough /rate_limit for CLI proxy liveness probe

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -59,9 +59,9 @@ func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// gh CLI probes /meta during initialization for feature detection.
-	// Treat it like GraphQL introspection metadata and pass through unfiltered.
-	if r.Method == http.MethodGet && rawPath == "/meta" {
+	// gh CLI probes /meta and /rate_limit during initialization for feature detection
+	// and connectivity checks. These are safe metadata endpoints — pass through unfiltered.
+	if r.Method == http.MethodGet && (rawPath == "/meta" || rawPath == "/rate_limit") {
 		h.passthrough(w, r, fullPath)
 		return
 	}

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -118,6 +118,29 @@ func TestServeHTTP_MetaPassthrough(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "verifiable_password_authentication")
 }
 
+func TestServeHTTP_RateLimitPassthrough(t *testing.T) {
+	var receivedURL string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedURL = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{"resources":{"core":{"limit":5000}}}`))
+		require.NoError(t, err)
+	}))
+	defer upstream.Close()
+
+	s := newTestServer(t, upstream.URL)
+	h := &proxyHandler{server: s}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v3/rate_limit", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "/rate_limit", receivedURL)
+	assert.Contains(t, w.Body.String(), "core")
+}
+
 // ─── ServeHTTP: write operations (non-GraphQL POST/PUT/DELETE/PATCH) ─────────
 
 func TestServeHTTP_WriteOperationsPassthrough(t *testing.T) {

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -119,9 +119,9 @@ func TestServeHTTP_MetaPassthrough(t *testing.T) {
 }
 
 func TestServeHTTP_RateLimitPassthrough(t *testing.T) {
-	var receivedURL string
+	receivedURLCh := make(chan string, 1)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		receivedURL = r.URL.RequestURI()
+		receivedURLCh <- r.URL.RequestURI()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte(`{"resources":{"core":{"limit":5000}}}`))
@@ -136,6 +136,7 @@ func TestServeHTTP_RateLimitPassthrough(t *testing.T) {
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
+	receivedURL := <-receivedURLCh
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "/rate_limit", receivedURL)
 	assert.Contains(t, w.Body.String(), "core")


### PR DESCRIPTION
The gh CLI liveness probe calls `GET /rate_limit` to verify connectivity. The DIFC proxy was blocking this as an unrecognized endpoint (HTTP 403), causing the cli-proxy sidecar to fail fast and prevent agent startup.

**Root cause:** `/rate_limit` is a GET request that enters the "read operation" path, but `MatchRoute()` returns nil for it, triggering the fail-closed "access denied: unrecognized endpoint" response.

**Fix:** Add `/rate_limit` to the passthrough list alongside `/meta` — both are safe read-only metadata endpoints used by `gh` CLI for initialization.

**Affected:** Any workflow using `features.cli-proxy: true` or `features.difc-proxy: true` with mcpg >= v0.3.23.

Reported via: https://github.com/github/gh-aw/actions/runs/27112965256/job/80016366723?pr=37708