### PR TITLE
fix: deduplicate write paths in label_response

### DIFF
--- a/guards/github-guard/rust-guard/src/lib.rs
+++ b/guards/github-guard/rust-guard/src/lib.rs
@@ -973,7 +973,11 @@ pub extern "C" fn label_response(
         log_info(&format!("    path_output_preview={}", output_preview));
 
         let n = try_write_json_output(&output_json, output_ptr, output_size, "label_response/path");
-        return if n < 0 { 0 } else { n };
+        if n < 0 {
+            log_info("<<< label_response returning 0 (output write failed)");
+            return 0;
+        }
+        return n;
     }
 
     // Fall back to legacy item-based labeling for singletons

--- a/guards/github-guard/rust-guard/src/lib.rs
+++ b/guards/github-guard/rust-guard/src/lib.rs
@@ -972,24 +972,8 @@ pub extern "C" fn label_response(
         let output_preview = safe_preview(&output_json, PREVIEW_MAX_BYTES);
         log_info(&format!("    path_output_preview={}", output_preview));
 
-        if output_json.len() as u32 > output_size {
-            log_warn(&format!(
-                "    output buffer too small ({} > {})",
-                output_json.len(),
-                output_size
-            ));
-            log_info("<<< label_response returning 0 (buffer too small)");
-            return 0;
-        }
-
-        // Write output
-        unsafe { write_bytes_to_output(output_ptr, output_json.as_bytes()) };
-
-        log_info(&format!(
-            "<<< label_response returning {} bytes (path-based)",
-            output_json.len()
-        ));
-        return output_json.len() as i32;
+        let n = try_write_json_output(&output_json, output_ptr, output_size, "label_response/path");
+        return if n < 0 { 0 } else { n };
     }
 
     // Fall back to legacy item-based labeling for singletons
@@ -1034,24 +1018,8 @@ pub extern "C" fn label_response(
     let output_preview = safe_preview(&output_json, PREVIEW_MAX_BYTES);
     log_info(&format!("    output_preview={}", output_preview));
 
-    if output_json.len() as u32 > output_size {
-        log_warn(&format!(
-            "    output buffer too small ({} > {})",
-            output_json.len(),
-            output_size
-        ));
-        log_info("<<< label_response returning 0 (buffer too small)");
-        return 0;
-    }
-
-    // Write output
-    unsafe { write_bytes_to_output(output_ptr, output_json.as_bytes()) };
-
-    log_info(&format!(
-        "<<< label_response returning {} bytes",
-        output_json.len()
-    ));
-    output_json.len() as i32
+    let n = try_write_json_output(&output_json, output_ptr, output_size, "label_response/legacy");
+    if n < 0 { 0 } else { n }
 }
 
 // ============================================================================

--- a/guards/github-guard/rust-guard/src/lib.rs
+++ b/guards/github-guard/rust-guard/src/lib.rs
@@ -1023,7 +1023,12 @@ pub extern "C" fn label_response(
     log_info(&format!("    output_preview={}", output_preview));
 
     let n = try_write_json_output(&output_json, output_ptr, output_size, "label_response/legacy");
-    if n < 0 { 0 } else { n }
+    if n < 0 {
+        log_info("<<< label_response returning 0 (output write failed)");
+        0
+    } else {
+        n
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes #8328

## Summary

The `label_response` function in the Rust guard had two separate output-write branches (path-based labeling and legacy item-based fallback) that both manually reimplemented the same write pattern with unsafe `as u32` and `as i32` casts, buffer size checks, and `write_bytes_to_output` calls.

The `try_write_json_output` helper already exists and is used by `label_agent` and `label_resource`, but `label_response` was never updated to use it.

## Changes

Replaced both 8-line manual write blocks with calls to `try_write_json_output`:
- **Path-based branch** (~line 975): now uses `try_write_json_output(..., "label_response/path")`
- **Legacy item-based branch** (~line 1037): now uses `try_write_json_output(..., "label_response/legacy")`

This removes 36 lines of duplicated code (replaced with 4 lines) and eliminates the unsafe `as u32`/`as i32` casts in favor of the helper's safe `u32::try_from` conversion.