### PR TITLE
Upgrade gh-aw to v0.82.2 pre-release and recompile workflows

### DIFF
--- a/.github/skills/agentic-workflows/SKILL.md
+++ b/.github/skills/agentic-workflows/SKILL.md
@@ -23,6 +23,7 @@ Load these files from `github/gh-aw` (they are not available locally).
 - `.github/aw/charts.md`
 - `.github/aw/cli-commands.md`
 - `.github/aw/context.md`
+- `.github/aw/create-agentic-workflow-trigger-details.md`
 - `.github/aw/create-agentic-workflow.md`
 - `.github/aw/create-shared-agentic-workflow.md`
 - `.github/aw/debug-agentic-workflow.md`


### PR DESCRIPTION
Updated dispatcher skill to include new create-agentic-workflow-trigger-details.md reference. All workflows recompiled successfully.