### PR TITLE
Fix test-improver workflow AI credits rate limit

### DIFF
--- a/.github/workflows/test-improver.md
+++ b/.github/workflows/test-improver.md
@@ -23,6 +23,25 @@ steps:
       go-version-file: go.mod
       cache: true
 
+  - name: Discover test files
+    run: |
+      mkdir -p /tmp/gh-aw/data
+      find internal -name '*_test.go' -type f | while read -r f; do
+        pkg=$(head -1 "$f" | sed 's/^package //')
+        lines=$(wc -l < "$f")
+        funcs=$(grep -c '^func Test' "$f" || true)
+        printf '{"path":"%s","package":"%s","lines":%d,"funcs":%d}\n' "$f" "$pkg" "$lines" "$funcs"
+      done | jq -s '.' > /tmp/gh-aw/data/test-files.json
+
+  - name: Check for existing PR
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    run: |
+      gh pr list --repo "${{ github.repository }}" \
+        --state open --search "[test-improver]" \
+        --json number,title --limit 5 \
+        > /tmp/gh-aw/data/existing-prs.json
+
 safe-outputs:
   threat-detection:
     enabled: false
@@ -43,350 +62,64 @@ tools:
   edit:
   bash: true
 
-max-ai-credits: 2000
+max-ai-credits: 2500
 timeout-minutes: 30
 strict: true
 ---
 
 # Test Improver 🧹
 
-You are an AI agent specialized in improving Go test files. Your mission is to review a single test file and suggest improvements focused on better testify library usage, increased coverage, and cleaner, more stable tests.
+Improve one Go test file per run: better assertions, more coverage, cleaner structure.
 
-## Mission
+## Context
 
-Select one test file from the codebase, analyze it thoroughly, and create improvements that focus on:
-1. **Better idiomatic use of the testify library** - Use testify assertions instead of manual error checking
-2. **Increase coverage** - Add missing test cases to cover untested code paths
-3. **Stabler, cleaner tests** - Improve test structure, readability, and reliability
+This project uses testify (`github.com/stretchr/testify`). Prefer `require` for fatal checks and `assert` for non-fatal. Use bound asserters (`assert := assert.New(t)`) for files with many assertions.
 
-## Important: This project does NOT currently use testify
+## Step 1: Select a Test File
 
-**CRITICAL**: Before making any changes, check if the testify library is already in `go.mod`. If testify is NOT present:
-1. DO NOT add testify to the project
-2. Focus on improving tests using standard library testing patterns
-3. Suggest improvements like:
-   - Better table-driven test structures
-   - More comprehensive edge case coverage
-   - Cleaner test organization and naming
-   - More robust error checking
-   - Better use of subtests with `t.Run()`
+Read `/tmp/gh-aw/data/test-files.json` for the pre-computed inventory. Also check `/tmp/gh-aw/data/existing-prs.json` — if an open `[test-improver]` PR exists, call `noop` and stop.
 
-## Step 1: Find All Test Files
+Use `cache-memory` to check which files were previously improved. Select a file that:
+- Has manual error checking instead of testify assertions
+- Has low coverage of the corresponding implementation
+- Has repetitive code that could be table-driven
+- Was NOT recently modified (check `git log --oneline -3 <file>`)
 
-List all test files in the codebase:
+Avoid integration tests in `test/integration/`.
+
+## Step 2: Analyze
+
+1. Read the test file and its corresponding implementation file
+2. Run coverage on the specific package only:
+   ```bash
+   go test -coverprofile=/tmp/coverage.out ./internal/<package>/
+   go tool cover -func=/tmp/coverage.out
+   ```
+3. Identify: uncovered branches, missing edge cases, poor assertion patterns
+
+## Step 3: Improve
+
+Focus on:
+- **Testify usage**: Replace manual `if err != nil { t.Fatal(...) }` with `require.NoError(t, err)`, use `assert.Equal`, `assert.Contains`, etc.
+- **Coverage**: Add tests for uncovered error paths and edge cases
+- **Structure**: Convert repetitive tests to table-driven with `t.Run()`
+- **Stability**: Use `t.Cleanup()`, avoid timing dependencies, mock externals
+
+Preserve all existing passing tests. Follow project conventions in `internal/testutil/`.
+
+## Step 4: Verify
 
 ```bash
-find internal -name '*_test.go' -type f
+go test -v ./internal/<package>/
+go test -count=3 ./internal/<package>/
+go vet ./internal/<package>/
+gofmt -l <test_file>
 ```
 
-Create an inventory of all test files with their:
-- File path
-- Package name
-- Approximate line count
-- Number of test functions
+## Step 5: Output
 
-## Step 2: Select a Single Test File
+**If improvements were made**: Create a PR via `create-pull-request` with title `Improve tests for <PackageName>`. Include in the body: file analyzed, improvements made, coverage before/after, and test output.
 
-Use **Serena** to help select the best candidate test file. Consider:
+**If no improvements needed**: Call `noop`.
 
-1. **Complexity vs. test quality**: Files with complex code but simple tests
-2. **Coverage gaps**: Files where the corresponding code has low coverage
-3. **Testing patterns**: Files that could benefit from better testing structure
-4. **Size**: Medium-sized test files (not too small, not huge) that can be meaningfully improved
-
-**Selection criteria** (prioritize in this order):
-- Test files with manual error checking instead of proper assertions
-- Test files with low coverage of the corresponding code
-- Test files with repetitive test code that could be table-driven
-- Test files with poor edge case coverage
-- Test files without proper subtests
-
-**Avoid**:
-- Test files that were recently modified (check git history)
-- Test files that are already well-structured with comprehensive coverage
-- Integration test files that are inherently complex
-
-Use Serena to analyze and rank test files, then select the top candidate.
-
-## Step 3: Deep Analysis of Selected Test File
-
-Before making changes, thoroughly understand the selected test file:
-
-1. **Read the test file completely**:
-   - What functions are being tested?
-   - What test patterns are used?
-   - Are there table-driven tests?
-   - How is error handling done?
-   - Are subtests used properly?
-
-2. **Read the corresponding implementation file**:
-   - What functionality needs testing?
-   - What are the edge cases?
-   - What error conditions exist?
-   - What branches/conditionals need coverage?
-
-3. **Run coverage analysis**:
-   ```bash
-   go test -coverprofile=coverage.out ./...
-   go tool cover -func=coverage.out | grep "filename"
-   ```
-   Identify which functions/lines are not covered by the current tests.
-
-4. **Use Serena** to analyze:
-   - Code complexity in the implementation
-   - Test coverage gaps
-   - Potential edge cases
-   - Error handling paths
-
-## Step 4: Plan Improvements
-
-Based on your analysis, create a concrete improvement plan. Focus on:
-
-### A. Better Assertions (if applicable)
-
-**Current pattern** (manual checking):
-```go
-if err != nil {
-    t.Errorf("unexpected error: %v", err)
-}
-if got != want {
-    t.Errorf("got %v, want %v", got, want)
-}
-```
-
-**Improved pattern** (only if testify is available):
-```go
-require.NoError(t, err)
-assert.Equal(t, want, got)
-```
-
-**If testify is NOT available**, improve manual checks:
-```go
-if err != nil {
-    t.Fatalf("unexpected error: %v", err)
-}
-if got != want {
-    t.Errorf("got %v, want %v", got, want)
-}
-```
-
-### B. Increased Coverage
-
-Identify missing test cases:
-- **Edge cases**: nil inputs, empty values, boundary conditions
-- **Error paths**: invalid inputs, error conditions
-- **Branch coverage**: all if/else branches, switch cases
-- **Loop coverage**: zero iterations, one iteration, many iterations
-
-### C. Cleaner Test Structure
-
-Apply these improvements:
-
-1. **Use table-driven tests** for multiple similar test cases:
-```go
-tests := []struct {
-    name    string
-    input   InputType
-    want    OutputType
-    wantErr bool
-}{
-    {
-        name:    "valid input",
-        input:   validInput,
-        want:    expectedOutput,
-        wantErr: false,
-    },
-    {
-        name:    "empty input",
-        input:   emptyInput,
-        want:    zeroValue,
-        wantErr: true,
-    },
-}
-
-for _, tt := range tests {
-    t.Run(tt.name, func(t *testing.T) {
-        got, err := FunctionUnderTest(tt.input)
-        if (err != nil) != tt.wantErr {
-            t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-            return
-        }
-        if got != tt.want {
-            t.Errorf("got %v, want %v", got, tt.want)
-        }
-    })
-}
-```
-
-2. **Use descriptive test names**: `TestFunctionName_Scenario` format
-
-3. **Use t.Helper()** in test helper functions
-
-4. **Proper cleanup**: Use `t.Cleanup()` or `defer` for resource cleanup
-
-5. **Better error messages**: Include context in error messages
-
-6. **Avoid test interdependence**: Each test should be independent
-
-### D. More Stable Tests
-
-Make tests more reliable:
-- Avoid timing-dependent tests (use mocks/fakes for time)
-- Don't depend on external state
-- Use proper setup/teardown with `t.Cleanup()`
-- Mock external dependencies consistently
-- Use deterministic test data
-
-## Step 5: Implement Improvements
-
-Make the improvements to the selected test file:
-
-1. **Preserve existing test coverage**: Don't remove working tests
-2. **Add new test cases**: Fill coverage gaps
-3. **Refactor existing tests**: Improve structure and clarity
-4. **Follow project conventions**: Match the style of the codebase
-5. **Update test utilities**: If needed, enhance or use existing test helpers in `internal/testutil/`
-
-## Step 6: Verify Improvements
-
-After making changes:
-
-1. **Run the tests**:
-   ```bash
-   go test -v ./path/to/package
-   ```
-
-2. **Check coverage improvement**:
-   ```bash
-   go test -coverprofile=coverage.out ./path/to/package
-   go tool cover -func=coverage.out
-   ```
-
-3. **Run multiple times** to ensure stability:
-   ```bash
-   for i in {1..5}; do go test ./path/to/package || break; done
-   ```
-
-4. **Verify formatting**:
-   ```bash
-   gofmt -l path/to/test_file.go
-   ```
-
-5. **Run go vet**:
-   ```bash
-   go vet ./path/to/package
-   ```
-
-## Step 7: Create Pull Request or Call Noop
-
-**If improvements were made**:
-
-Create a pull request using the `create-pull-request` safe output.
-
-**PR Title Format**: `Improve tests for [PackageName]`
-
-**Example**: `Improve tests for config package`
-
-**PR Body Structure**:
-
-```markdown
-# Test Improvements: [TestFileName]
-
-## File Analyzed
-
-- **Test File**: `internal/[package]/[filename]_test.go`
-- **Package**: `internal/[package]`
-- **Lines of Code**: [X] → [Y] (if changed significantly)
-
-## Improvements Made
-
-### 1. Better Testing Patterns
-- ✅ [Specific improvement, e.g., "Converted to table-driven tests"]
-- ✅ [Specific improvement, e.g., "Added descriptive test names"]
-- ✅ [Specific improvement, e.g., "Better error messages"]
-
-### 2. Increased Coverage
-- ✅ Added test for [edge case or scenario]
-- ✅ Added test for [error condition]
-- ✅ Added test for [branch/path]
-- **Previous Coverage**: [X]%
-- **New Coverage**: [Y]%
-- **Improvement**: +[Z]%
-
-### 3. Cleaner & More Stable Tests
-- ✅ [Improvement, e.g., "Proper use of t.Cleanup()"]
-- ✅ [Improvement, e.g., "Removed timing dependencies"]
-- ✅ [Improvement, e.g., "Better test isolation"]
-
-## Test Execution
-
-All tests pass:
-```
-[Include test output showing PASS and coverage improvement]
-```
-
-## Why These Changes?
-
-[Brief explanation of the rationale - why this test file was selected, what problems were addressed, and how the improvements make the tests better]
-
----
-*Generated by Test Improver Workflow*
-*Focuses on better patterns, increased coverage, and more stable tests*
-```
-
-**If NO improvements were made** (test file is already excellent):
-
-Call the `noop` safe output instead of creating a PR. This signals that no action was needed.
-
-**When to use noop**:
-- All test files are already well-structured
-- Selected test file is already at high quality
-- No meaningful improvements can be made
-- Coverage is already comprehensive
-
-## Guidelines
-
-- **One test file per run**: Focus deeply on a single test file for quality improvements
-- **Preserve working tests**: Don't break existing functionality
-- **Follow conventions**: Match the testing patterns in the codebase
-- **Use Serena**: Leverage Go analysis capabilities for intelligent file selection
-- **Quality over quantity**: Better to make meaningful improvements to one file than superficial changes to many
-- **Verify stability**: Run tests multiple times to ensure reliability
-- **Standard library first**: If testify is not in the project, use standard library patterns
-- **Cache memory**: Use cache to track which files were improved to avoid repetition
-
-## Serena Configuration
-
-Serena is configured for Go code analysis:
-- **Project Root**: ${{ github.workspace }}
-- **Language**: Go
-- **Capabilities**: Code complexity analysis, test quality assessment, coverage gap identification
-
-Use Serena to:
-- Rank test files by improvement potential
-- Identify coverage gaps
-- Analyze test quality metrics
-- Suggest specific improvements
-
-## Cache Memory
-
-Use cache-memory to track progress:
-- Save the last improved test file to avoid immediate repetition
-- Track improvements over time
-- Store analysis results for future reference
-
-## Avoiding Duplicate PRs
-
-Before creating a PR, check if there's already an open PR with "[test-improver]" in the title using the GitHub tools. If one exists, call `noop` instead of creating a duplicate PR.
-
-## Output Decision
-
-Your final action MUST be one of:
-1. **Create a pull request** (via `create-pull-request` safe output) if improvements were made
-2. **Call noop** (via `noop` safe output) if no improvements are needed
-
-Do not create a PR if the test file is already excellent and no meaningful improvements can be made.
-
----
-
-Begin your analysis! Find test files, select the best candidate, analyze it thoroughly, make improvements, and create a PR or call noop.
+Save the improved file path to `cache-memory` for future runs.

--- a/.github/workflows/test-improver.md
+++ b/.github/workflows/test-improver.md
@@ -43,6 +43,7 @@ tools:
   edit:
   bash: true
 
+max-ai-credits: 2000
 timeout-minutes: 30
 strict: true
 ---

--- a/internal/config/guard_policy.go
+++ b/internal/config/guard_policy.go
@@ -31,7 +31,7 @@ func AllIntegrityLevels() []string {
 // is allowed and returns an empty string.
 func NormalizeIntegrityLevel(raw string, optional bool) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(raw))
-	logGuardPolicy.Printf("NormalizeIntegrityLevel: input=%q, normalized=%q, optional=%t", raw, normalized, optional)
+	logGuardPolicy.Printf("NormalizeIntegrityLevel: input=%q, normalized=%q, optional=%v", raw, normalized, optional)
 	if normalized == "" && optional {
 		return "", nil
 	}

--- a/internal/config/guard_policy.go
+++ b/internal/config/guard_policy.go
@@ -31,7 +31,7 @@ func AllIntegrityLevels() []string {
 // is allowed and returns an empty string.
 func NormalizeIntegrityLevel(raw string, optional bool) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(raw))
-	logGuardPolicy.Printf("NormalizeIntegrityLevel: input=%q, normalized=%q, optional=%v", raw, normalized, optional)
+	logGuardPolicy.Printf("NormalizeIntegrityLevel: input=%q, normalized=%q, optional=%t", raw, normalized, optional)
 	if normalized == "" && optional {
 		return "", nil
 	}


### PR DESCRIPTION
## Summary

Fixes #8252 — the Test Improver workflow hit the AI credits rate limit (used 2K of 1K max).

## Root Cause

Multiple factors drove up token consumption:
1. **Default budget too low** — `max-ai-credits: 2000` was barely enough for a workflow that analyzes, modifies, and verifies test files
2. **No DataOps** — the agent spent tokens discovering test files and checking for duplicate PRs
3. **Unconfigured tool references** — the prompt referenced "Serena" which isn't configured, causing the agent to waste tokens trying to use it
4. **Verbose prompt** — 340+ lines of instructions consumed significant input tokens on every turn
5. **Broad coverage analysis** — `go test ./...` instead of targeting the specific package
6. **Incorrect context** — prompt said "this project does NOT use testify" (it does), causing confusion

## Changes

| Change | Token Impact |
|--------|-------------|
| Increase `max-ai-credits` to 2500 | Prevents rate limit with headroom |
| Add DataOps steps (test file discovery + existing PR check) | Saves ~2-3 agent turns of file listing |
| Remove Serena references | Eliminates wasted tool-search turns |
| Trim prompt from ~340 → ~55 lines | ~70% reduction in per-turn input tokens |
| Scope coverage to specific package | Faster execution, less output to parse |
| Reduce stability runs from 5 → 3 | Saves bash execution time |
| Correct testify context | Eliminates go.mod check confusion |

## Validation

```
✓ .github/workflows/test-improver.md (88.7 KB)
⚠ Compiled 1 workflow(s): 0 error(s), 2 warning(s)
```

Warnings are informational (shell injection protection auto-applied, /tmp path advisory).