### PR TITLE
Upgrade workflows to gh-aw v0.87.4 pre-release

### DIFF
--- a/.github/skills/agentic-workflows/SKILL.md
+++ b/.github/skills/agentic-workflows/SKILL.md
@@ -34,6 +34,7 @@ Load these files from `github/gh-aw` (they are not available locally).
 - `.github/aw/deployment-status.md`
 - `.github/aw/designer-mappings.md`
 - `.github/aw/designer.md`
+- `.github/aw/drive-memory.md`
 - `.github/aw/enclaves.md`
 - `.github/aw/evals.md`
 - `.github/aw/experiments.md`


### PR DESCRIPTION
## Summary

Upgrades the repository's agentic workflow support to the latest gh-aw pre-release, v0.87.4.

## Changes

- Ran `gh aw upgrade --pre-releases`
- Refreshed the agentic-workflows dispatcher skill with the new `drive-memory` guidance entry
- Recompiled all 36 workflows successfully

## Validation

- `gh aw compile` — 36 workflows compiled successfully
- `make agent-finished` — all formatting, build, lint, Go tests, and Rust guard tests passed