### PR TITLE
Make reconnect-retry HTTP transport test shutdown deterministic

### DIFF
--- a/internal/mcp/http_transport_test.go
+++ b/internal/mcp/http_transport_test.go
@@ -1830,11 +1830,6 @@ func newPlainJSONInitServer(t *testing.T) *httptest.Server {
 // response triggers a reconnect that succeeds, but the subsequent retry request itself fails
 // (e.g. server becomes unavailable after reconnect), sendHTTPRequest returns the retry error.
 func TestSendHTTPRequest_ReconnectSucceedsButRetryFails(t *testing.T) {
-	// closeAfterReconnect is closed once the reconnect initialize has been served.
-	// This allows us to close the listener immediately afterwards so the retry
-	// tools/list request hits a dead server.
-	closeAfterReconnect := make(chan struct{})
-
 	var mu sync.Mutex
 	initCount := 0
 	var srv *httptest.Server
@@ -1853,6 +1848,16 @@ func TestSendHTTPRequest_ReconnectSucceedsButRetryFails(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Mcp-Session-Id", fmt.Sprintf("session-%d", current))
+			if current >= 2 {
+				// On the reconnect initialize, deterministically tear down the
+				// server before the retry can be issued: force the current
+				// keep-alive connection closed and synchronously close the
+				// listener so the retry tools/list request cannot reconnect.
+				// (srv.Close() itself would block on the in-flight connection,
+				// so we close only the listener here and defer full cleanup.)
+				w.Header().Set("Connection", "close")
+				srv.Listener.Close() //nolint:errcheck
+			}
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
 				"jsonrpc": "2.0",
@@ -1862,16 +1867,6 @@ func TestSendHTTPRequest_ReconnectSucceedsButRetryFails(t *testing.T) {
 					"serverInfo":      map[string]interface{}{"name": "test"},
 				},
 			})
-			if current >= 2 {
-				// The reconnect initialize is complete; signal to close the server
-				// so the subsequent retry tools/list request cannot connect.
-				select {
-				case <-closeAfterReconnect:
-				default:
-					close(closeAfterReconnect)
-					go srv.Close()
-				}
-			}
 
 		case "tools/list":
 			// Always return session-not-found to trigger reconnect.
@@ -1880,6 +1875,7 @@ func TestSendHTTPRequest_ReconnectSucceedsButRetryFails(t *testing.T) {
 			fmt.Fprint(w, "session not found")
 		}
 	}))
+	defer srv.Close()
 
 	conn := newPlainJSONConn(t, srv.URL, map[string]string{"Authorization": "test-token"})
 	require.NotNil(t, conn)


### PR DESCRIPTION
## Summary

Addresses the review feedback on #9667 (which was merged before the feedback could be applied).

The Copilot reviewer flagged `TestSendHTTPRequest_ReconnectSucceedsButRetryFails` in `internal/mcp/http_transport_test.go` as racy:

> This shutdown is racy: starting `srv.Close()` in a goroutine does not guarantee that the listener/current keep-alive connection is closed before `sendHTTPRequest` issues its retry. The retry can therefore reach the handler, receive another 404, and make `require.Error` fail intermittently.

## Fix

Following the reviewer's suggestion, the teardown is now deterministic. On the reconnect (second) `initialize` response the handler:

- Sets `Connection: close` so the client cannot reuse the keep-alive connection for the retry.
- Synchronously closes `srv.Listener` before returning so the retry `tools/list` request cannot reconnect.

`srv.Close()` itself can't be called synchronously inside the handler (it blocks on the in-flight connection), so only the listener is closed inline and full server cleanup is deferred. The now-unused `closeAfterReconnect` channel and the `go srv.Close()` goroutine are removed.

## Verification

- Target test passes 50× (`-count=50`) and 20× under `-race`.
- `make agent-finished` passes (format, build, lint, all Go tests, Rust guard tests).
- Both SDK canary tests still pass.