### PR TITLE
Replace raw fmt.Errorf with RequiredStringField and NonEmptyString validators

### DIFF
--- a/internal/config/config_core_test.go
+++ b/internal/config/config_core_test.go
@@ -277,7 +277,7 @@ args = ["run", "--rm", "-i", "ghcr.io/github/github-mcp-server:latest"]
 	cfg, err := LoadFromFile(path)
 	require.Error(t, err)
 	assert.Nil(t, cfg)
-	assert.ErrorContains(t, err, "empty tool name")
+	assert.ErrorContains(t, err, "tool name cannot be empty")
 }
 
 // TestLoadFromFile_ToolResponseFilter_InvalidJqExpression verifies that an
@@ -344,7 +344,7 @@ my_tool = "   "
 	cfg, err := LoadFromFile(path)
 	require.Error(t, err)
 	assert.Nil(t, cfg)
-	assert.ErrorContains(t, err, "must not be empty")
+	assert.ErrorContains(t, err, "cannot be empty")
 }
 
 // TestLoadFromFile_UnknownKeysDoNotCauseError verifies that unknown configuration

--- a/internal/config/guard_policy.go
+++ b/internal/config/guard_policy.go
@@ -251,8 +251,9 @@ func (p *AllowOnlyPolicy) UnmarshalJSON(data []byte) error {
 	if p.Repos == nil {
 		return fmt.Errorf("allow-only must include repos")
 	}
-	if strings.TrimSpace(p.MinIntegrity) == "" {
-		return fmt.Errorf("allow-only must include min-integrity")
+	if err := RequiredStringField(strings.TrimSpace(p.MinIntegrity), "min-integrity", "allow-only.min-integrity",
+		"Specify the minimum integrity level (one of: none, unapproved, approved, merged)"); err != nil {
+		return err
 	}
 
 	logGuardPolicy.Printf("UnmarshalJSON: allow-only policy parsed, repos=%T, minIntegrity=%s", p.Repos, p.MinIntegrity)

--- a/internal/config/guard_policy_coverage_test.go
+++ b/internal/config/guard_policy_coverage_test.go
@@ -33,7 +33,7 @@ func TestValidateWriteSinkPolicy_EmptyAcceptEntry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateWriteSinkPolicy(tt.policy)
 			require.Error(t, err)
-			assert.ErrorContains(t, err, "must not be empty")
+			assert.ErrorContains(t, err, "cannot be empty")
 		})
 	}
 }
@@ -55,7 +55,7 @@ func TestNormalizeGuardPolicy_StringSliceReposError(t *testing.T) {
 		{
 			name:        "empty scope string",
 			repos:       []string{""},
-			errContains: "must not be empty",
+			errContains: "cannot be empty",
 		},
 		{
 			name:        "duplicate scopes",
@@ -109,7 +109,7 @@ func TestNormalizeToolCallLimits_EmptyKey(t *testing.T) {
 
 			assert.Nil(t, result)
 			require.Error(t, err)
-			assert.ErrorContains(t, err, "keys must not be empty")
+			assert.ErrorContains(t, err, "cannot be empty")
 		})
 	}
 }

--- a/internal/config/guard_policy_parse.go
+++ b/internal/config/guard_policy_parse.go
@@ -148,8 +148,9 @@ func BuildAllowOnlyPolicy(public bool, owner, repo, minIntegrity string) (*Guard
 	if scopeCount != 1 {
 		return nil, fmt.Errorf("exactly one AllowOnly scope variant must be set (public or owner[/repo])")
 	}
-	if integrityInput == "" {
-		return nil, fmt.Errorf("min-integrity is required")
+	if err := RequiredStringField(integrityInput, "min-integrity", "allow-only.min-integrity",
+		"Specify the minimum integrity level (one of: none, unapproved, approved, merged)"); err != nil {
+		return nil, err
 	}
 	if !hasIntegrity {
 		return nil, fmt.Errorf("min-integrity must be one of: %s", strings.Join(allIntegrityLevels, ", "))

--- a/internal/config/guard_policy_test.go
+++ b/internal/config/guard_policy_test.go
@@ -306,7 +306,7 @@ func TestNormalizeGuardPolicyBlockedAndApproval(t *testing.T) {
 
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "blocked-users entries must not be empty")
+		assert.ErrorContains(t, err, "blocked-users cannot be empty")
 	})
 
 	t.Run("empty approval-labels string entry returns error", func(t *testing.T) {
@@ -318,7 +318,7 @@ func TestNormalizeGuardPolicyBlockedAndApproval(t *testing.T) {
 
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "approval-labels entries must not be empty")
+		assert.ErrorContains(t, err, "approval-labels cannot be empty")
 	})
 
 	t.Run("empty blocked-users slice results in nil normalized list", func(t *testing.T) {
@@ -368,7 +368,7 @@ func TestNormalizeGuardPolicyRefusalLabels(t *testing.T) {
 
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "refusal-labels entries must not be empty")
+		assert.ErrorContains(t, err, "refusal-labels cannot be empty")
 	})
 }
 
@@ -422,7 +422,7 @@ func TestNormalizeGuardPolicyTrustedUsers(t *testing.T) {
 
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "trusted-users entries must not be empty")
+		assert.ErrorContains(t, err, "trusted-users cannot be empty")
 	})
 
 	t.Run("empty trusted-users slice results in nil normalized list", func(t *testing.T) {
@@ -446,7 +446,7 @@ func TestNormalizeGuardPolicyTrustedUsers(t *testing.T) {
 
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "trusted-users entries must not be empty")
+		assert.ErrorContains(t, err, "trusted-users cannot be empty")
 	})
 }
 
@@ -582,12 +582,12 @@ func TestNormalizeAndValidateScopeArray(t *testing.T) {
 		{
 			name:    "empty string element",
 			scopes:  []interface{}{""},
-			wantErr: "allow-only.repos scope entries must not be empty",
+			wantErr: "repos cannot be empty",
 		},
 		{
 			name:    "whitespace-only element",
 			scopes:  []interface{}{"   "},
-			wantErr: "allow-only.repos scope entries must not be empty",
+			wantErr: "repos cannot be empty",
 		},
 		{
 			name:    "invalid scope pattern",
@@ -730,12 +730,12 @@ func TestAllowOnlyPolicyUnmarshalJSON(t *testing.T) {
 		{
 			name:    "missing min-integrity field",
 			json:    `{"repos":"all"}`,
-			wantErr: "allow-only must include min-integrity",
+			wantErr: "min-integrity is required",
 		},
 		{
 			name:    "whitespace-only min-integrity",
 			json:    `{"repos":"all","min-integrity":"   "}`,
-			wantErr: "allow-only must include min-integrity",
+			wantErr: "min-integrity is required",
 		},
 		{
 			name: "canonical min-integrity key",
@@ -1244,7 +1244,7 @@ func TestNormalizeGuardPolicyReactionEndorsement(t *testing.T) {
 		}}
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "endorsement-reactions entries must not be empty")
+		assert.ErrorContains(t, err, "endorsement-reactions cannot be empty")
 	})
 
 	t.Run("empty disapproval-reactions entry rejected", func(t *testing.T) {
@@ -1255,7 +1255,7 @@ func TestNormalizeGuardPolicyReactionEndorsement(t *testing.T) {
 		}}
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "disapproval-reactions entries must not be empty")
+		assert.ErrorContains(t, err, "disapproval-reactions cannot be empty")
 	})
 
 	t.Run("disapproval-reactions deduplication (case-insensitive)", func(t *testing.T) {

--- a/internal/config/guard_policy_unmarshal_coverage_test.go
+++ b/internal/config/guard_policy_unmarshal_coverage_test.go
@@ -125,7 +125,7 @@ func TestGuardPolicyUnmarshalJSON_InvalidInnerJSON(t *testing.T) {
 		{
 			name:    "allow-only inner value fails AllowOnlyPolicy unmarshal - missing min-integrity",
 			json:    `{"allow-only": {"repos":"all"}}`,
-			wantErr: "allow-only must include min-integrity",
+			wantErr: "min-integrity is required",
 		},
 	}
 
@@ -338,7 +338,7 @@ func TestNormalizeGuardPolicy_EndorsementReactionDedup(t *testing.T) {
 		}}
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "allow-only.endorsement-reactions entries must not be empty")
+		assert.ErrorContains(t, err, "endorsement-reactions cannot be empty")
 	})
 
 	t.Run("deduplicate disapproval-reactions case-insensitively", func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestNormalizeGuardPolicy_EndorsementReactionDedup(t *testing.T) {
 		}}
 		_, err := NormalizeGuardPolicy(policy)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "allow-only.disapproval-reactions entries must not be empty")
+		assert.ErrorContains(t, err, "disapproval-reactions cannot be empty")
 	})
 
 	t.Run("invalid disapproval-integrity rejected", func(t *testing.T) {

--- a/internal/config/guard_policy_validation.go
+++ b/internal/config/guard_policy_validation.go
@@ -43,8 +43,8 @@ func ValidateWriteSinkPolicy(ws *WriteSinkPolicy) error {
 	seen := make(map[string]struct{})
 	for _, entry := range ws.Accept {
 		entry = strings.TrimSpace(entry)
-		if entry == "" {
-			return fmt.Errorf("write-sink.accept entries must not be empty")
+		if err := NonEmptyString(entry, "accept", "write-sink.accept"); err != nil {
+			return err
 		}
 		if entry == "*" {
 			return fmt.Errorf("write-sink.accept wildcard \"*\" must be the only entry")
@@ -228,8 +228,8 @@ func normalizeAndValidateScopeArray(scopes []interface{}) ([]string, error) {
 		}
 
 		scopeString = strings.TrimSpace(scopeString)
-		if scopeString == "" {
-			return nil, fmt.Errorf("allow-only.repos scope entries must not be empty")
+		if err := NonEmptyString(scopeString, "repos", "allow-only.repos"); err != nil {
+			return nil, err
 		}
 
 		if !isValidRepoScope(scopeString) {
@@ -330,8 +330,8 @@ func normalizeStringSlice(field string, input []string, caseNorm func(string) st
 	out := make([]string, 0, len(input))
 	for _, v := range input {
 		v = strings.TrimSpace(v)
-		if v == "" {
-			return nil, fmt.Errorf("allow-only.%s entries must not be empty", field)
+		if err := NonEmptyString(v, field, "allow-only."+field); err != nil {
+			return nil, err
 		}
 		key := caseNorm(v)
 		if _, exists := seen[key]; !exists {
@@ -390,8 +390,8 @@ func normalizeToolCallLimits(input map[string]int) (map[string]int, error) {
 	out := make(map[string]int, len(input))
 	for toolName, limit := range input {
 		toolName = strings.TrimSpace(toolName)
-		if toolName == "" {
-			return nil, fmt.Errorf("allow-only.tool-call-limits keys must not be empty")
+		if err := NonEmptyString(toolName, "tool-call-limits key", "allow-only.tool-call-limits"); err != nil {
+			return nil, err
 		}
 		if limit < 0 {
 			return nil, fmt.Errorf("allow-only.tool-call-limits[%q] must be >= 0", toolName)

--- a/internal/config/validate_helpers_coverage_test.go
+++ b/internal/config/validate_helpers_coverage_test.go
@@ -55,7 +55,7 @@ func TestValidateToolResponseFilters_DirectCall(t *testing.T) {
 			},
 			jsonPath:  "mcpServers.myserver.tool_response_filters",
 			wantErr:   true,
-			errSubstr: "mcpServers.myserver.tool_response_filters contains an empty tool name",
+			errSubstr: "tool name cannot be empty",
 		},
 		{
 			name: "whitespace-only tool name key returns error",
@@ -64,7 +64,7 @@ func TestValidateToolResponseFilters_DirectCall(t *testing.T) {
 			},
 			jsonPath:  "mcpServers.myserver.tool_response_filters",
 			wantErr:   true,
-			errSubstr: "contains an empty tool name",
+			errSubstr: "tool name cannot be empty",
 		},
 		{
 			name: "empty filter value returns error",
@@ -73,7 +73,7 @@ func TestValidateToolResponseFilters_DirectCall(t *testing.T) {
 			},
 			jsonPath:  "mcpServers.myserver.tool_response_filters",
 			wantErr:   true,
-			errSubstr: "must not be empty",
+			errSubstr: "cannot be empty",
 		},
 		{
 			name: "whitespace-only filter value returns error",
@@ -82,7 +82,7 @@ func TestValidateToolResponseFilters_DirectCall(t *testing.T) {
 			},
 			jsonPath:  "mcpServers.myserver.tool_response_filters",
 			wantErr:   true,
-			errSubstr: "must not be empty",
+			errSubstr: "cannot be empty",
 		},
 		{
 			name: "invalid jq expression returns error",
@@ -100,7 +100,7 @@ func TestValidateToolResponseFilters_DirectCall(t *testing.T) {
 			},
 			jsonPath:  "custom.path",
 			wantErr:   true,
-			errSubstr: "custom.path contains an empty tool name",
+			errSubstr: "tool name cannot be empty",
 		},
 		{
 			// $ENV.KEY is valid jq syntax and compiles successfully, but it triggers the

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -140,7 +140,7 @@ func validateToolResponseFiltersWithVars(filters map[string]string, jsonPath str
 			return err
 		}
 		filter := strings.TrimSpace(rawFilter)
-		if err := NonEmptyString(filter, toolName, jsonPath+"."+toolName); err != nil {
+		if err := NonEmptyString(filter, "tool response filter", jsonPath+"."+toolName); err != nil {
 			return err
 		}
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -136,12 +136,12 @@ func validateToolResponseFiltersWithVars(filters map[string]string, jsonPath str
 	}
 
 	for toolName, rawFilter := range filters {
-		if strings.TrimSpace(toolName) == "" {
-			return fmt.Errorf("%s contains an empty tool name", jsonPath)
+		if err := NonEmptyString(strings.TrimSpace(toolName), "tool name", jsonPath); err != nil {
+			return err
 		}
 		filter := strings.TrimSpace(rawFilter)
-		if filter == "" {
-			return fmt.Errorf("%s.%s must not be empty", jsonPath, toolName)
+		if err := NonEmptyString(filter, toolName, jsonPath+"."+toolName); err != nil {
+			return err
 		}
 
 		query, err := gojq.Parse(filter)

--- a/internal/config/validation_rules.go
+++ b/internal/config/validation_rules.go
@@ -166,6 +166,23 @@ func MountFormat(mount, jsonPath string, index int) *ValidationError {
 	return nil
 }
 
+// RequiredStringField validates that a required string field is not empty.
+// It returns a *ValidationError with structured context (Field, JSONPath,
+// Suggestion) so that callers get consistent, machine-readable validation
+// errors instead of plain fmt.Errorf strings.
+// Returns nil if the value is non-empty.
+func RequiredStringField(value, fieldName, jsonPath, suggestion string) *ValidationError {
+	if value == "" {
+		return &ValidationError{
+			Field:      fieldName,
+			Message:    fmt.Sprintf("%s is required", fieldName),
+			JSONPath:   jsonPath,
+			Suggestion: suggestion,
+		}
+	}
+	return nil
+}
+
 // NonEmptyString validates that a string field is not empty (minLength: 1)
 // Returns nil if valid, *ValidationError if invalid
 func NonEmptyString(value, fieldName, jsonPath string) *ValidationError {

--- a/internal/config/validation_rules_test.go
+++ b/internal/config/validation_rules_test.go
@@ -911,6 +911,70 @@ func TestSchemaValidationError(t *testing.T) {
 	}
 }
 
+func TestRequiredStringField(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      string
+		fieldName  string
+		jsonPath   string
+		suggestion string
+		shouldErr  bool
+		errMsg     string
+	}{
+		{
+			name:       "valid non-empty string",
+			value:      "approved",
+			fieldName:  "min-integrity",
+			jsonPath:   "allow-only.min-integrity",
+			suggestion: "Specify the minimum integrity level",
+			shouldErr:  false,
+		},
+		{
+			name:       "empty string returns error",
+			value:      "",
+			fieldName:  "min-integrity",
+			jsonPath:   "allow-only.min-integrity",
+			suggestion: "Specify the minimum integrity level",
+			shouldErr:  true,
+			errMsg:     "min-integrity is required",
+		},
+		{
+			name:       "custom field name in error",
+			value:      "",
+			fieldName:  "container",
+			jsonPath:   "mcpServers.github.container",
+			suggestion: "Add a container image",
+			shouldErr:  true,
+			errMsg:     "container is required",
+		},
+		{
+			name:       "suggestion included in error",
+			value:      "",
+			fieldName:  "url",
+			jsonPath:   "mcpServers.http-server.url",
+			suggestion: "Provide an HTTPS URL",
+			shouldErr:  true,
+			errMsg:     "Provide an HTTPS URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RequiredStringField(tt.value, tt.fieldName, tt.jsonPath, tt.suggestion)
+
+			if tt.shouldErr {
+				require.NotNil(t, err, "Expected validation error but got none")
+				assert.ErrorContains(t, err, tt.errMsg)
+				assert.ErrorContains(t, err, tt.jsonPath)
+				assert.Equal(t, tt.fieldName, err.Field)
+				assert.Equal(t, tt.suggestion, err.Suggestion)
+			} else {
+				require.NoError(t, validationErrAsError(err), "Unexpected validation error")
+			}
+		})
+	}
+}
+
 func TestNonEmptyString(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -1220,7 +1220,7 @@ func TestValidateToolResponseFilters(t *testing.T) {
 				},
 			},
 			shouldErr: true,
-			errMsg:    "must not be empty",
+			errMsg:    "cannot be empty",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #8321

Adds a `RequiredStringField` helper to `validation_rules.go` that returns `*ValidationError` with structured context (Field, JSONPath, Suggestion) instead of plain `fmt.Errorf` error strings. Replaces raw `if field == "" { return fmt.Errorf(...) }` patterns with calls to `RequiredStringField` and the existing `NonEmptyString` validator across the config package.

## Changes

### New function: `RequiredStringField`
- Added to `internal/config/validation_rules.go`
- Signature: `RequiredStringField(value, fieldName, jsonPath, suggestion string) *ValidationError`
- Returns `nil` if value is non-empty, structured `*ValidationError` if empty
- Includes comprehensive unit tests

### Call sites converted

**`guard_policy.go`** — min-integrity check in `AllowOnlyPolicy.UnmarshalJSON`
**`guard_policy_parse.go`** — min-integrity check in `BuildAllowOnlyPolicy`
**`guard_policy_validation.go`** — 4 empty-entry checks:
  - `write-sink.accept` entries
  - `allow-only.repos` scope entries
  - `normalizeStringSlice` entries (blocked-users, refusal-labels, approval-labels, trusted-users, endorsement-reactions, disapproval-reactions)
  - `tool-call-limits` keys

**`validation.go`** — tool response filter empty name/value checks

### Tests updated
All affected test assertions updated to match the new structured error message format from `ValidationError.Error()`. All existing tests pass.

## Verification

`make agent-finished` passes (format, build, lint, all tests including Rust guard).