### PR TITLE
Replace deprecated `api_key` with `agent_id` in example config

### DIFF
--- a/config.example-payload-threshold.toml
+++ b/config.example-payload-threshold.toml
@@ -9,7 +9,7 @@
 
 [gateway]
 port = 3000
-api_key = "your-api-key-here"
+agent_id = ""
 
 # Payload directory for storing large tool responses
 # Must be an absolute path


### PR DESCRIPTION
## Summary

Replace the deprecated `api_key` field with `agent_id` in `config.example-payload-threshold.toml`.

## Problem

`config.example-payload-threshold.toml` uses the deprecated `api_key` field (`api_key = "your-api-key-here"`) on line 12. Users who copy this example as a starting point see deprecation warnings at runtime.

## Fix

Replace `api_key = "your-api-key-here"` with `agent_id = ""`, matching the pattern used in `config.example.toml`.

Fixes #8305