### PR TITLE
fix: make force-public-repos decisions observable and fix flaky tests

### DIFF
--- a/internal/cmd/proxy.go
+++ b/internal/cmd/proxy.go
@@ -382,7 +382,7 @@ func clientAddr(addr string) string {
 //   - The repository is not public
 func proxyForcePublicReposIfNeeded(ctx context.Context, policyJSON, token, apiURL string) string {
 	if !proxyForcePublicRepo {
-		logger.LogInfo("difc", "forcePublicRepos: disabled by flag")
+		logger.LogInfo("difc", "forcePublicRepos: disabled")
 		return policyJSON
 	}
 

--- a/internal/cmd/proxy.go
+++ b/internal/cmd/proxy.go
@@ -382,13 +382,13 @@ func clientAddr(addr string) string {
 //   - The repository is not public
 func proxyForcePublicReposIfNeeded(ctx context.Context, policyJSON, token, apiURL string) string {
 	if !proxyForcePublicRepo {
-		logProxyCmd.Print("forcePublicRepos: disabled by flag")
+		logger.LogInfo("difc", "forcePublicRepos: disabled by flag")
 		return policyJSON
 	}
 
 	nwo := os.Getenv("GITHUB_REPOSITORY")
 	if nwo == "" {
-		logProxyCmd.Print("forcePublicRepos: GITHUB_REPOSITORY not set — skipping")
+		logger.LogInfo("difc", "forcePublicRepos: GITHUB_REPOSITORY not set — skipping")
 		return policyJSON
 	}
 
@@ -397,7 +397,7 @@ func proxyForcePublicReposIfNeeded(ctx context.Context, policyJSON, token, apiUR
 		authToken = envutil.LookupGitHubToken()
 	}
 	if authToken == "" {
-		logProxyCmd.Print("forcePublicRepos: no GitHub token available — skipping")
+		logger.LogInfo("difc", "forcePublicRepos: no GitHub token available — skipping")
 		return policyJSON
 	}
 
@@ -408,7 +408,7 @@ func proxyForcePublicReposIfNeeded(ctx context.Context, policyJSON, token, apiUR
 	}
 
 	if vis != githubhttp.RepoVisibilityPublic {
-		logProxyCmd.Printf("forcePublicRepos: repo %s is %s — no override needed", nwo, vis)
+		logger.LogInfo("difc", "forcePublicRepos: repo %s is %s — no override needed", nwo, vis)
 		return policyJSON
 	}
 

--- a/test/integration/proxy_force_public_repos_test.go
+++ b/test/integration/proxy_force_public_repos_test.go
@@ -69,10 +69,10 @@ func startProxyWithEnv(t *testing.T, policyJSON string, port string, extraArgs [
 	return env
 }
 
-// readLogs reads the proxy's mcp-gateway.log for assertion.
+// readLogs reads the proxy's proxy.log for assertion.
 func (e *proxyTestEnv) readLogs(t *testing.T) string {
 	t.Helper()
-	logPath := e.logDir + "/mcp-gateway.log"
+	logPath := e.logDir + "/proxy.log"
 	data, err := os.ReadFile(logPath)
 	if err != nil {
 		return ""
@@ -168,8 +168,8 @@ func TestProxyForcePublicRepos_FlagDisabled(t *testing.T) {
 	// Verify logs show the flag disabled the override
 	t.Run("LogShowsDisabled", func(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
-		stderr := env.stderr.String()
-		assert.Contains(t, stderr, "forcePublicRepos: disabled by flag",
+		combined := env.readLogs(t) + env.stderr.String()
+		assert.Contains(t, combined, "forcePublicRepos: disabled by flag",
 			"Should log that force-public-repos was disabled")
 	})
 }
@@ -201,8 +201,8 @@ func TestProxyForcePublicRepos_EnvVarDisabled(t *testing.T) {
 
 	t.Run("LogShowsDisabled", func(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
-		stderr := env.stderr.String()
-		assert.Contains(t, stderr, "forcePublicRepos: disabled by flag",
+		combined := env.readLogs(t) + env.stderr.String()
+		assert.Contains(t, combined, "forcePublicRepos: disabled by flag",
 			"Should log that force-public-repos was disabled by env var default")
 	})
 }
@@ -269,7 +269,9 @@ func TestProxyForcePublicRepos_NoGithubRepo(t *testing.T) {
 
 	// Verify logs show skipped check
 	time.Sleep(500 * time.Millisecond)
-	assert.Contains(t, stderr.String(), "GITHUB_REPOSITORY not set",
+	logData, _ := os.ReadFile(logDir + "/proxy.log")
+	combined := string(logData) + stderr.String()
+	assert.Contains(t, combined, "GITHUB_REPOSITORY not set",
 		"Should log that GITHUB_REPOSITORY is not set")
 }
 
@@ -279,17 +281,28 @@ func TestProxyForcePublicRepos_NoGithubRepo(t *testing.T) {
 
 // TestProxyForcePublicRepos_PrivateRepo verifies that when
 // GITHUB_REPOSITORY identifies a private repo, no override is applied.
+//
+// It points the proxy at a mock GitHub API that reports the repository as
+// private. This keeps the test deterministic and independent of the live
+// visibility of any real repository (the CI token is typically scoped to a
+// single public repo, so a real private repo is not reliably reachable).
 func TestProxyForcePublicRepos_PrivateRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping proxy integration test in short mode")
 	}
 
-	// Use a private repo that the token has access to (github/gh-aw-mcpg)
+	// Mock GitHub API that reports the repo as private for the visibility check
+	// and returns 200 for proxied read requests.
+	mockAPI := startMockGitHubAPI(t, "private", true)
+	defer mockAPI.Close()
+
+	// Policy allows the repo by name — a read should be permitted.
 	policy := `{"allow-only":{"repos":["github/gh-aw-mcpg"],"min-integrity":"none"}}`
 
-	env := startProxyWithEnv(t, policy, "18924", nil, []string{
-		"GITHUB_REPOSITORY=github/gh-aw-mcpg",
-	})
+	env := startProxyWithEnv(t, policy, "18924",
+		[]string{"--github-api-url", mockAPI.URL},
+		[]string{"GITHUB_REPOSITORY=github/gh-aw-mcpg"},
+	)
 	defer env.stop(t)
 
 	t.Run("PrivateRepo_Allowed", func(t *testing.T) {

--- a/test/integration/proxy_force_public_repos_test.go
+++ b/test/integration/proxy_force_public_repos_test.go
@@ -74,9 +74,7 @@ func (e *proxyTestEnv) readLogs(t *testing.T) string {
 	t.Helper()
 	logPath := e.logDir + "/proxy.log"
 	data, err := os.ReadFile(logPath)
-	if err != nil {
-		return ""
-	}
+	require.NoError(t, err, "Failed to read %s", logPath)
 	return string(data)
 }
 
@@ -169,7 +167,7 @@ func TestProxyForcePublicRepos_FlagDisabled(t *testing.T) {
 	t.Run("LogShowsDisabled", func(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
 		combined := env.readLogs(t) + env.stderr.String()
-		assert.Contains(t, combined, "forcePublicRepos: disabled by flag",
+		assert.Contains(t, combined, "forcePublicRepos: disabled",
 			"Should log that force-public-repos was disabled")
 	})
 }
@@ -202,7 +200,7 @@ func TestProxyForcePublicRepos_EnvVarDisabled(t *testing.T) {
 	t.Run("LogShowsDisabled", func(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
 		combined := env.readLogs(t) + env.stderr.String()
-		assert.Contains(t, combined, "forcePublicRepos: disabled by flag",
+		assert.Contains(t, combined, "forcePublicRepos: disabled",
 			"Should log that force-public-repos was disabled by env var default")
 	})
 }
@@ -269,7 +267,8 @@ func TestProxyForcePublicRepos_NoGithubRepo(t *testing.T) {
 
 	// Verify logs show skipped check
 	time.Sleep(500 * time.Millisecond)
-	logData, _ := os.ReadFile(logDir + "/proxy.log")
+	logData, err := os.ReadFile(logDir + "/proxy.log")
+	require.NoError(t, err, "Failed to read %s", logDir+"/proxy.log")
 	combined := string(logData) + stderr.String()
 	assert.Contains(t, combined, "GITHUB_REPOSITORY not set",
 		"Should log that GITHUB_REPOSITORY is not set")


### PR DESCRIPTION
## Summary

Running `make agent-finished` on `main` fails four `TestProxyForcePublicRepos_*` integration tests. This PR fixes them (and a fifth latent failure that surfaced once the log-source bug was fixed).

## Root causes

1. **Wrong log file.** In proxy mode the unified log is written to `proxy.log`, but the tests read `mcp-gateway.log` (used only by gateway mode). `readLogs` always returned `""`.
2. **Debug-only logging.** The force-public-repos skip/decision messages (`disabled by flag`, `GITHUB_REPOSITORY not set`, `no override needed`) were emitted through the debug logger (`logProxyCmd`), which only writes when `DEBUG` matches the namespace — so they never appeared without `DEBUG`.
3. **Outdated test premise.** `TestProxyForcePublicRepos_PrivateRepo` assumed `github/gh-aw-mcpg` is private. It is now **public**, so the override correctly fires. The test only passed before because it read the empty, wrong log file.

## Changes

- `internal/cmd/proxy.go`: elevate the force-public-repos decision messages from the debug logger to operational logging (`logger.LogInfo`, category `difc`), so these security-relevant decisions are always recorded in `proxy.log` — consistent with the existing `FORCED REPOS=PUBLIC` warning.
- `test/integration/proxy_force_public_repos_test.go`:
  - Read `proxy.log` instead of `mcp-gateway.log`; assert against combined file+stderr output.
  - Rewrite the private-repo test to point the proxy at a mock GitHub API reporting private visibility, making it deterministic and independent of any real repo's live visibility.

## Verification

- `make agent-finished` → all checks pass (Go tests + 576 Rust guard tests)
- `make test-container-proxy` → PASS
- `go test ./test/integration -run TestProxyForcePublicRepos` → all 5 tests pass
