### PR TITLE
Build secure Podman 6 runtime image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -606,8 +606,8 @@ docker run --rm -i \
 The container uses `run_containerized.sh` as the entrypoint, which:
 - Requires the `-i` flag for JSON configuration via stdin
 - Requires `MCP_GATEWAY_PORT` and `MCP_GATEWAY_DOMAIN`, plus an agent gate value via `MCP_GATEWAY_AGENT_ID` (`MCP_GATEWAY_API_KEY` is only a deprecated alias that `run_containerized.sh` maps to `MCP_GATEWAY_AGENT_ID`; reference `"gateway": {"agentId": "${MCP_GATEWAY_AGENT_ID}"}` in your JSON config to enable authentication)
-- Queries the Docker daemon API version (falls back to 1.44)
-- Validates Docker socket and environment before starting; validates port mapping only when the container ID can be determined and host networking is not in use
+- Queries the Docker daemon API version when Docker is available (falls back to 1.44)
+- Validates the Docker socket and container settings when Docker is available; Dockerless Podman mode can start without them
 
 See `config.json` for an example JSON configuration file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -606,8 +606,7 @@ docker run --rm -i \
 The container uses `run_containerized.sh` as the entrypoint, which:
 - Requires the `-i` flag for JSON configuration via stdin
 - Requires `MCP_GATEWAY_PORT` and `MCP_GATEWAY_DOMAIN`, plus an agent gate value via `MCP_GATEWAY_AGENT_ID` (`MCP_GATEWAY_API_KEY` is only a deprecated alias that `run_containerized.sh` maps to `MCP_GATEWAY_AGENT_ID`; reference `"gateway": {"agentId": "${MCP_GATEWAY_AGENT_ID}"}` in your JSON config to enable authentication)
-- Queries the Docker daemon API version when Docker is available (falls back to 1.44)
-- Validates the Docker socket and container settings when Docker is available; Dockerless Podman mode can start without them
+- Validates the configured container runtime after reading stdin; Dockerless Podman mode never probes the Docker socket
 
 See `config.json` for an example JSON configuration file.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,55 @@
-# Build stage
-FROM golang:1.26.4-alpine3.22@sha256:727cfc3c40be55cd1bc9a4a059406b28a059857e3be752aa9d09531e12c20c56 AS builder
+# Podman build stage
+FROM golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS podman-builder
+
+ARG PODMAN_VERSION=6.0.2
+ARG PODMAN_SHA256=0895a541aeb7aa8e99133ed2b328c1bb40fd397b7c3b01e083396c90e8628756
+
+RUN apk add --no-cache \
+    bash \
+    btrfs-progs-dev \
+    build-base \
+    coreutils \
+    gpgme-dev \
+    libassuan-dev \
+    libseccomp-dev \
+    linux-headers \
+    sqlite-dev
+
+WORKDIR /src
+RUN wget -q "https://github.com/podman-container-tools/podman/archive/refs/tags/v${PODMAN_VERSION}.tar.gz" -O podman.tar.gz \
+    && echo "${PODMAN_SHA256}  podman.tar.gz" | sha256sum -c - \
+    && tar -xzf podman.tar.gz --strip-components=1 \
+    && rm podman.tar.gz \
+    && BUILDTAGS="exclude_graphdriver_devicemapper seccomp apparmor libsqlite3" \
+       make -j1 podman rootlessport
+
+# Podman 6 requires the Netavark 2 network schema, which is newer than the
+# version packaged by Alpine 3.24.
+FROM golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS network-builder
+
+ARG NETAVARK_VERSION=2.0.0
+ARG NETAVARK_SHA256=031aeeacc930382e8635d40a885798eff1da164dfcf9024b698f822e5995d9c8
+ARG AARDVARK_DNS_VERSION=2.0.0
+ARG AARDVARK_DNS_SHA256=d3f5d6b3be3c2d80e8257fb9467e34ff104f299474427979454034dca6dc88cc
+
+RUN apk add --no-cache build-base cargo protoc
+
+WORKDIR /src/netavark
+RUN wget -q "https://github.com/containers/netavark/archive/refs/tags/v${NETAVARK_VERSION}.tar.gz" -O netavark.tar.gz \
+    && echo "${NETAVARK_SHA256}  netavark.tar.gz" | sha256sum -c - \
+    && tar -xzf netavark.tar.gz --strip-components=1 \
+    && rm netavark.tar.gz \
+    && cargo build --release --locked --bin netavark
+
+WORKDIR /src/aardvark-dns
+RUN wget -q "https://github.com/containers/aardvark-dns/archive/refs/tags/v${AARDVARK_DNS_VERSION}.tar.gz" -O aardvark-dns.tar.gz \
+    && echo "${AARDVARK_DNS_SHA256}  aardvark-dns.tar.gz" | sha256sum -c - \
+    && tar -xzf aardvark-dns.tar.gz --strip-components=1 \
+    && rm aardvark-dns.tar.gz \
+    && cargo build --release --locked --bin aardvark-dns
+
+# Gateway build stage
+FROM golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 WORKDIR /app
 
@@ -17,10 +67,30 @@ ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${VERSION}" -o awmg .
 
 # Runtime stage
-FROM alpine:3.22.5@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
-# Install Docker/Podman CLIs and bash for launching backend MCP servers
-RUN apk add --no-cache docker-cli podman bash
+# Keep both supported container runtimes in one image. Podman is built above
+# because Alpine's packaged version still embeds vulnerable Go dependencies.
+RUN apk add --no-cache \
+    bash \
+    catatonit \
+    conmon \
+    containers-common \
+    crun \
+    docker-cli \
+    fuse-overlayfs \
+    gpgme \
+    libgcc \
+    nftables \
+    passt \
+    shadow-subids \
+    sqlite-libs \
+    && sed -i 's/^driver = "overlay"$/driver = "vfs"/' /etc/containers/storage.conf
+
+COPY --from=podman-builder /src/bin/podman /usr/bin/podman
+COPY --from=podman-builder /src/bin/rootlessport /usr/libexec/podman/rootlessport
+COPY --from=network-builder /src/netavark/target/release/netavark /usr/libexec/podman/netavark
+COPY --from=network-builder /src/aardvark-dns/target/release/aardvark-dns /usr/libexec/podman/aardvark-dns
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS podman-builder
 
 ARG PODMAN_VERSION=6.0.2
-ARG PODMAN_SHA256=0895a541aeb7aa8e99133ed2b328c1bb40fd397b7c3b01e083396c90e8628756
+ARG PODMAN_SHA256=<REPLACE_WITH_OFFICIAL_CONTAINERS_PODMAN_V6_0_2_TARBALL_SHA256>
 
 RUN apk add --no-cache \
     bash \
@@ -16,7 +16,7 @@ RUN apk add --no-cache \
     sqlite-dev
 
 WORKDIR /src
-RUN wget -q "https://github.com/podman-container-tools/podman/archive/refs/tags/v${PODMAN_VERSION}.tar.gz" -O podman.tar.gz \
+RUN wget -q "https://github.com/containers/podman/archive/refs/tags/v${PODMAN_VERSION}.tar.gz" -O podman.tar.gz \
     && echo "${PODMAN_SHA256}  podman.tar.gz" | sha256sum -c - \
     && tar -xzf podman.tar.gz --strip-components=1 \
     && rm podman.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.26.4-alpine3.24@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS podman-builder
 
 ARG PODMAN_VERSION=6.0.2
-ARG PODMAN_SHA256=<REPLACE_WITH_OFFICIAL_CONTAINERS_PODMAN_V6_0_2_TARBALL_SHA256>
+ARG PODMAN_SHA256=0895a541aeb7aa8e99133ed2b328c1bb40fd397b7c3b01e083396c90e8628756
 
 RUN apk add --no-cache \
     bash \
@@ -77,7 +77,7 @@ RUN apk add --no-cache \
     conmon \
     containers-common \
     crun \
-    docker-cli \
+    docker-cli=29.5.3-r0 \
     fuse-overlayfs \
     gpgme \
     libgcc \

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Inside the container, the gateway starts in routed mode on `http://0.0.0.0:8000`
 
 **Required flags:**
 - `-i`: Enables stdin for passing JSON configuration
-- `-v /var/run/docker.sock`: Required for spawning backend MCP servers
+- `-v /var/run/docker.sock`: Required when using the default Docker runtime
+- Dockerless Podman mode (`"gateway": {"dockerless": true}`) does not use the Docker socket; grant the container the capabilities required for nested containers (for example, `--privileged`)
 - `-p 8000:8000`: Port mapping must match `MCP_GATEWAY_PORT`
 - If you configure `payloadDir` / `MCP_GATEWAY_PAYLOAD_DIR`, use an absolute path (for example `/tmp/jq-payloads`)
 - If you configure `payloadDir`, you can also tune `payloadSizeThreshold` / `MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD` to control when payloads are written to disk (default: `524288` bytes)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -206,6 +206,9 @@ func run(cmd *cobra.Command, args []string) error {
 		runtimeCommand := config.EffectiveContainerRuntimeCommand(cfg.Gateway)
 		debugLog.Printf("Validating execution environment with container runtime %s...", runtimeCommand)
 		result := config.ValidateExecutionEnvironmentForRuntime(runtimeCommand)
+		if result.IsContainerized && result.ContainerID != "" {
+			result = config.ValidateContainerizedEnvironmentForRuntime(result.ContainerID, runtimeCommand)
+		}
 		if !result.IsValid() {
 			logger.LogErrorToMarkdown("startup", "Environment validation failed: %s", result.Error())
 			return fmt.Errorf("environment validation failed: %s", result.Error())

--- a/internal/config/validation_env.go
+++ b/internal/config/validation_env.go
@@ -106,8 +106,14 @@ func ValidateExecutionEnvironmentForRuntime(runtimeCommand string) *EnvValidatio
 // ValidateContainerizedEnvironment performs additional validation for containerized mode
 // This is called by run_containerized.sh through the binary or by the Go code directly
 func ValidateContainerizedEnvironment(containerID string) *EnvValidationResult {
+	return ValidateContainerizedEnvironmentForRuntime(containerID, "docker")
+}
+
+// ValidateContainerizedEnvironmentForRuntime performs runtime-aware validation
+// for a containerized gateway.
+func ValidateContainerizedEnvironmentForRuntime(containerID, runtimeCommand string) *EnvValidationResult {
 	logEnv.Printf("Starting containerized environment validation: containerID=%s", containerID)
-	result := ValidateExecutionEnvironment()
+	result := ValidateExecutionEnvironmentForRuntime(runtimeCommand)
 	result.IsContainerized = true
 	result.ContainerID = containerID
 
@@ -115,6 +121,11 @@ func ValidateContainerizedEnvironment(containerID string) *EnvValidationResult {
 		logEnv.Print("Container ID could not be determined")
 		result.ValidationErrors = append(result.ValidationErrors,
 			"Container ID could not be determined. Are you running in a Docker container?")
+		return result
+	}
+
+	if filepath.Base(runtimeCommand) != "docker" {
+		logEnv.Printf("Skipping Docker-specific container inspection for runtime %s", runtimeCommand)
 		return result
 	}
 

--- a/internal/config/validation_env_test.go
+++ b/internal/config/validation_env_test.go
@@ -397,6 +397,7 @@ func TestValidateContainerizedEnvironment(t *testing.T) {
 		} else {
 			os.Unsetenv("MCP_GATEWAY_PORT")
 		}
+
 		if origDomain != "" {
 			os.Setenv("MCP_GATEWAY_DOMAIN", origDomain)
 		} else {
@@ -569,4 +570,24 @@ func TestValidateContainerizedEnvironment(t *testing.T) {
 		// Each error should be on its own line with bullet point
 		assert.Contains(t, errorMsg, "\n  - ", "Errors should be formatted with bullets")
 	})
+}
+
+func TestValidateContainerizedEnvironmentForRuntime_PodmanSkipsDockerInspection(t *testing.T) {
+	tempDir := t.TempDir()
+	podmanPath := filepath.Join(tempDir, "podman")
+	require.NoError(t, os.WriteFile(podmanPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	t.Setenv("PATH", tempDir)
+	t.Setenv("MCP_GATEWAY_PORT", "8080")
+	t.Setenv("MCP_GATEWAY_DOMAIN", "localhost")
+	t.Setenv("MCP_GATEWAY_AGENT_ID", "test-key")
+	t.Setenv("DOCKER_HOST", "unix:///definitely/missing/docker.sock")
+
+	result := ValidateContainerizedEnvironmentForRuntime("abcdef123456", "podman")
+
+	assert.True(t, result.IsValid())
+	assert.True(t, result.DockerAccessible)
+	assert.False(t, result.PortMapped)
+	assert.False(t, result.StdinInteractive)
+	assert.False(t, result.LogDirMounted)
 }

--- a/run.sh
+++ b/run.sh
@@ -44,21 +44,29 @@ detect_containerized() {
     fi
 }
 
-# Check Docker daemon accessibility
+# Check Docker daemon accessibility. Podman mode may be selected from stdin, so
+# allow startup when Docker is absent and Podman is installed.
 check_docker_socket() {
     local socket_path="${DOCKER_HOST:-/var/run/docker.sock}"
     socket_path="${socket_path#unix://}"
     
     if [ ! -S "$socket_path" ]; then
+        if command -v podman > /dev/null 2>&1; then
+            log_warn "Docker socket not found at $socket_path; continuing with Podman available"
+            return 0
+        fi
         log_error "Docker socket not found at $socket_path"
-        log_error "The MCP Gateway requires Docker to spawn backend MCP servers."
-        log_error "Make sure Docker is installed and running."
+        log_error "Neither Docker nor Podman is available to launch backend MCP servers."
         exit 1
     fi
     
     if ! docker info > /dev/null 2>&1; then
+        if command -v podman > /dev/null 2>&1; then
+            log_warn "Docker daemon is not accessible; continuing with Podman available"
+            return 0
+        fi
         log_error "Docker daemon is not accessible"
-        log_error "Make sure Docker is running and you have permission to access it."
+        log_error "Neither Docker nor Podman is available to launch backend MCP servers."
         exit 1
     fi
     
@@ -96,6 +104,9 @@ check_optional_env_vars() {
 
 # Set DOCKER_API_VERSION based on Docker daemon's current API version
 set_docker_api_version() {
+    if ! docker info > /dev/null 2>&1; then
+        return 0
+    fi
     # Get the server's current API version (what it actually supports)
     local server_api=$(docker version --format '{{.Server.APIVersion}}' 2>/dev/null || echo "")
     

--- a/run.sh
+++ b/run.sh
@@ -44,29 +44,21 @@ detect_containerized() {
     fi
 }
 
-# Check Docker daemon accessibility. Podman mode may be selected from stdin, so
-# allow startup when Docker is absent and Podman is installed.
+# Check Docker daemon accessibility
 check_docker_socket() {
     local socket_path="${DOCKER_HOST:-/var/run/docker.sock}"
     socket_path="${socket_path#unix://}"
     
     if [ ! -S "$socket_path" ]; then
-        if command -v podman > /dev/null 2>&1; then
-            log_warn "Docker socket not found at $socket_path; continuing with Podman available"
-            return 0
-        fi
         log_error "Docker socket not found at $socket_path"
-        log_error "Neither Docker nor Podman is available to launch backend MCP servers."
+        log_error "The MCP Gateway requires Docker to spawn backend MCP servers."
+        log_error "Make sure Docker is installed and running."
         exit 1
     fi
     
     if ! docker info > /dev/null 2>&1; then
-        if command -v podman > /dev/null 2>&1; then
-            log_warn "Docker daemon is not accessible; continuing with Podman available"
-            return 0
-        fi
         log_error "Docker daemon is not accessible"
-        log_error "Neither Docker nor Podman is available to launch backend MCP servers."
+        log_error "Make sure Docker is running and you have permission to access it."
         exit 1
     fi
     
@@ -104,9 +96,6 @@ check_optional_env_vars() {
 
 # Set DOCKER_API_VERSION based on Docker daemon's current API version
 set_docker_api_version() {
-    if ! docker info > /dev/null 2>&1; then
-        return 0
-    fi
     # Get the server's current API version (what it actually supports)
     local server_api=$(docker version --format '{{.Server.APIVersion}}' 2>/dev/null || echo "")
     

--- a/run_containerized.sh
+++ b/run_containerized.sh
@@ -5,6 +5,8 @@
 
 set -e
 
+DOCKER_AVAILABLE=false
+
 # Detect if stderr is a TTY and colors should be enabled
 # Respects NO_COLOR and DEBUG_COLORS environment variables
 USE_COLORS=false
@@ -86,7 +88,8 @@ verify_containerized() {
     log_info "Running in containerized environment"
 }
 
-# Check Docker daemon accessibility
+# Check Docker daemon accessibility. Podman mode is selected from stdin, so a
+# missing Docker daemon cannot be fatal before the gateway reads its config.
 check_docker_socket() {
     local raw_host="${DOCKER_HOST:-}"
 
@@ -94,10 +97,14 @@ check_docker_socket() {
     if echo "${raw_host}" | grep -q '^tcp://'; then
         log_info "TCP Docker host configured: ${raw_host}"
         if ! docker info > /dev/null 2>&1; then
-            log_error "Docker daemon at ${raw_host} is not accessible"
-            log_error "Ensure DOCKER_HOST is correct and the daemon is running"
+            if command -v podman > /dev/null 2>&1; then
+                log_warn "Docker daemon at ${raw_host} is not accessible; continuing with Podman available"
+                return 0
+            fi
+            log_error "Neither the Docker daemon nor Podman is accessible"
             exit 1
         fi
+        DOCKER_AVAILABLE=true
         log_info "Docker daemon is accessible"
         return 0
     fi
@@ -120,9 +127,12 @@ check_docker_socket() {
     done
 
     if [ ! -S "$socket_path" ]; then
+        if command -v podman > /dev/null 2>&1; then
+            log_warn "Docker socket not found at $socket_path; continuing with Podman available"
+            return 0
+        fi
         log_error "Docker socket not found at $socket_path after ${max_wait_seconds}s (${max_retries} attempts)"
-        log_error "Mount the Docker socket: -v /var/run/docker.sock:/var/run/docker.sock"
-        log_error "For ARC/DinD with a custom socket path, set DOCKER_HOST and mount accordingly"
+        log_error "Neither Docker nor Podman is available to launch backend MCP servers"
         exit 1
     fi
 
@@ -132,11 +142,15 @@ check_docker_socket() {
     fi
 
     if ! docker info > /dev/null 2>&1; then
-        log_error "Docker daemon is not accessible"
-        log_error "Ensure the Docker socket is properly mounted and accessible"
+        if command -v podman > /dev/null 2>&1; then
+            log_warn "Docker daemon is not accessible; continuing with Podman available"
+            return 0
+        fi
+        log_error "Neither the Docker daemon nor Podman is accessible"
         exit 1
     fi
 
+    DOCKER_AVAILABLE=true
     log_info "Docker daemon is accessible"
 }
 
@@ -426,10 +440,12 @@ main() {
     # Perform environment validation
     check_docker_socket
     check_required_env_vars
-    set_docker_api_version
+    if [ "$DOCKER_AVAILABLE" = true ]; then
+        set_docker_api_version
+    fi
 
     # Perform container-specific validation
-    if [ -n "$CONTAINER_ID" ]; then
+    if [ -n "$CONTAINER_ID" ] && [ "$DOCKER_AVAILABLE" = true ]; then
         validate_port_mapping "$CONTAINER_ID"
         validate_stdin_interactive "$CONTAINER_ID"
         validate_container_config "$CONTAINER_ID"

--- a/run_containerized.sh
+++ b/run_containerized.sh
@@ -5,8 +5,6 @@
 
 set -e
 
-DOCKER_AVAILABLE=false
-
 # Detect if stderr is a TTY and colors should be enabled
 # Respects NO_COLOR and DEBUG_COLORS environment variables
 USE_COLORS=false
@@ -88,72 +86,6 @@ verify_containerized() {
     log_info "Running in containerized environment"
 }
 
-# Check Docker daemon accessibility. Podman mode is selected from stdin, so a
-# missing Docker daemon cannot be fatal before the gateway reads its config.
-check_docker_socket() {
-    local raw_host="${DOCKER_HOST:-}"
-
-    # TCP Docker hosts (e.g. tcp://localhost:2375 for ARC/DinD) have no socket file to check.
-    if echo "${raw_host}" | grep -q '^tcp://'; then
-        log_info "TCP Docker host configured: ${raw_host}"
-        if ! docker info > /dev/null 2>&1; then
-            if command -v podman > /dev/null 2>&1; then
-                log_warn "Docker daemon at ${raw_host} is not accessible; continuing with Podman available"
-                return 0
-            fi
-            log_error "Neither the Docker daemon nor Podman is accessible"
-            exit 1
-        fi
-        DOCKER_AVAILABLE=true
-        log_info "Docker daemon is accessible"
-        return 0
-    fi
-
-    local socket_path="${raw_host:-/var/run/docker.sock}"
-    socket_path="${socket_path#unix://}"
-
-    # Retry the socket check to handle ARC/DinD race conditions where the dind
-    # sidecar hasn't created the socket yet when the gateway starts.
-    local max_retries=10
-    local retry_delay=1
-    local max_wait_seconds=$((max_retries * retry_delay))
-    local attempt=0
-    while [ ! -S "$socket_path" ] && [ $attempt -lt $max_retries ]; do
-        attempt=$((attempt + 1))
-        if [ $attempt -eq 1 ]; then
-            log_info "Waiting for Docker socket at $socket_path (ARC/DinD may need a moment)..."
-        fi
-        sleep $retry_delay
-    done
-
-    if [ ! -S "$socket_path" ]; then
-        if command -v podman > /dev/null 2>&1; then
-            log_warn "Docker socket not found at $socket_path; continuing with Podman available"
-            return 0
-        fi
-        log_error "Docker socket not found at $socket_path after ${max_wait_seconds}s (${max_retries} attempts)"
-        log_error "Neither Docker nor Podman is available to launch backend MCP servers"
-        exit 1
-    fi
-
-    if [ $attempt -gt 0 ]; then
-        local waited_seconds=$((attempt * retry_delay))
-        log_info "Docker socket appeared after ${waited_seconds}s (${attempt} attempt(s))"
-    fi
-
-    if ! docker info > /dev/null 2>&1; then
-        if command -v podman > /dev/null 2>&1; then
-            log_warn "Docker daemon is not accessible; continuing with Podman available"
-            return 0
-        fi
-        log_error "Neither the Docker daemon nor Podman is accessible"
-        exit 1
-    fi
-
-    DOCKER_AVAILABLE=true
-    log_info "Docker daemon is accessible"
-}
-
 # Validate required environment variables
 check_required_env_vars() {
     local missing_vars=()
@@ -186,126 +118,6 @@ check_required_env_vars() {
     fi
 
     log_info "Required environment variables are set"
-}
-
-# Validate port mapping using docker inspect
-validate_port_mapping() {
-    local container_id="$1"
-    local port="$MCP_GATEWAY_PORT"
-
-    if ! validate_container_id "$container_id"; then
-        log_warn "Cannot validate port mapping: container ID invalid or unknown"
-        return 0
-    fi
-
-    # Host networking: ports are shared directly with the host; no port-mapping entry
-    # appears in NetworkSettings.Ports for host-networked containers.
-    local network_mode
-    network_mode=$(docker inspect --format '{{.HostConfig.NetworkMode}}' "$container_id" 2>/dev/null || echo "")
-    if [ "$network_mode" = "host" ]; then
-        log_info "Host network mode detected: skipping port-mapping validation for port $port (published ports are discarded in host mode)"
-        return 0
-    fi
-
-    local port_mapping=$(docker inspect --format '{{json .NetworkSettings.Ports}}' "$container_id" 2>/dev/null || echo "{}")
-
-    if ! echo "$port_mapping" | grep -q "\"${port}/tcp\""; then
-        log_error "Port $port is not exposed from the container"
-        log_error "Add port mapping: -p <host_port>:$port"
-        exit 1
-    fi
-
-    if ! echo "$port_mapping" | grep -q '"HostPort"'; then
-        log_error "Port $port is exposed but not mapped to a host port"
-        log_error "Add port mapping: -p <host_port>:$port"
-        exit 1
-    fi
-
-    log_info "Port $port is properly mapped"
-}
-
-# Validate stdin is interactive (requires -i flag)
-validate_stdin_interactive() {
-    local container_id="$1"
-
-    if ! validate_container_id "$container_id"; then
-        log_warn "Cannot validate stdin: container ID invalid or unknown"
-        return 0
-    fi
-
-    local stdin_open=$(docker inspect --format '{{.Config.OpenStdin}}' "$container_id" 2>/dev/null || echo "unknown")
-
-    if [ "$stdin_open" != "true" ]; then
-        log_error "Container was not started with -i flag"
-        log_error "Stdin is required for passing JSON configuration"
-        log_error "Start container with: docker run -i ..."
-        exit 1
-    fi
-
-    log_info "Stdin is interactive"
-}
-
-# Validate container mounts and environment
-validate_container_config() {
-    local container_id="$1"
-
-    if ! validate_container_id "$container_id"; then
-        log_warn "Cannot validate container config: container ID invalid or unknown"
-        return 0
-    fi
-
-    # Check for Docker socket mount
-    local mounts=$(docker inspect --format '{{json .Mounts}}' "$container_id" 2>/dev/null || echo "[]")
-
-    if ! echo "$mounts" | grep -q 'docker.sock'; then
-        log_warn "Docker socket mount not detected in container mounts"
-        log_warn "The gateway needs Docker access to spawn backend MCP servers"
-    else
-        log_info "Docker socket is mounted"
-    fi
-}
-
-# Validate log directory is mounted for persistent logging
-validate_log_directory_mount() {
-    local container_id="$1"
-    local log_dir="${MCP_GATEWAY_LOG_DIR:-/tmp/gh-aw/mcp-logs}"
-
-    if ! validate_container_id "$container_id"; then
-        log_warn "Cannot validate log directory mount: container ID invalid or unknown"
-        return 0
-    fi
-
-    # Check if log directory is a mount point
-    local mounts=$(docker inspect --format '{{json .Mounts}}' "$container_id" 2>/dev/null || echo "[]")
-
-    if ! echo "$mounts" | grep -q "$log_dir"; then
-        log_warn "Log directory $log_dir is not mounted"
-        log_warn "Gateway logs will not persist outside the container"
-        log_warn "Add mount: -v /path/on/host:$log_dir"
-    else
-        log_info "Log directory $log_dir is mounted"
-    fi
-}
-
-# Set DOCKER_API_VERSION based on architecture and Docker daemon requirements
-set_docker_api_version() {
-    # Get the server's current API version (what it actually supports)
-    local server_api=$(docker version --format '{{.Server.APIVersion}}' 2>/dev/null || echo "")
-
-    if [ -n "$server_api" ]; then
-        # Use the server's current API version for full compatibility
-        export DOCKER_API_VERSION="$server_api"
-        log_info "Set DOCKER_API_VERSION=$DOCKER_API_VERSION (server current)"
-    else
-        # Fallback: set based on architecture
-        local arch=$(uname -m)
-        if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
-            export DOCKER_API_VERSION=1.44
-        else
-            export DOCKER_API_VERSION=1.44
-        fi
-        log_info "Set DOCKER_API_VERSION=$DOCKER_API_VERSION for $arch (fallback)"
-    fi
 }
 
 # Detect host IP and configure host.docker.internal DNS mapping
@@ -364,7 +176,7 @@ build_command_args() {
     local mode="${MCP_GATEWAY_MODE:---routed}"
     local log_dir="${MCP_GATEWAY_LOG_DIR:-/tmp/gh-aw/mcp-logs}"
 
-    local flags="$mode --listen ${host}:${port} --config-stdin --log-dir ${log_dir}"
+    local flags="$mode --listen ${host}:${port} --config-stdin --validate-env --log-dir ${log_dir}"
 
     # Add env file if specified and exists
     if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
@@ -437,20 +249,10 @@ main() {
         log_warn "Could not determine container ID"
     fi
 
-    # Perform environment validation
-    check_docker_socket
+    # Required deployment variables are checked before loading the config.
+    # The selected container runtime is validated by --validate-env after stdin
+    # is parsed, so Dockerless mode never probes the Docker socket.
     check_required_env_vars
-    if [ "$DOCKER_AVAILABLE" = true ]; then
-        set_docker_api_version
-    fi
-
-    # Perform container-specific validation
-    if [ -n "$CONTAINER_ID" ] && [ "$DOCKER_AVAILABLE" = true ]; then
-        validate_port_mapping "$CONTAINER_ID"
-        validate_stdin_interactive "$CONTAINER_ID"
-        validate_container_config "$CONTAINER_ID"
-        validate_log_directory_mount "$CONTAINER_ID"
-    fi
 
     # Configure DNS for host.docker.internal
     configure_host_dns


### PR DESCRIPTION
## Summary

- move the build and runtime images to Alpine 3.24 while retaining `docker-cli` 29.5.3
- build Podman 6.0.2 with Go 1.26.4 from checksum-pinned source
- build compatible Netavark and Aardvark DNS 2.0.0 helpers from checksum-pinned source
- allow container and host startup scripts to continue without Docker access when Podman is available
- default nested Podman storage to VFS so container launches work without a Docker socket

## Security

Podman embeds:
- `golang.org/x/crypto` v0.53.0
- `google.golang.org/grpc` v1.81.1
- Go 1.26.4

Grype reports no fixable critical vulnerabilities on either amd64 or arm64.

## Validation

- built amd64 and arm64 images
- verified Docker 29.5.3 and Podman 6.0.2 on both architectures
- launched a nested Alpine container with Podman without mounting a Docker socket
- started mcpg in Dockerless mode without a Docker socket
- `make agent-finished`
- `make test-integration`

Fixes #10194