### PR TITLE
Add dockerless Podman mode

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -127,6 +127,20 @@ Run `./awmg --help` for full CLI options. Selected frequently-used flags (run `.
   - Can be overridden by environment variable `MCP_GATEWAY_CONTAINER_RUNTIME`
   - If `MCP_GATEWAY_CONTAINER_RUNTIME` is set to an unsupported value, it is ignored and the configured/default runtime is used
 
+- **`gateway.dockerless`** (optional, JSON stdin only): Run containerized stdio MCP servers with Podman without requiring Docker
+  - Defaults to `false`
+  - When `true`, Podman takes precedence over `MCP_GATEWAY_CONTAINER_RUNTIME`
+  - `gateway.containerRuntime`, when also set, must be `"podman"`
+  - `gateway.containerRuntimeCommand`, when also set, must point to a `podman` executable
+
+```json
+{
+  "gateway": {
+    "dockerless": true
+  }
+}
+```
+
 - **`gateway.containerRuntimeCommand`** (optional): Override runtime binary/path (for example, `"/usr/bin/podman"` or `"nerdctl"`)
 
 - **`gateway.containerRuntimeArgs`** (optional): Additional runtime-level args inserted before `run` for JSON stdin `container` launches

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -185,17 +185,6 @@ func run(cmd *cobra.Command, args []string) error {
 	defer cleanupWasmCache()
 	logger.StartupInfo("WASM compilation cache directory: %s", resolvedWasmCacheDir)
 
-	// Validate execution environment if requested
-	if validateEnv {
-		debugLog.Printf("Validating execution environment...")
-		result := config.ValidateExecutionEnvironment()
-		if !result.IsValid() {
-			logger.LogErrorToMarkdown("startup", "Environment validation failed: %s", result.Error())
-			return fmt.Errorf("environment validation failed: %s", result.Error())
-		}
-		logger.StartupInfo("Environment validation passed")
-	}
-
 	// Load configuration
 	var cfg *config.Config
 	var err error
@@ -216,6 +205,18 @@ func run(cmd *cobra.Command, args []string) error {
 
 	debugLog.Printf("Configuration loaded with %d servers", len(cfg.Servers))
 	log.Printf("Loaded %d MCP server(s)", len(cfg.Servers))
+
+	// Validate after loading configuration so dockerless mode can select Podman.
+	if validateEnv {
+		runtimeCommand := config.EffectiveContainerRuntimeCommand(cfg.Gateway)
+		debugLog.Printf("Validating execution environment with container runtime %s...", runtimeCommand)
+		result := config.ValidateExecutionEnvironmentForRuntime(runtimeCommand)
+		if !result.IsValid() {
+			logger.LogErrorToMarkdown("startup", "Environment validation failed: %s", result.Error())
+			return fmt.Errorf("environment validation failed: %s", result.Error())
+		}
+		logger.StartupInfo("Environment validation passed")
+	}
 
 	// Log server names to markdown
 	serverNames := make([]string, 0, len(cfg.Servers))

--- a/internal/config/config_core.go
+++ b/internal/config/config_core.go
@@ -117,6 +117,10 @@ type GatewayConfig struct {
 	// ToolTimeout is the maximum time (seconds) to wait for tool execution
 	ToolTimeout int `toml:"tool_timeout" json:"tool_timeout,omitempty"`
 
+	// Dockerless forces Podman for stdin JSON container launches.
+	// It is intentionally unavailable in TOML configuration.
+	Dockerless bool `toml:"-" json:"dockerless,omitempty"`
+
 	// ContainerRuntime selects the container runtime used for stdio MCP server launches
 	// in stdin JSON configurations that specify a container image.
 	// Supported values: "docker" (default), "podman".

--- a/internal/config/config_stdin.go
+++ b/internal/config/config_stdin.go
@@ -40,6 +40,7 @@ type StdinGatewayConfig struct {
 	Domain                      string                    `json:"domain,omitempty"`
 	StartupTimeout              *int                      `json:"startupTimeout,omitempty"`
 	ToolTimeout                 *int                      `json:"toolTimeout,omitempty"`
+	Dockerless                  bool                      `json:"dockerless,omitempty"`
 	ContainerRuntime            string                    `json:"containerRuntime,omitempty"`
 	ContainerRuntimeCommand     string                    `json:"containerRuntimeCommand,omitempty"`
 	ContainerRuntimeArgs        []string                  `json:"containerRuntimeArgs,omitempty"`
@@ -411,6 +412,7 @@ func convertStdinConfig(stdinCfg *StdinConfig) (*Config, error) {
 			APIKey:                  stdinCfg.Gateway.APIKey,
 			Domain:                  stdinCfg.Gateway.Domain,
 			StartupTimeout:          intPtrOrDefault(stdinCfg.Gateway.StartupTimeout, DefaultStartupTimeout),
+			Dockerless:              stdinCfg.Gateway.Dockerless,
 			ContainerRuntime:        stdinCfg.Gateway.ContainerRuntime,
 			ContainerRuntimeCommand: stdinCfg.Gateway.ContainerRuntimeCommand,
 			ContainerRuntimeArgs:    append([]string{}, stdinCfg.Gateway.ContainerRuntimeArgs...),

--- a/internal/config/config_stdin_test.go
+++ b/internal/config/config_stdin_test.go
@@ -119,6 +119,39 @@ func TestConvertStdinServerConfig_MinimalStdioServer(t *testing.T) {
 }
 
 func TestConvertStdinConfig_ContainerRuntimeSelection(t *testing.T) {
+	t.Run("dockerless mode defaults to podman", func(t *testing.T) {
+		stdinCfg := &StdinConfig{
+			MCPServers: map[string]*StdinServerConfig{
+				"test": {Type: "stdio", Container: "ghcr.io/example/server:latest"},
+			},
+			Gateway: &StdinGatewayConfig{
+				Dockerless: true,
+			},
+		}
+
+		cfg, err := convertStdinConfig(stdinCfg)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Servers["test"])
+		assert.True(t, cfg.Gateway.Dockerless)
+		assert.Equal(t, "podman", cfg.Servers["test"].Command)
+	})
+
+	t.Run("dockerless mode takes precedence over runtime environment override", func(t *testing.T) {
+		t.Setenv("MCP_GATEWAY_CONTAINER_RUNTIME", "docker")
+		stdinCfg := &StdinConfig{
+			MCPServers: map[string]*StdinServerConfig{
+				"test": {Type: "stdio", Container: "ghcr.io/example/server:latest"},
+			},
+			Gateway: &StdinGatewayConfig{
+				Dockerless: true,
+			},
+		}
+
+		cfg, err := convertStdinConfig(stdinCfg)
+		require.NoError(t, err)
+		assert.Equal(t, "podman", cfg.Servers["test"].Command)
+	})
+
 	t.Run("gateway.containerRuntime=podman selects podman command", func(t *testing.T) {
 		stdinCfg := &StdinConfig{
 			MCPServers: map[string]*StdinServerConfig{
@@ -191,6 +224,42 @@ func TestConvertStdinConfig_ContainerRuntimeSelection(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cfg.Servers["test"])
 		assert.Equal(t, "podman", cfg.Servers["test"].Command)
+	})
+}
+
+func TestValidateGatewayConfig_Dockerless(t *testing.T) {
+	t.Run("accepts dockerless without explicit runtime", func(t *testing.T) {
+		assert.NoError(t, validateGatewayConfig(&StdinGatewayConfig{Dockerless: true}))
+	})
+
+	t.Run("accepts dockerless with podman runtime", func(t *testing.T) {
+		assert.NoError(t, validateGatewayConfig(&StdinGatewayConfig{
+			Dockerless:       true,
+			ContainerRuntime: "podman",
+		}))
+	})
+
+	t.Run("rejects dockerless with docker runtime", func(t *testing.T) {
+		err := validateGatewayConfig(&StdinGatewayConfig{
+			Dockerless:       true,
+			ContainerRuntime: "docker",
+		})
+		assert.ErrorContains(t, err, `gateway.containerRuntime must be "podman" when gateway.dockerless is enabled`)
+	})
+
+	t.Run("accepts dockerless with explicit podman path", func(t *testing.T) {
+		assert.NoError(t, validateGatewayConfig(&StdinGatewayConfig{
+			Dockerless:              true,
+			ContainerRuntimeCommand: "/usr/local/bin/podman",
+		}))
+	})
+
+	t.Run("rejects dockerless with non-podman command", func(t *testing.T) {
+		err := validateGatewayConfig(&StdinGatewayConfig{
+			Dockerless:              true,
+			ContainerRuntimeCommand: "nerdctl",
+		})
+		assert.ErrorContains(t, err, `gateway.containerRuntimeCommand must resolve to "podman" when gateway.dockerless is enabled`)
 	})
 }
 

--- a/internal/config/container_runtime.go
+++ b/internal/config/container_runtime.go
@@ -65,6 +65,13 @@ func effectiveContainerRuntimeName(configRuntime string) string {
 }
 
 func effectiveContainerRuntimeCommand(gateway *GatewayConfig) string {
+	if gateway != nil && gateway.Dockerless {
+		if trimmedRuntimeCommand := strings.TrimSpace(gateway.ContainerRuntimeCommand); trimmedRuntimeCommand != "" {
+			return trimmedRuntimeCommand
+		}
+		return containerRuntimePodman
+	}
+
 	runtime := DefaultContainerRuntime
 	if gateway != nil {
 		runtime = gateway.ContainerRuntime
@@ -88,4 +95,9 @@ func configuredContainerRuntimeCommand(gateway *GatewayConfig) string {
 		command = strings.TrimSpace(gateway.ContainerRuntimeCommand)
 	}
 	return command
+}
+
+// EffectiveContainerRuntimeCommand returns the runtime executable used for container launches.
+func EffectiveContainerRuntimeCommand(gateway *GatewayConfig) string {
+	return effectiveContainerRuntimeCommand(gateway)
 }

--- a/internal/config/container_runtime_test.go
+++ b/internal/config/container_runtime_test.go
@@ -6,6 +6,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestEffectiveContainerRuntimeCommand_Dockerless(t *testing.T) {
+	t.Run("uses podman regardless of environment override", func(t *testing.T) {
+		t.Setenv("MCP_GATEWAY_CONTAINER_RUNTIME", "docker")
+		assert.Equal(t, "podman", effectiveContainerRuntimeCommand(&GatewayConfig{Dockerless: true}))
+	})
+
+	t.Run("preserves explicit podman command path", func(t *testing.T) {
+		assert.Equal(t, "/opt/bin/podman", effectiveContainerRuntimeCommand(&GatewayConfig{
+			Dockerless:              true,
+			ContainerRuntimeCommand: "/opt/bin/podman",
+		}))
+	})
+}
+
 // TestEffectiveContainerRuntimeName covers the uncovered branch where
 // MCP_GATEWAY_CONTAINER_RUNTIME is set to an invalid value (not docker/podman).
 func TestEffectiveContainerRuntimeName_InvalidEnvVar(t *testing.T) {

--- a/internal/config/schema/mcp-gateway-config.schema.json
+++ b/internal/config/schema/mcp-gateway-config.schema.json
@@ -388,6 +388,11 @@
           "minimum": 1,
           "default": 60
         },
+        "dockerless": {
+          "type": "boolean",
+          "description": "When true, runs containerized stdio MCP servers with Podman and does not require Docker. This setting takes precedence over MCP_GATEWAY_CONTAINER_RUNTIME. Defaults to false.",
+          "default": false
+        },
         "containerRuntime": {
           "type": "string",
           "description": "Container runtime used to launch stdio MCP servers from JSON stdin container configs. Defaults to 'docker'. Supported values: 'docker', 'podman'. Can be overridden by MCP_GATEWAY_CONTAINER_RUNTIME.",

--- a/internal/config/stdin_gateway_unmarshal_test.go
+++ b/internal/config/stdin_gateway_unmarshal_test.go
@@ -124,7 +124,8 @@ func TestStdinGatewayConfig_UnmarshalJSON_FieldValues(t *testing.T) {
 		"agentId": "test-agent",
 		"domain": "example.com",
 		"startupTimeout": 60,
-		"toolTimeout": 120
+		"toolTimeout": 120,
+		"dockerless": true
 	}`, port))
 
 	var g StdinGatewayConfig
@@ -138,6 +139,7 @@ func TestStdinGatewayConfig_UnmarshalJSON_FieldValues(t *testing.T) {
 	assert.Equal(t, 60, *g.StartupTimeout)
 	require.NotNil(t, g.ToolTimeout)
 	assert.Equal(t, 120, *g.ToolTimeout)
+	assert.True(t, g.Dockerless)
 	assert.True(t, g.agentIDSet)
 	assert.False(t, g.legacyAPIKeySet)
 }

--- a/internal/config/validation_env.go
+++ b/internal/config/validation_env.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/github/gh-aw-mcpg/internal/logger"
@@ -30,7 +31,7 @@ var RequiredEnvVars = []string{
 // Fields:
 //   - IsContainerized: Whether the gateway is running inside a Docker container
 //   - ContainerID: The Docker container ID if containerized
-//   - DockerAccessible: Whether the Docker daemon is accessible
+//   - DockerAccessible: Whether the selected container runtime is accessible
 //   - MissingEnvVars: List of required environment variables that are not set
 //   - PortMapped: Whether the gateway port is mapped to the host (containerized mode)
 //   - StdinInteractive: Whether stdin is interactive (containerized mode)
@@ -65,6 +66,11 @@ func (r *EnvValidationResult) Error() string {
 // ValidateExecutionEnvironment performs comprehensive validation of the execution environment
 // It checks Docker accessibility, required environment variables, and containerization status
 func ValidateExecutionEnvironment() *EnvValidationResult {
+	return ValidateExecutionEnvironmentForRuntime("docker")
+}
+
+// ValidateExecutionEnvironmentForRuntime validates the environment for the selected container runtime.
+func ValidateExecutionEnvironmentForRuntime(runtimeCommand string) *EnvValidationResult {
 	logEnv.Print("Starting execution environment validation")
 	result := &EnvValidationResult{}
 
@@ -72,12 +78,17 @@ func ValidateExecutionEnvironment() *EnvValidationResult {
 	result.IsContainerized, result.ContainerID = sys.DetectContainerID()
 	logEnv.Printf("Containerization check: isContainerized=%v, containerID=%s", result.IsContainerized, result.ContainerID)
 
-	// Check Docker daemon accessibility
-	result.DockerAccessible = sys.CheckDockerAccessible()
+	// Check selected container runtime accessibility.
+	result.DockerAccessible = sys.CheckContainerRuntimeAccessible(runtimeCommand)
 	if !result.DockerAccessible {
-		logEnv.Print("Docker daemon is not accessible")
-		result.ValidationErrors = append(result.ValidationErrors,
-			"Docker daemon is not accessible. Ensure the Docker socket is mounted or Docker is running.")
+		logEnv.Printf("Container runtime is not accessible: command=%s", runtimeCommand)
+		if filepath.Base(runtimeCommand) == "docker" {
+			result.ValidationErrors = append(result.ValidationErrors,
+				"Docker daemon is not accessible. Ensure the Docker socket is mounted or Docker is running.")
+		} else {
+			result.ValidationErrors = append(result.ValidationErrors,
+				fmt.Sprintf("Container runtime %q is not accessible. Ensure it is installed, running, and usable.", runtimeCommand))
+		}
 	}
 
 	// Check required environment variables

--- a/internal/config/validation_env_test.go
+++ b/internal/config/validation_env_test.go
@@ -354,6 +354,29 @@ func TestValidateExecutionEnvironment(t *testing.T) {
 	})
 }
 
+func TestValidateExecutionEnvironmentForRuntime(t *testing.T) {
+	t.Setenv("MCP_GATEWAY_PORT", "8080")
+	t.Setenv("MCP_GATEWAY_DOMAIN", "localhost")
+	t.Setenv("MCP_GATEWAY_AGENT_ID", "test-agent")
+
+	result := ValidateExecutionEnvironmentForRuntime("true")
+
+	assert.True(t, result.DockerAccessible)
+	assert.Empty(t, result.ValidationErrors)
+}
+
+func TestValidateExecutionEnvironmentForRuntime_DockerPathError(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "unix:///nonexistent/docker.sock")
+	t.Setenv("MCP_GATEWAY_PORT", "8080")
+	t.Setenv("MCP_GATEWAY_DOMAIN", "localhost")
+	t.Setenv("MCP_GATEWAY_AGENT_ID", "test-agent")
+
+	result := ValidateExecutionEnvironmentForRuntime("/usr/bin/docker")
+
+	assert.False(t, result.DockerAccessible)
+	assert.Contains(t, result.ValidationErrors, "Docker daemon is not accessible. Ensure the Docker socket is mounted or Docker is running.")
+}
+
 func TestValidateContainerizedEnvironment(t *testing.T) {
 	// Save original env vars
 	origPort := os.Getenv("MCP_GATEWAY_PORT")

--- a/internal/config/validation_env_test.go
+++ b/internal/config/validation_env_test.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/github/gh-aw-mcpg/internal/sys"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetectContainerID(t *testing.T) {
@@ -355,11 +357,16 @@ func TestValidateExecutionEnvironment(t *testing.T) {
 }
 
 func TestValidateExecutionEnvironmentForRuntime(t *testing.T) {
+	runtimeDir := t.TempDir()
+	podmanPath := filepath.Join(runtimeDir, "podman")
+	require.NoError(t, os.WriteFile(podmanPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", runtimeDir)
+	t.Setenv("DOCKER_HOST", "unix:///nonexistent/docker.sock")
 	t.Setenv("MCP_GATEWAY_PORT", "8080")
 	t.Setenv("MCP_GATEWAY_DOMAIN", "localhost")
 	t.Setenv("MCP_GATEWAY_AGENT_ID", "test-agent")
 
-	result := ValidateExecutionEnvironmentForRuntime("true")
+	result := ValidateExecutionEnvironmentForRuntime("podman")
 
 	assert.True(t, result.DockerAccessible)
 	assert.Empty(t, result.ValidationErrors)

--- a/internal/config/validation_gateway.go
+++ b/internal/config/validation_gateway.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -36,12 +37,22 @@ func validateGatewayConfig(gateway *StdinGatewayConfig) error {
 	if err := validateContainerRuntimeValue(gateway.ContainerRuntime, "gateway.containerRuntime"); err != nil {
 		return err
 	}
+	if gateway.Dockerless {
+		runtime := normalizeContainerRuntime(gateway.ContainerRuntime)
+		if runtime != "" && runtime != containerRuntimePodman {
+			return fmt.Errorf("gateway.containerRuntime must be %q when gateway.dockerless is enabled", containerRuntimePodman)
+		}
+	}
 	if err := validateContainerRuntimeCommandNotBlank(
 		gateway.ContainerRuntimeCommand,
 		"containerRuntimeCommand",
 		"gateway.containerRuntimeCommand",
 	); err != nil {
 		return err
+	}
+	if gateway.Dockerless && gateway.ContainerRuntimeCommand != "" &&
+		filepath.Base(strings.TrimSpace(gateway.ContainerRuntimeCommand)) != containerRuntimePodman {
+		return fmt.Errorf("gateway.containerRuntimeCommand must resolve to %q when gateway.dockerless is enabled", containerRuntimePodman)
 	}
 
 	// Validate payloadDir if provided (per schema: must be absolute path)

--- a/internal/sys/docker.go
+++ b/internal/sys/docker.go
@@ -45,7 +45,7 @@ func CheckDockerAccessible() bool {
 
 // CheckContainerRuntimeAccessible verifies that the selected container runtime can be used.
 func CheckContainerRuntimeAccessible(command string) bool {
-if command == "docker" {
+	if filepath.Base(command) == "docker" {
 		return CheckDockerAccessible()
 	}
 

--- a/internal/sys/docker.go
+++ b/internal/sys/docker.go
@@ -45,7 +45,7 @@ func CheckDockerAccessible() bool {
 
 // CheckContainerRuntimeAccessible verifies that the selected container runtime can be used.
 func CheckContainerRuntimeAccessible(command string) bool {
-	if filepath.Base(command) == "docker" {
+if command == "docker" {
 		return CheckDockerAccessible()
 	}
 

--- a/internal/sys/docker.go
+++ b/internal/sys/docker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -39,6 +40,21 @@ func CheckDockerAccessible() bool {
 	cmd.Stderr = nil
 	accessible := cmd.Run() == nil
 	logDocker.Printf("Docker daemon check: accessible=%v", accessible)
+	return accessible
+}
+
+// CheckContainerRuntimeAccessible verifies that the selected container runtime can be used.
+func CheckContainerRuntimeAccessible(command string) bool {
+	if filepath.Base(command) == "docker" {
+		return CheckDockerAccessible()
+	}
+
+	logDocker.Printf("Checking container runtime accessibility: command=%s", command)
+	cmd := exec.Command(command, "info")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	accessible := cmd.Run() == nil
+	logDocker.Printf("Container runtime check: command=%s, accessible=%v", command, accessible)
 	return accessible
 }
 

--- a/internal/sys/docker_test.go
+++ b/internal/sys/docker_test.go
@@ -1,6 +1,8 @@
 package sys
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -204,6 +206,16 @@ func TestCheckDockerAccessible(t *testing.T) {
 func TestCheckContainerRuntimeAccessible(t *testing.T) {
 	assert.True(t, CheckContainerRuntimeAccessible("true"))
 	assert.False(t, CheckContainerRuntimeAccessible("/path/that/does/not/exist/podman"))
+}
+
+func TestCheckContainerRuntimeAccessible_PodmanWithoutDocker(t *testing.T) {
+	runtimeDir := t.TempDir()
+	podmanPath := filepath.Join(runtimeDir, "podman")
+	require.NoError(t, os.WriteFile(podmanPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	t.Setenv("PATH", runtimeDir)
+	t.Setenv("DOCKER_HOST", "unix:///nonexistent/docker.sock")
+
+	assert.True(t, CheckContainerRuntimeAccessible("podman"))
 }
 
 func TestCheckPortMapping(t *testing.T) {

--- a/internal/sys/docker_test.go
+++ b/internal/sys/docker_test.go
@@ -201,6 +201,11 @@ func TestCheckDockerAccessible(t *testing.T) {
 	})
 }
 
+func TestCheckContainerRuntimeAccessible(t *testing.T) {
+	assert.True(t, CheckContainerRuntimeAccessible("true"))
+	assert.False(t, CheckContainerRuntimeAccessible("/path/that/does/not/exist/podman"))
+}
+
 func TestCheckPortMapping(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary
- add an opt-in `gateway.dockerless` setting to stdin JSON configuration
- force Podman for containerized stdio MCP servers when enabled
- make `--validate-env` check the selected runtime without requiring Docker
- validate conflicting runtime settings and document the new mode

## Compatibility
Docker remains the default when `gateway.dockerless` is omitted or false.

## Testing
- `make agent-finished`