### PR TITLE
Extract shared HTTP response body read helpers to httputil package

### DIFF
--- a/internal/githubhttp/collaborator.go
+++ b/internal/githubhttp/collaborator.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+
+	"github.com/github/gh-aw-mcpg/internal/httputil"
 
 	"github.com/github/gh-aw-mcpg/internal/logger"
 	"github.com/github/gh-aw-mcpg/internal/strutil"
@@ -83,18 +84,12 @@ func FetchCollaboratorPermission(
 	if resp.Body == nil {
 		return nil, fmt.Errorf("failed to fetch response: response body is nil")
 	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
+	body, err := httputil.ReadResponseBody(resp, "GitHub API")
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		logCollab.Printf("FetchCollaboratorPermission: GitHub API error: owner=%s, repo=%s, username=%s, err=%v", owner, repo, username, err)
+		return nil, err
 	}
-
 	logCollab.Printf("FetchCollaboratorPermission: response received: status=%d, bodyLen=%d", resp.StatusCode, len(body))
-	if resp.StatusCode >= 400 {
-		logCollab.Printf("FetchCollaboratorPermission: GitHub API error: status=%d, owner=%s, repo=%s, username=%s", resp.StatusCode, owner, repo, username)
-		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
-	}
 
 	return LogAndWrapCollaboratorPermission(body, owner, repo, username, resp.StatusCode, logPrintf), nil
 }

--- a/internal/githubhttp/collaborator_test.go
+++ b/internal/githubhttp/collaborator_test.go
@@ -219,7 +219,7 @@ func TestFetchCollaboratorPermissionHelper(t *testing.T) {
 			func(format string, args ...interface{}) {},
 		)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "failed to read response")
+		assert.ErrorContains(t, err, "failed to read GitHub API response")
 	})
 
 	t.Run("returns status code errors", func(t *testing.T) {
@@ -237,7 +237,7 @@ func TestFetchCollaboratorPermissionHelper(t *testing.T) {
 			func(format string, args ...interface{}) {},
 		)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "GitHub API returned 404")
+		assert.ErrorContains(t, err, "GitHub API returned HTTP 404")
 	})
 
 	t.Run("returns error when fetch returns nil response without error", func(t *testing.T) {

--- a/internal/httputil/response.go
+++ b/internal/httputil/response.go
@@ -42,6 +42,12 @@ func ReadResponseBody(resp *http.Response, context string) ([]byte, error) {
 // Use this variant when the caller needs an exact status match (e.g. 200 only)
 // and wants the body included in the error message.
 func ReadResponseBodyStrict(resp *http.Response, expectedStatus int, context string) ([]byte, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("failed to read %s response: nil response", context)
+	}
+	if resp.Body == nil {
+		return nil, fmt.Errorf("failed to read %s response: response body is nil", context)
+	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/httputil/response.go
+++ b/internal/httputil/response.go
@@ -1,0 +1,51 @@
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ReadResponseBody reads the full body from an HTTP response, closes it, and
+// checks the status code. If the status code is >= 400, it returns an error
+// using the provided context string. The response body is always closed before
+// returning.
+//
+// This helper deduplicates the common pattern of defer Body.Close() + io.ReadAll
+// + status-code check that appears in proxy, githubhttp, and similar call sites.
+func ReadResponseBody(resp *http.Response, context string) ([]byte, error) {
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s response: %w", context, err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("%s returned HTTP %d", context, resp.StatusCode)
+	}
+
+	return body, nil
+}
+
+// ReadResponseBodyStrict reads the full body from an HTTP response, closes it,
+// and checks that the status code equals expectedStatus exactly. If the status
+// code does not match, it returns an error that includes the response body for
+// diagnostics. The response body is always closed before returning.
+//
+// Use this variant when the caller needs an exact status match (e.g. 200 only)
+// and wants the body included in the error message.
+func ReadResponseBodyStrict(resp *http.Response, expectedStatus int, context string) ([]byte, error) {
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s response: %w", context, err)
+	}
+
+	if resp.StatusCode != expectedStatus {
+		return nil, fmt.Errorf("%s returned HTTP %d: %s", context, resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}

--- a/internal/httputil/response.go
+++ b/internal/httputil/response.go
@@ -14,6 +14,12 @@ import (
 // This helper deduplicates the common pattern of defer Body.Close() + io.ReadAll
 // + status-code check that appears in proxy, githubhttp, and similar call sites.
 func ReadResponseBody(resp *http.Response, context string) ([]byte, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("failed to read %s response: nil response", context)
+	}
+	if resp.Body == nil {
+		return nil, fmt.Errorf("failed to read %s response: response body is nil", context)
+	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/httputil/response_test.go
+++ b/internal/httputil/response_test.go
@@ -1,0 +1,172 @@
+package httputil
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func TestReadResponseBody(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		wantBody  string
+		wantErr   string
+		wantNoErr bool
+	}{
+		{
+			name:      "success 200",
+			status:    http.StatusOK,
+			body:      `{"ok":true}`,
+			wantBody:  `{"ok":true}`,
+			wantNoErr: true,
+		},
+		{
+			name:      "success 201",
+			status:    http.StatusCreated,
+			body:      `created`,
+			wantBody:  `created`,
+			wantNoErr: true,
+		},
+		{
+			name:      "success 302 redirect",
+			status:    http.StatusFound,
+			body:      `redirect`,
+			wantBody:  `redirect`,
+			wantNoErr: true,
+		},
+		{
+			name:    "error 400",
+			status:  http.StatusBadRequest,
+			body:    `bad request`,
+			wantErr: "GitHub API returned HTTP 400",
+		},
+		{
+			name:    "error 404",
+			status:  http.StatusNotFound,
+			body:    `not found`,
+			wantErr: "GitHub API returned HTTP 404",
+		},
+		{
+			name:    "error 500",
+			status:  http.StatusInternalServerError,
+			body:    `server error`,
+			wantErr: "GitHub API returned HTTP 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := newResponse(tt.status, tt.body)
+			body, err := ReadResponseBody(resp, "GitHub API")
+
+			if tt.wantNoErr {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantBody, string(body))
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, body)
+			}
+		})
+	}
+}
+
+func TestReadResponseBody_ReadError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(&failReader{}),
+	}
+	body, err := ReadResponseBody(resp, "test")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read test response")
+	assert.Nil(t, body)
+}
+
+func TestReadResponseBodyStrict(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		expectedStatus int
+		body           string
+		wantBody       string
+		wantErr        string
+		wantNoErr      bool
+	}{
+		{
+			name:           "exact match 200",
+			status:         http.StatusOK,
+			expectedStatus: http.StatusOK,
+			body:           `{"token":"abc"}`,
+			wantBody:       `{"token":"abc"}`,
+			wantNoErr:      true,
+		},
+		{
+			name:           "exact match 201",
+			status:         http.StatusCreated,
+			expectedStatus: http.StatusCreated,
+			body:           `created`,
+			wantBody:       `created`,
+			wantNoErr:      true,
+		},
+		{
+			name:           "mismatch 201 vs 200",
+			status:         http.StatusCreated,
+			expectedStatus: http.StatusOK,
+			body:           `unexpected`,
+			wantErr:        "OIDC returned HTTP 201: unexpected",
+		},
+		{
+			name:           "error 403 includes body",
+			status:         http.StatusForbidden,
+			expectedStatus: http.StatusOK,
+			body:           `{"error":"forbidden"}`,
+			wantErr:        `OIDC returned HTTP 403: {"error":"forbidden"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := newResponse(tt.status, tt.body)
+			body, err := ReadResponseBodyStrict(resp, tt.expectedStatus, "OIDC")
+
+			if tt.wantNoErr {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantBody, string(body))
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Nil(t, body)
+			}
+		})
+	}
+}
+
+func TestReadResponseBodyStrict_ReadError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(&failReader{}),
+	}
+	body, err := ReadResponseBodyStrict(resp, http.StatusOK, "test")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read test response")
+	assert.Nil(t, body)
+}
+
+type failReader struct{}
+
+func (f *failReader) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}

--- a/internal/oidc/provider.go
+++ b/internal/oidc/provider.go
@@ -10,8 +10,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+
+	"github.com/github/gh-aw-mcpg/internal/httputil"
 	"net/url"
 	"strings"
 	"sync"
@@ -120,17 +121,11 @@ func (p *Provider) fetchToken(ctx context.Context, audience string) (string, tim
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("OIDC token request failed: %w", err)
 	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
+	body, err := httputil.ReadResponseBodyStrict(resp, http.StatusOK, "OIDC token request")
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("failed to read OIDC token response: %w", err)
+		return "", time.Time{}, err
 	}
-
 	logOIDC.Printf("OIDC token HTTP response: status=%d, bodyLen=%d", resp.StatusCode, len(body))
-	if resp.StatusCode != http.StatusOK {
-		return "", time.Time{}, fmt.Errorf("OIDC token request returned HTTP %d: %s", resp.StatusCode, string(body))
-	}
 
 	// Parse token value from response: {"value": "<jwt>"}
 	var tokenResp struct {

--- a/internal/oidc/provider_test.go
+++ b/internal/oidc/provider_test.go
@@ -443,5 +443,5 @@ func TestProvider_BodyReadError(t *testing.T) {
 	provider := oidc.NewProvider(server.URL, "test-token")
 	_, err := provider.Token(context.Background(), "https://example.com")
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "failed to read OIDC token response")
+	assert.ErrorContains(t, err, "failed to read OIDC token request response")
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -308,16 +308,10 @@ func (r *restBackendCaller) CallTool(ctx context.Context, toolName string, args 
 	if err != nil {
 		return nil, fmt.Errorf("REST call failed: %w", err)
 	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
+	body, err := httputil.ReadResponseBody(resp, "GitHub API")
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode >= 400 {
-		logProxy.Printf("restBackendCaller: %s returned %d", toolName, resp.StatusCode)
-		return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+		logProxy.Printf("restBackendCaller: %s returned error: %v", toolName, err)
+		return nil, err
 	}
 
 	// Wrap in MCP response format: {content: [{type: "text", text: "..."}]}


### PR DESCRIPTION
## Summary

Fixes #8320

Deduplicates the HTTP response body read + status check pattern that was independently implemented in three files.

## Changes

### New helpers (`internal/httputil/response.go`)

- **`ReadResponseBody(resp, context)`** — Reads the full body, closes it, and returns an error if status ≥ 400. Used by proxy and collaborator call sites.
- **`ReadResponseBodyStrict(resp, expectedStatus, context)`** — Reads the full body, closes it, and returns an error (including the body text) if the status doesn't match exactly. Used by the OIDC call site which checks `!= 200` and includes the body in error messages.

### Refactored call sites

| File | Before | After |
|------|--------|-------|
| `internal/proxy/proxy.go` | `defer Close` + `ReadAll` + `>= 400` check | `httputil.ReadResponseBody` |
| `internal/githubhttp/collaborator.go` | `defer Close` + `ReadAll` + `>= 400` check | `httputil.ReadResponseBody` |
| `internal/oidc/provider.go` | `defer Close` + `ReadAll` + `!= 200` check (body in error) | `httputil.ReadResponseBodyStrict` |

### Test updates

- Added comprehensive tests for both new helpers in `internal/httputil/response_test.go`
- Updated existing test assertions in `collaborator_test.go` and `provider_test.go` to match the slightly different error message format from the shared helpers