### PR TITLE
Upgrade gh-aw extension to latest pre-release and recompile workflows

### DIFF
--- a/.github/skills/agentic-workflows/SKILL.md
+++ b/.github/skills/agentic-workflows/SKILL.md
@@ -29,6 +29,7 @@ Load these files from `github/gh-aw` (they are not available locally).
 - `.github/aw/debug-agentic-workflow.md`
 - `.github/aw/dependabot.md`
 - `.github/aw/deployment-status.md`
+- `.github/aw/designer.md`
 - `.github/aw/experiments.md`
 - `.github/aw/github-agentic-workflows.md`
 - `.github/aw/github-mcp-server.md`


### PR DESCRIPTION
## Summary

Runs `gh aw upgrade --pre-releases` to pick up the latest pre-release of the gh-aw extension and recompiles all workflows.

## Changes

- **`.github/skills/agentic-workflows/SKILL.md`**: Added new `designer.md` skill reference

All 34 workflows were recompiled successfully with no other changes needed.