### PR TITLE
Retry late HTTP backend registration

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -259,6 +259,52 @@ When using `gateway.containerRuntime: "podman"` in containerized/Kubernetes envi
   - Example (stdin JSON): `"toolTimeout": 600` on an HTTP MCP server that may take up to 10 minutes
   - Example (TOML): `tool_timeout = 600` under a `[servers.my-server]` section
 
+### Late-starting HTTP backends
+
+Routed mode supports HTTP MCP servers that are configured before their upstream process
+starts. A failed startup connection does not fail gateway startup or remove
+`/mcp/<server-id>`. Before creating a routed MCP session, the gateway retries backend
+initialization and `tools/list`. Until discovery succeeds, the route returns HTTP 503 with
+`backend_unavailable`; callers should retry the `initialize` handshake. Failed discovery
+attempts are coalesced per backend and rate-limited to one attempt per second.
+
+Each connection attempt uses the server's `connectTimeout`. The global
+`gateway.startupTimeout` applies to stdio process startup and does **not** extend HTTP
+backend retries. Tool execution uses the per-server `toolTimeout`, or
+`gateway.toolTimeout` when the server field is omitted. Gateway health and unrelated
+server routes remain available while one HTTP upstream is unavailable.
+
+The gh-aw-firewall enclave integration uses the following JSON stdin contract:
+
+```json
+{
+  "mcpServers": {
+    "awf-enclave": {
+      "type": "http",
+      "url": "http://awf-enclave-mcp:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer ${AWF_ENCLAVE_MCP_CAPABILITY}"
+      },
+      "tools": ["enclave_run_script", "enclave_run_agent"],
+      "connectTimeout": 120,
+      "toolTimeout": 150
+    }
+  }
+}
+```
+
+- `tools` must contain only the enclave executors enabled for the run.
+- `toolTimeout` must be at least the largest enabled enclave timeout plus 30 seconds.
+- JSON stdin expands `AWF_ENCLAVE_MCP_CAPABILITY` before validation. The capability must
+  be present in the mcpg environment, but must not be passed to the primary agent.
+- The firewall readiness endpoint is the routed mcpg URL ending in
+  `/mcp/awf-enclave`. Readiness is established with `initialize`,
+  `notifications/initialized`, and a complete allowlisted `tools/list`.
+- This contract requires MCP Gateway specification version `1.15.0` and an mcpg build
+  newer than `v0.4.8` that includes late HTTP backend registration. The gh-aw compiler
+  follow-up must pin the first released image containing that change rather than
+  `v0.4.8`.
+
 - **`rate_limit_threshold`** (optional, TOML config only): Number of consecutive rate-limit errors from this backend that will trip the circuit breaker (transition CLOSED → OPEN). When OPEN, requests are immediately rejected until the breaker is eligible to transition to HALF-OPEN again; this is normally controlled by `rate_limit_cooldown`, but if the gateway knows an upstream rate-limit reset time (for example from response headers or parsed tool error text), that reset time takes precedence. **Not available in JSON stdin format.** Default: `3`.
 
 - **`rate_limit_cooldown`** (optional, TOML config only): Default number of seconds before the circuit breaker allows a single probe request (transition OPEN → HALF-OPEN). If the gateway knows an upstream rate-limit reset time, it uses that reset time instead of this cooldown to decide when to probe again. If the probe succeeds the circuit closes; if rate-limited again it re-opens. **Not available in JSON stdin format.** Default: `60`.

--- a/internal/config/config_stdin_test.go
+++ b/internal/config/config_stdin_test.go
@@ -391,6 +391,23 @@ func TestConvertStdinServerConfig_HeadersExpansion(t *testing.T) {
 	assert.Equal(t, "static-header", result.Headers["X-Static"])
 }
 
+func TestConvertStdinServerConfig_EnclaveBearerHeaderExpansion(t *testing.T) {
+	t.Setenv("AWF_ENCLAVE_MCP_CAPABILITY", "0123456789abcdef")
+
+	server := &StdinServerConfig{
+		Type: "http",
+		URL:  "http://awf-enclave-mcp:8080/mcp",
+		Headers: map[string]string{
+			"Authorization": "Bearer ${AWF_ENCLAVE_MCP_CAPABILITY}",
+		},
+	}
+
+	result, err := convertStdinServerConfig("awf-enclave", server, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "Bearer 0123456789abcdef", result.Headers["Authorization"])
+}
+
 // TestConvertStdinServerConfig_HeadersExpansionError tests error handling for headers with undefined variables.
 func TestConvertStdinServerConfig_HeadersExpansionError(t *testing.T) {
 	os.Unsetenv("MISSING_TOKEN")

--- a/internal/mcp/connection.go
+++ b/internal/mcp/connection.go
@@ -274,7 +274,7 @@ func NewHTTPConnection(ctx context.Context, serverID, url string, headers map[st
 	logConn.Printf("SSE transport failed: %v", err)
 
 	// Try 3: Plain JSON-RPC over HTTP (non-standard, for fallback)
-	conn, err = tryPlainJSONTransport(ctx, cancel, serverID, url, headers, headerClient)
+	conn, err = tryPlainJSONTransport(ctx, cancel, serverID, url, headers, headerClient, connectTimeout)
 	if err == nil {
 		logger.LogInfo("backend", "Successfully connected using plain JSON-RPC transport, url=%s", url)
 		return conn, nil

--- a/internal/mcp/http_transport.go
+++ b/internal/mcp/http_transport.go
@@ -422,7 +422,7 @@ func trySSETransport(ctx context.Context, cancel context.CancelFunc, serverID, u
 
 // tryPlainJSONTransport attempts to connect using plain JSON-RPC 2.0 over HTTP POST (non-standard)
 // This is used for compatibility with servers like safeinputs that don't implement standard MCP HTTP transports
-func tryPlainJSONTransport(ctx context.Context, cancel context.CancelFunc, serverID, url string, headers map[string]string, httpClient *http.Client) (*Connection, error) {
+func tryPlainJSONTransport(ctx context.Context, cancel context.CancelFunc, serverID, url string, headers map[string]string, httpClient *http.Client, connectTimeout time.Duration) (*Connection, error) {
 	logHTTP.Printf("Attempting plain JSON-RPC transport: serverID=%s, url=%s", serverID, sanitize.RedactURL(url))
 	conn := &Connection{
 		ctx:               ctx,
@@ -433,6 +433,7 @@ func tryPlainJSONTransport(ctx context.Context, cancel context.CancelFunc, serve
 		headers:           headers,
 		httpClient:        httpClient,
 		httpTransportType: HTTPTransportPlainJSON,
+		connectTimeout:    connectTimeout,
 	}
 
 	// Send initialize request to establish a session with the HTTP backend
@@ -451,6 +452,12 @@ func tryPlainJSONTransport(ctx context.Context, cancel context.CancelFunc, serve
 
 // initializeHTTPSession sends an initialize request to the HTTP backend and captures the session ID
 func (c *Connection) initializeHTTPSession() (string, error) {
+	connectCtx, cancel := context.WithTimeout(c.ctx, normalizeConnectTimeout(c.connectTimeout))
+	defer cancel()
+	return c.initializeHTTPSessionContext(connectCtx)
+}
+
+func (c *Connection) initializeHTTPSessionContext(ctx context.Context) (string, error) {
 	// Generate unique request ID
 	requestID := atomic.AddUint64(&requestIDCounter, 1)
 
@@ -470,7 +477,7 @@ func (c *Connection) initializeHTTPSession() (string, error) {
 	// define a session ID on the initialize request — the server assigns it in the
 	// response.  Sending a synthetic ID could cause some backends to misinterpret
 	// the request as resuming an existing (and unknown) session.
-	result, err := c.executeHTTPRequest(c.ctx, "initialize", initParams, requestID, nil)
+	result, err := c.executeHTTPRequest(ctx, "initialize", initParams, requestID, nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/mcp/plain_json_connect_timeout_test.go
+++ b/internal/mcp/plain_json_connect_timeout_test.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTryPlainJSONTransportHonorsConnectTimeout(t *testing.T) {
+	unblock := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-unblock
+	}))
+	defer server.Close()
+	defer close(unblock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	connectTimeout := 50 * time.Millisecond
+
+	start := time.Now()
+	conn, err := tryPlainJSONTransport(
+		ctx,
+		cancel,
+		"slow-plain-json",
+		server.URL,
+		nil,
+		server.Client(),
+		connectTimeout,
+	)
+
+	require.Error(t, err)
+	assert.Nil(t, conn)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), time.Second)
+}

--- a/internal/mcp/sdk_method_dispatch_test.go
+++ b/internal/mcp/sdk_method_dispatch_test.go
@@ -251,7 +251,7 @@ func newPlainJSONConn(t *testing.T, serverURL string, headers map[string]string)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	httpClient := &http.Client{Timeout: 30 * time.Second}
-	conn, err := tryPlainJSONTransport(ctx, cancel, "test-server", serverURL, headers, httpClient)
+	conn, err := tryPlainJSONTransport(ctx, cancel, "test-server", serverURL, headers, httpClient, defaultConnectTimeout)
 	require.NoError(t, err)
 	return conn
 }

--- a/internal/server/http_server.go
+++ b/internal/server/http_server.go
@@ -111,6 +111,16 @@ func CreateHTTPServerForRoutedMode(addr string, unifiedServer *UnifiedServer, ap
 			backendID := serverID
 			route := fmt.Sprintf("/mcp/%s", backendID)
 
+			handlerCfg := buildDefaultHandlerConfig(unifiedServer, sessionTimeout, defaultHandlerConfigOptions{
+				handlerLog: logRouted,
+				logTag:     "routed:" + backendID,
+				apiKey:     apiKey,
+				hmacSecret: hmacSecret,
+			})
+			if serverCfg := unifiedServer.cfg.Servers[backendID]; serverCfg != nil && serverCfg.Type == "http" {
+				handlerCfg.backendID = backendID
+			}
+
 			finalHandler := buildMCPHandler(func(r *http.Request) *sdk.Server {
 				if _, ok := setupSessionCallback(r, backendID); !ok {
 					return nil
@@ -122,12 +132,7 @@ func CreateHTTPServerForRoutedMode(addr string, unifiedServer *UnifiedServer, ap
 					logRouted.Printf("[CACHE] Creating new filtered server: backend=%s, session=%s", backendID, util.FormatSessionIDForLog(sessionID))
 					return createFilteredServer(unifiedServer, backendID)
 				})
-			}, buildDefaultHandlerConfig(unifiedServer, sessionTimeout, defaultHandlerConfigOptions{
-				handlerLog: logRouted,
-				logTag:     "routed:" + backendID,
-				apiKey:     apiKey,
-				hmacSecret: hmacSecret,
-			}))
+			}, handlerCfg)
 
 			mux.Handle(route+"/", finalHandler)
 			mux.Handle(route, finalHandler)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -23,6 +23,7 @@ type mcpHandlerConfig struct {
 	unifiedServer  *UnifiedServer
 	apiKey         string
 	hmacSecret     string
+	backendID      string
 }
 
 type defaultHandlerConfigOptions struct {
@@ -118,5 +119,9 @@ func buildMCPHandler(serverFactory func(*http.Request) *sdk.Server, cfg mcpHandl
 		Logger:         logger.NewSlogLoggerWithHandler(cfg.handlerLog),
 		SessionTimeout: cfg.sessionTimeout,
 	})
-	return wrapWithMiddleware(WrapWithSessionAutoInit(h), cfg.logTag, cfg.unifiedServer, cfg.apiKey, cfg.hmacSecret)
+	handler := WrapWithSessionAutoInit(h)
+	if cfg.backendID != "" {
+		handler = requireBackendRegistration(cfg.unifiedServer, cfg.backendID, handler)
+	}
+	return wrapWithMiddleware(handler, cfg.logTag, cfg.unifiedServer, cfg.apiKey, cfg.hmacSecret)
 }

--- a/internal/server/routed.go
+++ b/internal/server/routed.go
@@ -73,3 +73,22 @@ func createFilteredServer(unifiedServer *UnifiedServer, backendID string) *sdk.S
 
 	return server
 }
+
+// requireBackendRegistration prevents a failed startup discovery from creating a
+// long-lived routed MCP session with an empty tool set. Each request retries through
+// ensureToolsRegistered until the backend has completed initialize and tools/list.
+func requireBackendRegistration(unifiedServer *UnifiedServer, backendID string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := unifiedServer.ensureToolsRegistered(r.Context(), backendID); err != nil {
+			logger.LogWarnToServer(backendID, "backend", "HTTP backend is not ready: %v", err)
+			httputil.WriteErrorResponse(
+				w,
+				http.StatusServiceUnavailable,
+				"backend_unavailable",
+				"Backend MCP server is not ready; retry initialization",
+			)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/routed_late_http_backend_test.go
+++ b/internal/server/routed_late_http_backend_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/github/gh-aw-mcpg/internal/config"
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestRoutedHTTPBackendRecoversAfterLateStartup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+	backendAddress := listener.Addr().String()
+	require.NoError(listener.Close())
+
+	const capability = "enclave-test-capability"
+	cfg := &config.Config{
+		Servers: map[string]*config.ServerConfig{
+			"awf-enclave": {
+				Type:           "http",
+				URL:            "http://" + backendAddress + "/mcp",
+				Headers:        map[string]string{"Authorization": "Bearer " + capability},
+				Tools:          []string{"enclave_run_script"},
+				ConnectTimeout: 1,
+				ToolTimeout:    150,
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	us, err := NewUnified(ctx, cfg)
+	require.NoError(err, "gateway startup must survive an unavailable HTTP backend")
+	defer us.Close()
+	assert.Empty(us.GetToolsForBackend("awf-enclave"))
+
+	gateway := CreateHTTPServerForRoutedMode("127.0.0.1:0", us, "", "")
+	gatewayServer := httptest.NewServer(gateway.Handler)
+	defer gatewayServer.Close()
+	route := gatewayServer.URL + "/mcp/awf-enclave"
+
+	status, body := postRawMCP(t, route, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"readiness","version":"1.0"}}}`)
+	assert.Equal(http.StatusServiceUnavailable, status)
+	assert.NotContains(string(body), capability)
+
+	var (
+		receivedMu      sync.Mutex
+		receivedHeaders []string
+		receivedMethods []string
+	)
+	backendSDK := sdk.NewServer(&sdk.Implementation{Name: "awf-enclave-mcp", Version: "1.0"}, nil)
+	addTestBackendTool(backendSDK, "enclave_run_script")
+	addTestBackendTool(backendSDK, "enclave_run_agent")
+	backendMCPHandler := sdk.NewStreamableHTTPHandler(func(*http.Request) *sdk.Server {
+		return backendSDK
+	}, nil)
+	backendHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, readErr := readAndRestoreRequestBody(r)
+		if readErr != nil {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		var request struct {
+			Method string `json:"method"`
+		}
+		_ = json.Unmarshal(body, &request)
+
+		receivedMu.Lock()
+		receivedHeaders = append(receivedHeaders, r.Header.Get("Authorization"))
+		if request.Method != "" {
+			receivedMethods = append(receivedMethods, request.Method)
+		}
+		receivedMu.Unlock()
+		if r.Header.Get("Authorization") != "Bearer "+capability {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		backendMCPHandler.ServeHTTP(w, r)
+	})
+
+	backendListener, err := net.Listen("tcp", backendAddress)
+	require.NoError(err)
+	backendHTTPServer := &http.Server{Handler: backendHandler}
+	backendDone := make(chan error, 1)
+	go func() {
+		backendDone <- backendHTTPServer.Serve(backendListener)
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		require.NoError(backendHTTPServer.Shutdown(shutdownCtx))
+		require.ErrorIs(<-backendDone, http.ErrServerClosed)
+	})
+
+	time.Sleep(backendRegistrationRetryInterval + 100*time.Millisecond)
+
+	client := sdk.NewClient(&sdk.Implementation{Name: "firewall-readiness", Version: "1.0"}, nil)
+	gatewayClient := gatewayServer.Client()
+	gatewayClient.Transport = testHeaderTransport{
+		base:  gatewayClient.Transport,
+		key:   "Authorization",
+		value: "Bearer firewall-readiness",
+	}
+	transport := &sdk.StreamableClientTransport{
+		Endpoint:             route,
+		HTTPClient:           gatewayClient,
+		DisableStandaloneSSE: true,
+		MaxRetries:           -1,
+	}
+	readinessCtx, readinessCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer readinessCancel()
+	session, err := client.Connect(readinessCtx, transport, nil)
+	require.NoError(err, "initialize and notifications/initialized must succeed after backend startup")
+	defer session.Close()
+
+	tools, err := session.ListTools(readinessCtx, &sdk.ListToolsParams{})
+	require.NoError(err)
+	require.Len(tools.Tools, 1, "the routed tool list must enforce the configured allowlist")
+	assert.Equal("enclave_run_script", tools.Tools[0].Name)
+
+	_, err = session.CallTool(readinessCtx, &sdk.CallToolParams{
+		Name:      "enclave_run_agent",
+		Arguments: map[string]interface{}{},
+	})
+	require.Error(err, "a tool excluded by the allowlist must not be callable through the routed server")
+
+	receivedMu.Lock()
+	defer receivedMu.Unlock()
+	require.NotEmpty(receivedHeaders)
+	for _, header := range receivedHeaders {
+		assert.Equal("Bearer "+capability, header)
+	}
+	assert.Contains(receivedMethods, "initialize")
+	assert.Contains(receivedMethods, "notifications/initialized")
+	assert.Contains(receivedMethods, "tools/list")
+}
+
+type testHeaderTransport struct {
+	base       http.RoundTripper
+	key, value string
+}
+
+func (t testHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	cloned.Header.Set(t.key, t.value)
+	return t.base.RoundTrip(cloned)
+}
+
+func addTestBackendTool(server *sdk.Server, name string) {
+	server.AddTool(&sdk.Tool{
+		Name:        name,
+		Description: name,
+		InputSchema: map[string]interface{}{"type": "object"},
+	}, func(context.Context, *sdk.CallToolRequest) (*sdk.CallToolResult, error) {
+		return &sdk.CallToolResult{Content: []sdk.Content{&sdk.TextContent{Text: "ok"}}}, nil
+	})
+}
+
+func postRawMCP(t *testing.T, url, payload string) (int, []byte) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBufferString(payload))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		require.NoError(t, json.Unmarshal(body, &parsed))
+	}
+	return resp.StatusCode, body
+}

--- a/internal/server/tool_registry.go
+++ b/internal/server/tool_registry.go
@@ -121,13 +121,6 @@ func (us *UnifiedServer) ensureToolsRegistered(ctx context.Context, serverID str
 	if registered {
 		return nil
 	}
-	if us.hasToolsForBackend(serverID) {
-		us.registrationMu.Lock()
-		us.registeredBackends[serverID] = true
-		delete(us.registrationFailures, serverID)
-		us.registrationMu.Unlock()
-		return nil
-	}
 	if retryDeferred && time.Now().Before(failure.retryAfter) {
 		return failure.err
 	}

--- a/internal/server/tool_registry.go
+++ b/internal/server/tool_registry.go
@@ -49,7 +49,7 @@ func (us *UnifiedServer) registerAllToolsSequential(serverIDs []string) error {
 	errs := &registrationErrors{total: len(serverIDs)}
 	for _, serverID := range serverIDs {
 		logUnified.Printf("Registering tools from backend: %s", serverID)
-		if err := us.registerToolsFromBackend(serverID); err != nil {
+		if err := us.ensureToolsRegistered(us.ctx, serverID); err != nil {
 			logger.LogError("backend", "Failed to register tools from %s: %v", serverID, err)
 			errs.record(serverID)
 		}
@@ -74,7 +74,7 @@ func (us *UnifiedServer) registerAllToolsParallel(serverIDs []string) error {
 			defer wg.Done()
 
 			startTime := time.Now()
-			err := us.registerToolsFromBackend(sid)
+			err := us.ensureToolsRegistered(us.ctx, sid)
 			duration := time.Since(startTime)
 
 			results <- launchResult{
@@ -109,8 +109,79 @@ func (us *UnifiedServer) registerAllToolsParallel(serverIDs []string) error {
 	return nil
 }
 
+// ensureToolsRegistered serializes discovery for a backend and remembers successful
+// registrations. Failed attempts are not cached, so routed requests can retry after an
+// HTTP backend that was unavailable during gateway startup becomes ready.
+func (us *UnifiedServer) ensureToolsRegistered(ctx context.Context, serverID string) error {
+	us.registrationMu.RLock()
+	registered := us.registeredBackends[serverID]
+	registrationLock := us.backendRegistration[serverID]
+	failure, retryDeferred := us.registrationFailures[serverID]
+	us.registrationMu.RUnlock()
+	if registered {
+		return nil
+	}
+	if us.hasToolsForBackend(serverID) {
+		us.registrationMu.Lock()
+		us.registeredBackends[serverID] = true
+		delete(us.registrationFailures, serverID)
+		us.registrationMu.Unlock()
+		return nil
+	}
+	if retryDeferred && time.Now().Before(failure.retryAfter) {
+		return failure.err
+	}
+	if registrationLock == nil {
+		return fmt.Errorf("backend %q is not configured", serverID)
+	}
+
+	registrationLock.Lock()
+	defer registrationLock.Unlock()
+
+	us.registrationMu.RLock()
+	registered = us.registeredBackends[serverID]
+	failure, retryDeferred = us.registrationFailures[serverID]
+	us.registrationMu.RUnlock()
+	if registered {
+		return nil
+	}
+	if retryDeferred && time.Now().Before(failure.retryAfter) {
+		return failure.err
+	}
+	if err := us.registerToolsFromBackendContext(ctx, serverID); err != nil {
+		us.registrationMu.Lock()
+		us.registrationFailures[serverID] = backendRegistrationFailure{
+			err:        err,
+			retryAfter: time.Now().Add(backendRegistrationRetryInterval),
+		}
+		us.registrationMu.Unlock()
+		return err
+	}
+
+	us.registrationMu.Lock()
+	us.registeredBackends[serverID] = true
+	delete(us.registrationFailures, serverID)
+	us.registrationMu.Unlock()
+	return nil
+}
+
+func (us *UnifiedServer) hasToolsForBackend(serverID string) bool {
+	us.toolsMu.RLock()
+	defer us.toolsMu.RUnlock()
+	for _, tool := range us.tools {
+		if tool.BackendID == serverID {
+			return true
+		}
+	}
+	return false
+}
+
 // registerToolsFromBackend registers tools from a specific backend with <server>___<tool> naming
 func (us *UnifiedServer) registerToolsFromBackend(serverID string) error {
+	return us.registerToolsFromBackendContext(us.ctx, serverID)
+}
+
+func (us *UnifiedServer) registerToolsFromBackendContext(ctx context.Context, serverID string) error {
 	logUnified.Printf("Registering tools from backend: %s", serverID)
 
 	// Get connection to backend
@@ -136,7 +207,7 @@ func (us *UnifiedServer) registerToolsFromBackend(serverID string) error {
 		} `json:"tools"`
 	}
 	if err := fetchBackendList(
-		context.Background(),
+		ctx,
 		conn,
 		serverID,
 		"tools/list",
@@ -272,7 +343,7 @@ func (us *UnifiedServer) registerToolsFromBackend(serverID string) error {
 
 	// Register prompts from this backend. Prompt support is optional; failures are
 	// logged but do not cause tool registration to fail.
-	if err := us.registerPromptsFromBackend(context.Background(), serverID, conn); err != nil {
+	if err := us.registerPromptsFromBackend(ctx, serverID, conn); err != nil {
 		logger.LogWarn("backend", "Failed to register prompts from %s (non-fatal): %v", serverID, err)
 	}
 

--- a/internal/server/tool_registry.go
+++ b/internal/server/tool_registry.go
@@ -158,17 +158,6 @@ func (us *UnifiedServer) ensureToolsRegistered(ctx context.Context, serverID str
 	return nil
 }
 
-func (us *UnifiedServer) hasToolsForBackend(serverID string) bool {
-	us.toolsMu.RLock()
-	defer us.toolsMu.RUnlock()
-	for _, tool := range us.tools {
-		if tool.BackendID == serverID {
-			return true
-		}
-	}
-	return false
-}
-
 // registerToolsFromBackend registers tools from a specific backend with <server>___<tool> naming
 func (us *UnifiedServer) registerToolsFromBackend(serverID string) error {
 	return us.registerToolsFromBackendContext(us.ctx, serverID)

--- a/internal/server/unified.go
+++ b/internal/server/unified.go
@@ -27,8 +27,14 @@ import (
 var logUnified = logger.ForFile()
 
 const rateLimitExceededStatus = "rate limit exceeded"
+const backendRegistrationRetryInterval = time.Second
 
 var errRateLimitExceeded = errors.New(rateLimitExceededStatus)
+
+type backendRegistrationFailure struct {
+	err        error
+	retryAfter time.Time
+}
 
 // MCPGatewaySpecVersion is the MCP Gateway Specification version this implementation conforms to
 const MCPGatewaySpecVersion = "1.15.0"
@@ -83,6 +89,10 @@ type UnifiedServer struct {
 	sessionMu            sync.RWMutex
 	tools                map[string]*ToolInfo // prefixed tool name -> tool info
 	toolsMu              sync.RWMutex
+	registrationMu       sync.RWMutex
+	registeredBackends   map[string]bool
+	backendRegistration  map[string]*sync.Mutex
+	registrationFailures map[string]backendRegistrationFailure
 	sequentialLaunch     bool   // When true, launches MCP servers sequentially during startup. Default is false (parallel launch).
 	payloadDir           string // Base directory for storing large payload files (segmented by session ID)
 	payloadPathPrefix    string // Path prefix to use when returning payloadPath to clients (allows remapping host paths to client/agent container paths)
@@ -159,6 +169,9 @@ func NewUnified(ctx context.Context, cfg *config.Config) (*UnifiedServer, error)
 		ctx:                  ctx,
 		sessions:             make(map[string]*Session),
 		tools:                make(map[string]*ToolInfo),
+		registeredBackends:   make(map[string]bool),
+		backendRegistration:  make(map[string]*sync.Mutex, len(cfg.Servers)),
+		registrationFailures: make(map[string]backendRegistrationFailure),
 		sequentialLaunch:     cfg.SequentialLaunch,
 		payloadDir:           payloadDir,
 		payloadPathPrefix:    payloadPathPrefix,
@@ -173,6 +186,9 @@ func NewUnified(ctx context.Context, cfg *config.Config) (*UnifiedServer, error)
 
 		// Cache tracer at construction to avoid calling otel.Tracer on every request.
 		CachedTracer: tracing.CachedTracer{Tracer: tracing.Tracer()},
+	}
+	for serverID := range cfg.Servers {
+		us.backendRegistration[serverID] = &sync.Mutex{}
 	}
 
 	// Create MCP server with logger


### PR DESCRIPTION
## Summary

- keep routed mcpg healthy when an HTTP MCP upstream is configured before it starts
- retry and serialize backend initialize/tool discovery before creating a routed MCP session, returning retryable HTTP 503 responses while unavailable
- re-register only allowlisted tools once the upstream appears and preserve auth/HMAC/shutdown middleware ordering
- apply `connectTimeout` to the plain JSON fallback as well as SDK-managed transports
- document the exact `awf-enclave` JSON stdin contract and version requirement

## Dependency

Prerequisite for github/gh-aw-firewall#6992 (enclave stack layer 4). That PR starts `awf-enclave-mcp` after the compiler-owned mcpg container, then proves `initialize` + `notifications/initialized` + allowlisted `tools/list` through `/mcp/awf-enclave` before starting the primary agent.

A follow-up in github/gh-aw must emit the documented `awf-enclave` HTTP server entry, capability header substitution, enabled-tool allowlist, `connectTimeout`, and `toolTimeout`, and pin the first mcpg release containing this PR.

Important contract clarification: `gateway.startupTimeout` governs stdio process startup; HTTP recovery is governed by per-server `connectTimeout` plus the caller's bounded readiness retry window. Firewall/compiler assumptions should use `connectTimeout: 120` and retry `initialize` on `backend_unavailable`, not rely on `gateway.startupTimeout` to keep an HTTP attempt alive.

## Validation

- `GODEBUG=netdns=go make agent-finished`
- `GODEBUG=netdns=go make test-integration`
- focused delayed-start regression covers unavailable startup, retryable route, upstream bearer auth, initialize/initialized/tools-list discovery, routed allowlist filtering/rejection, and 150-second per-server tool timeout configuration
- focused transport regression covers a silent plain-JSON upstream respecting `connectTimeout`