### PR TITLE
refactor: use NewLabeledResource constructor instead of inline struct literals

### DIFF
--- a/internal/guard/noop.go
+++ b/internal/guard/noop.go
@@ -35,7 +35,7 @@ func (g *NoopGuard) LabelAgent(ctx context.Context, policy interface{}, backend 
 func (g *NoopGuard) LabelResource(ctx context.Context, toolName string, args interface{}, backend BackendCaller, caps *difc.Capabilities) (*difc.LabeledResource, difc.OperationType, error) {
 	logNoop.Printf("Labeling resource: tool=%s, operation=read-write (conservative)", toolName)
 
-	// Empty resource = no label requirements = all operations allowed
+	// Empty labels = no label requirements = all operations allowed
 	resource := difc.NewLabeledResource("noop resource (no restrictions)")
 
 	logNoop.Printf("Resource labeled with no restrictions: tool=%s", toolName)

--- a/internal/guard/noop.go
+++ b/internal/guard/noop.go
@@ -36,12 +36,7 @@ func (g *NoopGuard) LabelResource(ctx context.Context, toolName string, args int
 	logNoop.Printf("Labeling resource: tool=%s, operation=read-write (conservative)", toolName)
 
 	// Empty resource = no label requirements = all operations allowed
-	resource := &difc.LabeledResource{
-		Description: "noop resource (no restrictions)",
-		Secrecy:     *difc.NewSecrecyLabel(),
-		Integrity:   *difc.NewIntegrityLabel(),
-		Structure:   nil, // No fine-grained labeling
-	}
+	resource := difc.NewLabeledResource("noop resource (no restrictions)")
 
 	logNoop.Printf("Resource labeled with no restrictions: tool=%s", toolName)
 

--- a/internal/guard/wasm_parse.go
+++ b/internal/guard/wasm_parse.go
@@ -439,7 +439,7 @@ func parseCollectionLabeledData(items []any) (*difc.CollectionLabeledData, error
 
 		// Parse labels
 		if labelsData, ok := itemMap["labels"].(map[string]any); ok {
-			labels := difc.NewLabeledResource("")
+			labels := &difc.LabeledResource{}
 			fillLabeledResourceFromMap(labelsData, labels)
 
 			labeledItem.Labels = labels

--- a/internal/guard/wasm_parse.go
+++ b/internal/guard/wasm_parse.go
@@ -400,7 +400,7 @@ func parseResourceResponse(response map[string]any) (*difc.LabeledResource, difc
 		return nil, difc.OperationWrite, fmt.Errorf("invalid resource format in guard response")
 	}
 
-	resource := &difc.LabeledResource{}
+	resource := difc.NewLabeledResource("")
 	fillLabeledResourceFromMap(resourceData, resource)
 
 	// Parse operation type
@@ -439,7 +439,7 @@ func parseCollectionLabeledData(items []any) (*difc.CollectionLabeledData, error
 
 		// Parse labels
 		if labelsData, ok := itemMap["labels"].(map[string]any); ok {
-			labels := &difc.LabeledResource{}
+			labels := difc.NewLabeledResource("")
 			fillLabeledResourceFromMap(labelsData, labels)
 
 			labeledItem.Labels = labels

--- a/internal/guard/wasm_parse.go
+++ b/internal/guard/wasm_parse.go
@@ -400,7 +400,7 @@ func parseResourceResponse(response map[string]any) (*difc.LabeledResource, difc
 		return nil, difc.OperationWrite, fmt.Errorf("invalid resource format in guard response")
 	}
 
-	resource := difc.NewLabeledResource("")
+	resource := &difc.LabeledResource{}
 	fillLabeledResourceFromMap(resourceData, resource)
 
 	// Parse operation type

--- a/internal/guard/write_sink.go
+++ b/internal/guard/write_sink.go
@@ -89,11 +89,8 @@ func (g *WriteSinkGuard) LabelResource(_ context.Context, toolName string, toolA
 	logWriteSink.Printf("LabelResource: tool=%s, operation=write, accept_tags=%d", toolName, len(g.acceptTags))
 	g.auditURLsInBody(toolName, toolArgs)
 
-	resource := &difc.LabeledResource{
-		Description: "write-sink (" + toolName + ")",
-		Secrecy:     *difc.NewSecrecyLabelWithTags(g.acceptTags),
-		Integrity:   *difc.NewIntegrityLabel(), // empty: no integrity requirements
-	}
+	resource := difc.NewLabeledResource("write-sink (" + toolName + ")")
+	resource.Secrecy = *difc.NewSecrecyLabelWithTags(g.acceptTags)
 
 	return resource, difc.OperationWrite, nil
 }


### PR DESCRIPTION
## Summary

Replace all inline `&difc.LabeledResource{}` constructions with calls to the canonical `difc.NewLabeledResource()` constructor, reducing code duplication and ensuring consistent initialization.

## Changes

| File | Change |
|------|--------|
| `internal/guard/noop.go` | Replace 5-line inline struct with `difc.NewLabeledResource("noop resource (no restrictions)")` |
| `internal/guard/wasm_parse.go` (line 403) | Replace `&difc.LabeledResource{}` with `difc.NewLabeledResource("")` before `fillLabeledResourceFromMap` |
| `internal/guard/wasm_parse.go` (line 442) | Same pattern as above for collection item labels |
| `internal/guard/write_sink.go` | Replace inline struct with `difc.NewLabeledResource(...)` then override `Secrecy` with custom tags |

## Rationale

`difc.NewLabeledResource()` already initializes `Description`, `Secrecy`, `Integrity`, and `Structure` with proper defaults. Bypassing it with inline struct literals duplicates that logic and risks inconsistency if the constructor defaults change.

For `write_sink.go`, the constructor is used for default initialization, then `Secrecy` is overridden with `NewSecrecyLabelWithTags` since that case requires custom accept tags.

For `wasm_parse.go`, the constructor defaults are immediately overwritten by `fillLabeledResourceFromMap`, but using the constructor ensures all fields start with valid defaults rather than zero values.

Fixes #8319