### PR TITLE
build: enforce pinned golangci-lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ This runs:
 - `gofmt` check for code formatting
 - `golangci-lint` for additional static analysis (misspell, unconvert)
 
-**Note**: `make install` installs `golangci-lint` v2.12.2 only when `golangci-lint` is not already found on your PATH/GOPATH. If another version is already installed, `make lint` uses that existing binary.
+**Note**: `make install` ensures `golangci-lint` v2.12.2 is available. If another version is already found on your PATH/GOPATH, it is upgraded to v2.12.2.
 
 To run golangci-lint directly with all configured linters:
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -312,13 +312,13 @@ install:
 			echo "✓ golangci-lint v$$INSTALLED_LINT_VERSION is installed"; \
 		else \
 			echo "⚠ golangci-lint v$$INSTALLED_LINT_VERSION is installed; upgrading to $(GOLANGCI_LINT_VERSION)..."; \
-			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION); \
+			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION); \
 			echo "✓ golangci-lint $(GOLANGCI_LINT_VERSION) installed"; \
 		fi; \
 	else \
 		echo "✗ golangci-lint is not installed"; \
 		echo "  Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION); \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION); \
 		echo "✓ golangci-lint $(GOLANGCI_LINT_VERSION) installed"; \
 	fi
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ BINARY_NAME=awmg
 # Go and toolchain versions
 GO_VERSION=1.26.4
 GOLANGCI_LINT_VERSION=v2.12.2
+GOLANGCI_LINT_VERSION_NUMBER=$(patsubst v%,%,$(GOLANGCI_LINT_VERSION))
 
 # Build the CLI binary
 build:
@@ -27,9 +28,9 @@ lint:
 	@echo "Running golangci-lint..."
 	@GOPATH=$$(go env GOPATH); \
 	if [ -f "$$GOPATH/bin/golangci-lint" ]; then \
-		$$GOPATH/bin/golangci-lint run --timeout=5m || echo "⚠ Warning: golangci-lint failed (compatibility issue with Go 1.26.4). Continuing with other checks..."; \
+		$$GOPATH/bin/golangci-lint run --timeout=5m; \
 	elif command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run --timeout=5m || echo "⚠ Warning: golangci-lint failed (compatibility issue with Go 1.26.4). Continuing with other checks..."; \
+		golangci-lint run --timeout=5m; \
 	else \
 		echo "⚠ Warning: golangci-lint not found. Run 'make install' to install it."; \
 		echo "  Skipping golangci-lint checks..."; \
@@ -106,9 +107,9 @@ agent-finished:
 	@echo "Running golangci-lint..."
 	@GOPATH=$$(go env GOPATH); \
 	if [ -f "$$GOPATH/bin/golangci-lint" ]; then \
-		$$GOPATH/bin/golangci-lint run --timeout=5m || echo "⚠ Warning: golangci-lint failed (compatibility issue with Go 1.26.4). Continuing with other checks..."; \
+		$$GOPATH/bin/golangci-lint run --timeout=5m; \
 	elif command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run --timeout=5m || echo "⚠ Warning: golangci-lint failed (compatibility issue with Go 1.26.4). Continuing with other checks..."; \
+		golangci-lint run --timeout=5m; \
 	else \
 		echo "⚠ Warning: golangci-lint not found. Run 'make install' to install it."; \
 		echo "  Skipping golangci-lint checks..."; \
@@ -299,13 +300,21 @@ install:
 	@echo ""
 	@echo "Checking golangci-lint installation..."
 	@GOPATH=$$(go env GOPATH); \
+	LINTER=""; \
 	if [ -f "$$GOPATH/bin/golangci-lint" ] || command -v golangci-lint >/dev/null 2>&1; then \
 		if [ -f "$$GOPATH/bin/golangci-lint" ]; then \
-			INSTALLED_LINT_VERSION=$$($$GOPATH/bin/golangci-lint version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown"); \
+			LINTER="$$GOPATH/bin/golangci-lint"; \
 		else \
-			INSTALLED_LINT_VERSION=$$(golangci-lint version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown"); \
+			LINTER="golangci-lint"; \
 		fi; \
-		echo "✓ golangci-lint v$$INSTALLED_LINT_VERSION is installed"; \
+		INSTALLED_LINT_VERSION=$$($$LINTER version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown"); \
+		if [ "$$INSTALLED_LINT_VERSION" = "$(GOLANGCI_LINT_VERSION_NUMBER)" ]; then \
+			echo "✓ golangci-lint v$$INSTALLED_LINT_VERSION is installed"; \
+		else \
+			echo "⚠ golangci-lint v$$INSTALLED_LINT_VERSION is installed; upgrading to $(GOLANGCI_LINT_VERSION)..."; \
+			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION); \
+			echo "✓ golangci-lint $(GOLANGCI_LINT_VERSION) installed"; \
+		fi; \
 	else \
 		echo "✗ golangci-lint is not installed"; \
 		echo "  Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."; \

--- a/Makefile
+++ b/Makefile
@@ -312,13 +312,21 @@ install:
 			echo "✓ golangci-lint v$$INSTALLED_LINT_VERSION is installed"; \
 		else \
 			echo "⚠ golangci-lint v$$INSTALLED_LINT_VERSION is installed; upgrading to $(GOLANGCI_LINT_VERSION)..."; \
-			curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION); \
+			INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh"; \
+			TMP_SCRIPT=$$(mktemp); \
+			trap 'rm -f "$$TMP_SCRIPT"' EXIT; \
+			curl -sSfL "$$INSTALL_SCRIPT_URL" -o "$$TMP_SCRIPT" && \
+			sh "$$TMP_SCRIPT" -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION) && \
 			echo "✓ golangci-lint $(GOLANGCI_LINT_VERSION) installed"; \
 		fi; \
 	else \
 		echo "✗ golangci-lint is not installed"; \
 		echo "  Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION); \
+		INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh"; \
+		TMP_SCRIPT=$$(mktemp); \
+		trap 'rm -f "$$TMP_SCRIPT"' EXIT; \
+		curl -sSfL "$$INSTALL_SCRIPT_URL" -o "$$TMP_SCRIPT" && \
+		sh "$$TMP_SCRIPT" -b $$GOPATH/bin $(GOLANGCI_LINT_VERSION) && \
 		echo "✓ golangci-lint $(GOLANGCI_LINT_VERSION) installed"; \
 	fi
 	@echo ""


### PR DESCRIPTION
## Summary
- propagate `golangci-lint` failures from `make lint` and `make agent-finished`
- detect stale local linter versions during `make install`
- upgrade mismatched installations to the repository-pinned `v2.12.2`, which is compatible with Go 1.26.4

## Validation
- `make agent-finished`