### PR TITLE
Add capability-bound enclave issue reads

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -107,6 +107,10 @@ When running `awmg proxy`, these variables configure the upstream GitHub API:
 |----------|-------------|---------|
 | `GITHUB_API_URL` | Explicit GitHub API endpoint (e.g., `https://api.mycompany.ghe.com`); used by proxy to set upstream target | (auto-derived) |
 | `GITHUB_SERVER_URL` | GitHub server URL; proxy auto-derives API endpoint: `*.ghe.com` → `api.*.ghe.com`, GHES → `<host>/api/v3`, `github.com` → `api.github.com` | (falls back to `api.github.com`) |
+| `MCP_GATEWAY_ENCLAVE_POLICY_JSON` | Enables the fail-closed `issues-read-v1` enclave profile with a compiler-generated workflow/run/repository/operation policy. Must be paired with `MCP_GATEWAY_ENCLAVE_CAPABILITY_KEY`. | (disabled) |
+| `MCP_GATEWAY_ENCLAVE_CAPABILITY_KEY` | Workflow-run root key used only to verify AWF-minted invocation capabilities. Must be exactly 64 lowercase hex characters and must not be exposed to the enclave. | (disabled) |
+
+When either enclave variable is set, both are required and proxy startup also requires a GitHub token. Enclave mode rejects `--policy`, trusted-bot overrides, and trusted-user overrides; it synthesizes the guard policy from the enclave policy and forces DIFC propagation mode.
 
 ## GitHub Actions Runtime Variables
 

--- a/docs/PROXY_MODE.md
+++ b/docs/PROXY_MODE.md
@@ -119,13 +119,13 @@ Only canonical lowercase repository paths using `GET` are accepted:
 
 The profile supports `gh api --method GET` for those endpoints, including allowlisted issue filters and pagination. It does **not** support `gh issue list`, `gh issue view`, GraphQL, search, metadata, `/reflect`, writes, downloads, arbitrary repository routes, encoded paths, or redirects.
 
-The capability's assigned repository is authorized directly. Every other target receives an exact PAT-backed `GET /repos/{owner}/{repo}` visibility check and is allowed only when GitHub positively reports `public`. Private, internal, unknown, malformed, rate-limited, and failed lookups return the same generic denial without exposing the upstream status or body. Only negative visibility decisions are cached; cache entries contain a normalized repository and boolean decision, never credentials or response bodies.
+The capability initializes its invocation agent with the assigned repository secrecy label `private:<owner>/<repo>`. The DIFC read rule requires resource secrecy to be a subset of agent secrecy: the assigned private repository carries the same tag and is allowed, public resources carry no secrecy tag and are allowed, and any other private repository carries a different tag and is denied before issue data is fetched. Propagate mode cannot expand an enclave invocation beyond its capability-bound assigned-repository secrecy maximum. Every other target also receives an exact PAT-backed `GET /repos/{owner}/{repo}` visibility check and is allowed only when GitHub positively reports `public`. Private, internal, unknown, malformed, rate-limited, and failed lookups return the same generic denial without exposing the upstream status or body. Only negative visibility decisions are cached; cache entries contain a normalized repository and expiry, never credentials or response bodies.
 
 All accepted upstream and guard-enrichment requests discard the inbound Bearer value and use mcpg's PAT. Request traces omit paths until authorization succeeds, and guard logs record payload sizes rather than response bodies.
 
 ### DIFC labels
 
-Assigned private repository responses use the existing `private:<owner>/<repo>` secrecy vocabulary. Confirmed public reads remain public. Per-invocation state is keyed by a non-revealing digest of the run and invocation IDs. Sequential or collection reads preserve the existing aggregation rules: secrecy is a union and integrity is an intersection, so mixed data receives the strongest secrecy and weakest integrity.
+Assigned private repository responses use the existing `private:<owner>/<repo>` secrecy vocabulary. The signed capability binds the invocation's sole private repository label, and the DIFC evaluator hard-denies any resource whose secrecy is not a subset of that label. Confirmed public response data remains public. Per-invocation state is keyed by a non-revealing digest of the run and invocation IDs. Sequential or collection reads preserve the existing aggregation rules: secrecy is a union and integrity is an intersection, so mixed data receives the strongest secrecy and weakest integrity.
 
 ## Reflect Endpoint
 

--- a/docs/PROXY_MODE.md
+++ b/docs/PROXY_MODE.md
@@ -95,7 +95,7 @@ It provides `MCP_GATEWAY_ENCLAVE_CAPABILITY_KEY` as exactly 64 lowercase hex cha
 }
 ```
 
-Startup fails if the policy, root key, or trusted upstream GitHub token is absent or invalid. `--policy`, `--trusted-bots`, and `--trusted-users` cannot be combined with this profile. mcpg derives the composite guard scope from the assigned repositories plus `public`, initializes each invocation with empty secrecy and the configured integrity baseline, and forces `propagate` mode after guard initialization.
+Startup fails if the policy, root key, or trusted upstream GitHub token is absent or invalid. `--policy`, `--trusted-bots`, and `--trusted-users` cannot be combined with this profile. mcpg derives the composite guard scope from the assigned repositories plus `public`, initializes each invocation with its capability-bound `private:<owner>/<repo>` secrecy label and the configured integrity baseline, and forces bounded `propagate` mode after guard initialization.
 
 ### Invocation capability
 

--- a/docs/PROXY_MODE.md
+++ b/docs/PROXY_MODE.md
@@ -60,12 +60,81 @@ gh CLI  →  awmg proxy (localhost:8443, TLS)  →  api.github.com
 
 Write operations (PUT, POST, DELETE, PATCH) pass through unmodified.
 
+## Single-use enclave profile (`issues-read-v1`)
+
+`issues-read-v1` is a separate fail-closed profile for an AWF enclave. Generic proxy mode does not provide this profile's capability or repository boundary and must not be used as a substitute.
+
+### Topology and startup
+
+The gh-aw compiler owns a dedicated mcpg proxy containing the GitHub PAT, policy, and root capability key. AWF attaches it to the private `awf-enclave-github-control` network with alias `awf-enclave-github-proxy:18443`. The enclave connects only to an AWF-owned PAT-free CLI proxy; it never connects directly to mcpg and never receives the PAT or root key.
+
+The compiler labels the mcpg container with:
+
+```text
+com.github.gh-aw.enclave-github.run=<workflow-run-identity>
+```
+
+It provides `MCP_GATEWAY_ENCLAVE_CAPABILITY_KEY` as exactly 64 lowercase hex characters and supplies this mcpg-only policy in `MCP_GATEWAY_ENCLAVE_POLICY_JSON`:
+
+```json
+{
+  "version": 1,
+  "profile": "issues-read-v1",
+  "audience": "gh-aw-enclave-github",
+  "workflow_run_id": "<workflow-run-identity>",
+  "repositories": [
+    {"repo": "owner/name", "sensitivity": "confidential"}
+  ],
+  "public_min_integrity": "approved",
+  "allowed_operations": [
+    "issues.comments.list",
+    "issues.get",
+    "issues.list"
+  ],
+  "max_capability_ttl_seconds": 600
+}
+```
+
+Startup fails if the policy, root key, or trusted upstream GitHub token is absent or invalid. `--policy`, `--trusted-bots`, and `--trusted-users` cannot be combined with this profile. mcpg derives the composite guard scope from the assigned repositories plus `public`, initializes each invocation with empty secrecy and the configured integrity baseline, and forces `propagate` mode after guard initialization.
+
+### Invocation capability
+
+`enclave-mcp-server` mints one capability per invocation, writes it to a mode `0600` file, and removes it with the single-use enclave. The wrapper sends it through AWF's CLI proxy as `Authorization: Bearer <token>`. The compact format is:
+
+```text
+awf-egh1.<base64url-unpadded claims JSON>.<base64url-unpadded HMAC-SHA256>
+```
+
+The signature covers the ASCII `awf-egh1.<encoded-claims>` value using the decoded 32-byte root key. Claims bind `v`, `aud`, `run`, `inv`, assigned `repo`, `profile`, lexicographically sorted `ops`, `nbf`, and `exp`. The `run` claim is compared byte-for-byte with policy `workflow_run_id`, which gh-aw sets to `AWF_ENCLAVE_GITHUB_PROXY_IDENTITY` in the form `gh-aw-egh-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${JOB_HASH}` and validates against `^[a-z0-9][a-z0-9-]{0,63}$`; AWF's internal container run ID is not used. mcpg verifies the signature, workflow run, repository assignment, operation subset, ordering, and compiler-capped lifetime before route authorization. The capability can be reused for the HTTP calls made by that invocation until `exp`; it is never forwarded upstream.
+
+### Supported REST and CLI surface
+
+Only canonical lowercase repository paths using `GET` are accepted:
+
+| Operation | REST path |
+|-----------|-----------|
+| `issues.list` | `/repos/{owner}/{repo}/issues` |
+| `issues.get` | `/repos/{owner}/{repo}/issues/{number}` |
+| `issues.comments.list` | `/repos/{owner}/{repo}/issues/{number}/comments` |
+
+The profile supports `gh api --method GET` for those endpoints, including allowlisted issue filters and pagination. It does **not** support `gh issue list`, `gh issue view`, GraphQL, search, metadata, `/reflect`, writes, downloads, arbitrary repository routes, encoded paths, or redirects.
+
+The capability's assigned repository is authorized directly. Every other target receives an exact PAT-backed `GET /repos/{owner}/{repo}` visibility check and is allowed only when GitHub positively reports `public`. Private, internal, unknown, malformed, rate-limited, and failed lookups return the same generic denial without exposing the upstream status or body. Only negative visibility decisions are cached; cache entries contain a normalized repository and boolean decision, never credentials or response bodies.
+
+All accepted upstream and guard-enrichment requests discard the inbound Bearer value and use mcpg's PAT. Request traces omit paths until authorization succeeds, and guard logs record payload sizes rather than response bodies.
+
+### DIFC labels
+
+Assigned private repository responses use the existing `private:<owner>/<repo>` secrecy vocabulary. Confirmed public reads remain public. Per-invocation state is keyed by a non-revealing digest of the run and invocation IDs. Sequential or collection reads preserve the existing aggregation rules: secrecy is a union and integrity is an intersection, so mixed data receives the strongest secrecy and weakest integrity.
+
 ## Reflect Endpoint
 
 Proxy mode exposes an unauthenticated DIFC reflection endpoint:
 
 - `GET /reflect`
 - `GET /api/v3/reflect` (`GH_HOST` style REST base path used by `gh` against GHES/proxy targets; normalized to `/reflect`)
+
+The enclave profile disables `/reflect`; only `/health` and `/healthz` remain unauthenticated.
 
 Response schema:
 

--- a/guards/github-guard/docs/agentic-workflow-policy.schema.json
+++ b/guards/github-guard/docs/agentic-workflow-policy.schema.json
@@ -31,6 +31,10 @@
                 "type": "string",
                 "oneOf": [
                   {
+                    "description": "Public repository catch-all. May be combined with exact or wildcard private scopes.",
+                    "const": "public"
+                  },
+                  {
                     "description": "Owner wildcard scope. Example: owner/*",
                     "pattern": "^[a-z0-9_-]{1,39}/\\*$"
                   },

--- a/guards/github-guard/rust-guard/src/labels/helpers.rs
+++ b/guards/github-guard/rust-guard/src/labels/helpers.rs
@@ -316,11 +316,17 @@ fn first_matching_scope<'a>(
     repo: &str,
     ctx: &'a PolicyContext,
 ) -> Option<&'a PolicyScopeEntry> {
-    ctx.scopes.iter().find(|scope| {
+    let matches = |scope: &&PolicyScopeEntry| {
         let scoped_owner = scope.scope_owner.as_deref().unwrap_or("");
         let scoped_repo = scope.scope_repo.as_deref().unwrap_or("");
         repo_matches_scope(scope.scope_kind, owner, repo, scoped_owner, scoped_repo)
-    })
+    };
+
+    ctx.scopes
+        .iter()
+        .filter(|scope| !matches!(scope.scope_kind, ScopeKind::All | ScopeKind::Public))
+        .find(matches)
+        .or_else(|| ctx.scopes.iter().find(matches))
 }
 
 fn format_integrity_label(prefix: &str, scope: &str, base: &str) -> String {
@@ -1038,10 +1044,11 @@ pub(crate) fn repo_visibility_secrecy(
         Some(true) => policy_private_scope_label(owner, repo, repo_id, ctx),
         Some(false) => vec![],
         None => {
-            if ctx
-                .scopes
-                .iter()
-                .any(|scope| matches!(scope.scope_kind, ScopeKind::Public))
+            if !ctx.scopes.is_empty()
+                && ctx
+                    .scopes
+                    .iter()
+                    .all(|scope| matches!(scope.scope_kind, ScopeKind::Public))
             {
                 return vec![];
             }
@@ -2557,6 +2564,40 @@ mod tests {
         assert_eq!(
             repo_visibility_secrecy("owner", "repo", "owner/repo", &ctx),
             Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn test_concrete_scope_precedes_public_scope() {
+        let owner = "enclave-scope-owner";
+        let repo = "enclave-scope-repo";
+        let repo_id = format!("{owner}/{repo}");
+        let ctx = PolicyContext {
+            scopes: vec![
+                PolicyScopeEntry {
+                    scope_kind: ScopeKind::Public,
+                    scope_owner: None,
+                    scope_repo: None,
+                    scope_label: "public".to_string(),
+                },
+                PolicyScopeEntry {
+                    scope_kind: ScopeKind::Repo,
+                    scope_owner: Some(owner.to_string()),
+                    scope_repo: Some(repo.to_string()),
+                    scope_label: repo_id.clone(),
+                },
+            ],
+            ..Default::default()
+        };
+        let _guard = super::super::backend::cache_repo_visibility_for_tests(&repo_id, true);
+
+        assert_eq!(
+            policy_private_scope_label(owner, repo, &repo_id, &ctx),
+            vec![format!("private:{repo_id}")]
+        );
+        assert_eq!(
+            repo_visibility_secrecy(owner, repo, &repo_id, &ctx),
+            vec![format!("private:{repo_id}")]
         );
     }
 

--- a/guards/github-guard/rust-guard/src/labels/mod.rs
+++ b/guards/github-guard/rust-guard/src/labels/mod.rs
@@ -3836,6 +3836,58 @@ mod tests {
     }
 
     #[test]
+    fn test_issue_read_comments_are_labeled_per_author() {
+        let ctx = default_ctx();
+        let tool_args = json!({
+            "owner": "github",
+            "repo": "gh-aw-mcpg",
+            "issue_number": 2278,
+            "method": "get_comments"
+        });
+        let response = json!([
+            {
+                "id": 1,
+                "user": {"login": "github-actions[bot]"},
+                "author_association": "NONE",
+                "body": "trusted"
+            },
+            {
+                "id": 2,
+                "user": {"login": "external"},
+                "author_association": "CONTRIBUTOR",
+                "body": "untrusted"
+            }
+        ]);
+
+        let items = label_response_items("issue_read", &tool_args, &response, &ctx);
+        assert_eq!(items.len(), 2);
+        assert!(items[0]
+            .labels
+            .integrity
+            .iter()
+            .any(|label| label.starts_with("approved:")));
+        assert!(items[1]
+            .labels
+            .integrity
+            .iter()
+            .any(|label| label.starts_with("unapproved:")));
+
+        let paths = label_response_paths("issue_read", &tool_args, &response, &ctx)
+            .expect("comment arrays must receive path labels");
+        assert_eq!(paths.labeled_paths.len(), 2);
+        assert!(paths.labeled_paths[0]
+            .labels
+            .integrity
+            .iter()
+            .any(|label| label.starts_with("approved:")));
+        assert!(paths.labeled_paths[1]
+            .labels
+            .integrity
+            .iter()
+            .any(|label| label.starts_with("unapproved:")));
+    }
+
+    #[test]
     fn test_label_response_items_pull_request_read_member() {
         // pull_request_read should label responses the same as get_pull_request
         let ctx = default_ctx();

--- a/guards/github-guard/rust-guard/src/labels/mod.rs
+++ b/guards/github-guard/rust-guard/src/labels/mod.rs
@@ -2634,6 +2634,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_unknown_visibility_with_exact_and_public_scopes_is_not_assumed_public() {
+        let ctx = PolicyContext {
+            scopes: vec![
+                PolicyScopeEntry {
+                    scope_kind: ScopeKind::Repo,
+                    scope_owner: Some("assigned".to_string()),
+                    scope_repo: Some("private".to_string()),
+                    scope_label: "assigned/private".to_string(),
+                },
+                PolicyScopeEntry {
+                    scope_kind: ScopeKind::Public,
+                    scope_owner: None,
+                    scope_repo: None,
+                    scope_label: "public".to_string(),
+                },
+            ],
+            ..Default::default()
+        };
+        let inherited = vec!["private:other/repo".to_string()];
+        let tool_args = json!({"owner": "other", "repo": "repo"});
+
+        let (secrecy, _, _) = apply_tool_labels(
+            "actions_list",
+            &tool_args,
+            "other/repo",
+            inherited.clone(),
+            vec![],
+            String::new(),
+            &ctx,
+        );
+
+        assert_eq!(
+            secrecy, inherited,
+            "a composite exact-plus-public policy must not treat unknown visibility as public"
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Context: get_me
     // -------------------------------------------------------------------------

--- a/guards/github-guard/rust-guard/src/labels/response_items.rs
+++ b/guards/github-guard/rust-guard/src/labels/response_items.rs
@@ -245,7 +245,9 @@ pub fn label_response_items(
                 .get(field_names::METHOD)
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            if is_non_get_read_sub_method(tool_name, tool_names::ISSUE_READ, method) {
+            if is_non_get_read_sub_method(tool_name, tool_names::ISSUE_READ, method)
+                && method != "get_comments"
+            {
                 // Fall through — use resource-level labels from tool_rules
             } else {
                 let items = extract_items_slice(&actual_response, "issues");

--- a/guards/github-guard/rust-guard/src/labels/response_paths.rs
+++ b/guards/github-guard/rust-guard/src/labels/response_paths.rs
@@ -258,7 +258,9 @@ pub fn label_response_paths(
                 .get(field_names::METHOD)
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
-            if is_non_get_read_sub_method(tool_name, tool_names::ISSUE_READ, method) {
+            if is_non_get_read_sub_method(tool_name, tool_names::ISSUE_READ, method)
+                && method != "get_comments"
+            {
                 // Fall through — use resource-level labels
             } else if let Some(repo_item_ctx) = resolve_repo_item_context(
                 tool_name,

--- a/guards/github-guard/rust-guard/src/labels/tool_rules.rs
+++ b/guards/github-guard/rust-guard/src/labels/tool_rules.rs
@@ -34,10 +34,11 @@ fn apply_repo_visibility_secrecy(
         Some(true) => policy_private_scope_label(owner, repo, repo_id, ctx),
         Some(false) => vec![],
         None => {
-            if ctx
+            if !ctx.scopes.is_empty()
+                && ctx
                 .scopes
                 .iter()
-                .any(|scope| matches!(scope.scope_kind, ScopeKind::Public))
+                .all(|scope| matches!(scope.scope_kind, ScopeKind::Public))
             {
                 return vec![];
             }

--- a/guards/github-guard/rust-guard/src/lib.rs
+++ b/guards/github-guard/rust-guard/src/lib.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;
 use std::alloc::{alloc as std_alloc, dealloc as std_dealloc, Layout};
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::ops::Deref;
 use std::slice;
 use std::sync::{Arc, Mutex};
@@ -29,23 +30,6 @@ use std::sync::{Arc, Mutex};
 const POLICY_SCOPE_ALL: &str = "all";
 const POLICY_SCOPE_PUBLIC: &str = "public";
 const DIFC_MODE: &str = "filter";
-
-/// Maximum number of bytes to include in a log preview of serialized JSON.
-const PREVIEW_MAX_BYTES: usize = 500;
-
-/// Truncate a string to at most `max_bytes` bytes on a valid UTF-8 character
-/// boundary. Returns the full string when it is shorter than the limit.
-fn safe_preview(s: &str, max_bytes: usize) -> &str {
-    if s.len() <= max_bytes {
-        return s;
-    }
-
-    let mut end = max_bytes;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
 
 fn should_fallback_to_single_item_label(response: &Value) -> bool {
     !response.is_array()
@@ -751,8 +735,28 @@ fn parse_scope(scope: ReposValue) -> Result<Vec<PolicyScopeEntry>, String> {
                 return Err("AllowOnly.repos array must contain at least one scope".to_string());
             }
 
+            let mut seen = HashSet::with_capacity(scopes.len());
             for scope_entry in scopes {
-                let (scope_kind, scope_owner, scope_repo) = parse_scoped_entry(scope_entry.trim())?;
+                let scope_entry = scope_entry.trim();
+                if !seen.insert(scope_entry.to_string()) {
+                    return Err("AllowOnly.repos entries must be unique".to_string());
+                }
+                if scope_entry == POLICY_SCOPE_ALL {
+                    return Err(
+                        "AllowOnly.repos 'all' cannot be combined with other scopes".to_string()
+                    );
+                }
+                if scope_entry == POLICY_SCOPE_PUBLIC {
+                    entries.push(PolicyScopeEntry {
+                        scope_kind: ScopeKind::Public,
+                        scope_owner: None,
+                        scope_repo: None,
+                        scope_label: POLICY_SCOPE_PUBLIC.to_string(),
+                    });
+                    continue;
+                }
+
+                let (scope_kind, scope_owner, scope_repo) = parse_scoped_entry(scope_entry)?;
                 let scope_label =
                     scope_string(scope_kind, scope_owner.as_deref(), scope_repo.as_deref());
                 entries.push(PolicyScopeEntry {
@@ -962,24 +966,7 @@ pub extern "C" fn label_response(
     // Read input bytes
     let input_bytes = unsafe { slice::from_raw_parts(input_ptr as *const u8, input_len as usize) };
 
-    // Log a bounded preview of the input for debugging.
-    // Only decode up to PREVIEW_MAX_BYTES so logging stays cheap, and
-    // if the prefix ends mid-codepoint, fall back to the valid UTF-8 prefix.
-    let preview_bytes = &input_bytes[..input_bytes.len().min(PREVIEW_MAX_BYTES)];
-    let preview = match std::str::from_utf8(preview_bytes) {
-        Ok(s) => s,
-        Err(e) => {
-            let valid_up_to = e.valid_up_to();
-            if valid_up_to == 0 {
-                ""
-            } else {
-                std::str::from_utf8(&preview_bytes[..valid_up_to]).unwrap_or("")
-            }
-        }
-    };
-    if !preview.is_empty() {
-        log_info(&format!("    input_preview={}", preview));
-    }
+    log_info(&format!("    input_bytes={}", input_bytes.len()));
 
     // Parse input JSON
     let input: LabelResponseInput = match serde_json::from_slice(input_bytes) {
@@ -1020,9 +1007,7 @@ pub extern "C" fn label_response(
             }
         };
 
-        // Log output preview for debugging
-        let output_preview = safe_preview(&output_json, PREVIEW_MAX_BYTES);
-        log_info(&format!("    path_output_preview={}", output_preview));
+        log_info(&format!("    path_output_bytes={}", output_json.len()));
 
         let n = try_write_json_output(&output_json, output_ptr, output_size, "label_response/path");
         if n < 0 {
@@ -1070,9 +1055,7 @@ pub extern "C" fn label_response(
         }
     };
 
-    // Log output preview for debugging
-    let output_preview = safe_preview(&output_json, PREVIEW_MAX_BYTES);
-    log_info(&format!("    output_preview={}", output_preview));
+    log_info(&format!("    output_bytes={}", output_json.len()));
 
     let n = try_write_json_output(
         &output_json,
@@ -1214,6 +1197,30 @@ mod tests {
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].scope_kind, ScopeKind::Public);
         assert_eq!(parsed[0].scope_label, "public");
+    }
+
+    #[test]
+    fn parse_scope_accepts_exact_repo_plus_public() {
+        let parsed = parse_scope(ReposValue::ScopedList(vec![
+            "octocat/hello-world".to_string(),
+            "public".to_string(),
+        ]))
+        .expect("exact repo plus public should parse");
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].scope_kind, ScopeKind::Repo);
+        assert_eq!(parsed[1].scope_kind, ScopeKind::Public);
+    }
+
+    #[test]
+    fn parse_scope_rejects_all_in_composite() {
+        let err = parse_scope(ReposValue::ScopedList(vec![
+            "octocat/hello-world".to_string(),
+            "all".to_string(),
+        ]))
+        .expect_err("all must not be combined with scoped entries");
+
+        assert!(err.contains("cannot be combined"));
     }
 
     #[test]
@@ -1657,89 +1664,6 @@ mod tests {
              got: {:?}",
             final_integrity
         );
-    }
-
-    // === UTF-8 safe preview tests (issue #3711) ===
-
-    #[test]
-    fn test_safe_preview_ascii_under_limit() {
-        let s = "hello";
-        assert_eq!(safe_preview(s, 500), "hello");
-    }
-
-    #[test]
-    fn test_safe_preview_ascii_at_limit() {
-        let s = "a".repeat(500);
-        assert_eq!(safe_preview(&s, 500), s.as_str());
-    }
-
-    #[test]
-    fn test_safe_preview_ascii_over_limit() {
-        let s = "a".repeat(600);
-        assert_eq!(safe_preview(&s, 500).len(), 500);
-    }
-
-    #[test]
-    fn test_safe_preview_cjk_boundary() {
-        // Each CJK character is 3 bytes in UTF-8. Build a string where byte 500
-        // falls in the middle of a character (500 is not divisible by 3).
-        // 166 chars = 498 bytes, 167 chars = 501 bytes.
-        let cjk = "中".repeat(167); // 501 bytes
-        assert_eq!(cjk.len(), 501);
-
-        let preview = safe_preview(&cjk, 500);
-        // Must truncate to 498 bytes (166 chars) — the last valid boundary before 500.
-        assert_eq!(preview.len(), 498);
-        assert_eq!(preview.chars().count(), 166);
-    }
-
-    #[test]
-    fn test_safe_preview_emoji_boundary() {
-        // 🎉 is 4 bytes in UTF-8. 125 emojis = 500 bytes exactly (boundary safe).
-        // 126 emojis = 504 bytes; truncating at 500 would split the 126th emoji.
-        let emoji = "🎉".repeat(126); // 504 bytes
-        assert_eq!(emoji.len(), 504);
-
-        let preview = safe_preview(&emoji, 500);
-        // Must truncate to 500 bytes (125 complete emojis).
-        assert_eq!(preview.len(), 500);
-        assert_eq!(preview.chars().count(), 125);
-    }
-
-    #[test]
-    fn test_safe_preview_mixed_content_near_boundary() {
-        // Simulate a JSON string with ASCII keys and a CJK value crossing byte 500.
-        // {"body":"<padding>中中中..."}
-        let prefix = "{\"body\":\""; // 9 bytes
-        let padding = "x".repeat(489); // 489 bytes — total so far: 498
-        let cjk_tail = "中中中中中"; // 5 × 3 = 15 bytes — subtotal: 513
-
-        let json = format!("{}{}{}\"}}", prefix, padding, cjk_tail); // +3 bytes for "\"}}" => 516 total
-        assert!(json.len() > 500);
-
-        let preview = safe_preview(&json, 500);
-        // Byte 498 is the start of the first CJK char (498..501). Byte 500 is
-        // mid-character, so floor_char_boundary(500) should give 498.
-        assert_eq!(preview.len(), 498);
-        // Verify it's valid UTF-8 (implicit — it's a &str).
-        assert!(preview.ends_with('x'));
-    }
-
-    #[test]
-    fn test_safe_preview_empty_string() {
-        assert_eq!(safe_preview("", 500), "");
-    }
-
-    #[test]
-    fn test_safe_preview_two_byte_chars() {
-        // é is 2 bytes in UTF-8. 250 chars = 500 bytes (exact boundary).
-        // 251 chars = 502 bytes; byte 500 is the first byte of the 251st char.
-        let accented = "é".repeat(251); // 502 bytes
-        assert_eq!(accented.len(), 502);
-
-        let preview = safe_preview(&accented, 500);
-        assert_eq!(preview.len(), 500);
-        assert_eq!(preview.chars().count(), 250);
     }
 
     #[test]

--- a/internal/cmd/proxy.go
+++ b/internal/cmd/proxy.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/github/gh-aw-mcpg/internal/config"
 	"github.com/github/gh-aw-mcpg/internal/difc"
+	"github.com/github/gh-aw-mcpg/internal/enclavegithub"
 	"github.com/github/gh-aw-mcpg/internal/envutil"
 	"github.com/github/gh-aw-mcpg/internal/githubhttp"
 	"github.com/github/gh-aw-mcpg/internal/httputil"
@@ -146,20 +147,82 @@ Local usage:
 	return cmd
 }
 
+func resolveEnclaveProxyConfig(
+	policyRaw string,
+	capabilityKey string,
+	explicitGuardPolicy string,
+	trustedBots []string,
+	trustedUsers []string,
+) (*proxy.EnclaveConfig, string, bool, error) {
+	enabled := policyRaw != "" || capabilityKey != ""
+	if !enabled {
+		return nil, "", false, nil
+	}
+	if policyRaw == "" || capabilityKey == "" {
+		return nil, "", true, fmt.Errorf(
+			"%s and %s must be configured together",
+			enclavegithub.EnvPolicyJSON,
+			enclavegithub.EnvCapabilityKey,
+		)
+	}
+	if explicitGuardPolicy != "" {
+		return nil, "", true, fmt.Errorf(
+			"--policy and %s cannot be combined",
+			enclavegithub.EnvPolicyJSON,
+		)
+	}
+	if len(trustedBots) != 0 || len(trustedUsers) != 0 {
+		return nil, "", true, fmt.Errorf(
+			"trusted bot and user overrides are not supported in enclave proxy mode",
+		)
+	}
+
+	policy, err := enclavegithub.ParsePolicy(policyRaw)
+	if err != nil {
+		return nil, "", true, err
+	}
+	verifier, err := enclavegithub.NewVerifier(capabilityKey, policy)
+	if err != nil {
+		return nil, "", true, err
+	}
+	guardPolicy, err := policy.GuardPolicyJSON()
+	if err != nil {
+		return nil, "", true, err
+	}
+	return &proxy.EnclaveConfig{Policy: policy, Verifier: verifier}, guardPolicy, true, nil
+}
+
 func runProxy(cmd *cobra.Command, args []string) error {
 	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	logProxyCmd.Printf("Starting proxy: listen=%s, guard=%s, mode=%s, tls=%v", proxyListen, proxyGuardWasm, proxyDIFCMode, proxyTLS)
+	enclavePolicyRaw := os.Getenv(enclavegithub.EnvPolicyJSON)
+	enclaveCapabilityKey := os.Getenv(enclavegithub.EnvCapabilityKey)
+	enclaveConfig, enclaveGuardPolicy, enclaveEnabled, err := resolveEnclaveProxyConfig(
+		enclavePolicyRaw,
+		enclaveCapabilityKey,
+		proxyPolicy,
+		proxyTrustedBots,
+		proxyTrustedUsers,
+	)
+	if err != nil {
+		return err
+	}
+	effectiveDIFCMode := proxyDIFCMode
+	if enclaveEnabled {
+		effectiveDIFCMode = difc.ModePropagate
+	}
 
-	if _, err := difc.ParseEnforcementMode(proxyDIFCMode); err != nil {
+	logProxyCmd.Printf("Starting proxy: listen=%s, guard=%s, mode=%s, tls=%v, enclave=%v", proxyListen, proxyGuardWasm, effectiveDIFCMode, proxyTLS, enclaveEnabled)
+
+	if _, err := difc.ParseEnforcementMode(effectiveDIFCMode); err != nil {
 		return fmt.Errorf("invalid --guards-mode flag: %w", err)
 	}
 
 	// Initialize loggers
 	logger.InitProxyLoggers(proxyLogDir)
 
-	logger.LogInfo("startup", "MCPG Proxy starting: listen=%s, guard=%s, mode=%s, tls=%v", proxyListen, proxyGuardWasm, proxyDIFCMode, proxyTLS)
+	logger.LogInfo("startup", "MCPG Proxy starting: listen=%s, guard=%s, mode=%s, tls=%v, enclave=%v", proxyListen, proxyGuardWasm, effectiveDIFCMode, proxyTLS, enclaveEnabled)
 
 	resolvedWasmCacheDir, cleanupWasmCache, err := setupWasmCompilationCache(ctx, cmd.Flags().Changed("wasm-cache-dir"), proxyWasmCacheDir, proxyLogDir)
 	if err != nil {
@@ -199,8 +262,11 @@ func runProxy(cmd *cobra.Command, args []string) error {
 		token = envutil.LookupGitHubToken()
 	}
 	if token != "" {
-		logger.LogInfo("startup", "Fallback GitHub token configured from flag/env")
+		logger.LogInfo("startup", "GitHub token configured from flag/env")
 	} else {
+		if enclaveEnabled {
+			return fmt.Errorf("GitHub token is required for enclave proxy mode")
+		}
 		logger.LogInfo("startup", "No fallback token — proxy will forward client Authorization headers")
 	}
 
@@ -219,21 +285,24 @@ func runProxy(cmd *cobra.Command, args []string) error {
 	// This overrides the compiled policy to prevent agents from reading private
 	// repos, even if the compiler misconfigured the allow-only scope.
 	effectivePolicy := proxyPolicy
-	if effectivePolicy != "" {
+	if enclaveEnabled {
+		effectivePolicy = enclaveGuardPolicy
+	} else if effectivePolicy != "" {
 		effectivePolicy = proxyForcePublicReposIfNeeded(ctx, effectivePolicy, token, apiURL)
 	}
 
 	// Create the proxy server
 	logProxyCmd.Printf("Creating proxy server: guard=%s, hasPolicy=%v, mode=%s, trustedBots=%d, trustedUsers=%d",
-		proxyGuardWasm, effectivePolicy != "", proxyDIFCMode, len(proxyTrustedBots), len(proxyTrustedUsers))
+		proxyGuardWasm, effectivePolicy != "", effectiveDIFCMode, len(proxyTrustedBots), len(proxyTrustedUsers))
 	proxySrv, err := proxy.New(ctx, proxy.Config{
 		WasmPath:     proxyGuardWasm,
 		Policy:       effectivePolicy,
 		GitHubToken:  token,
 		GitHubAPIURL: apiURL,
-		DIFCMode:     proxyDIFCMode,
+		DIFCMode:     effectiveDIFCMode,
 		TrustedBots:  proxyTrustedBots,
 		TrustedUsers: proxyTrustedUsers,
+		Enclave:      enclaveConfig,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create proxy server: %w", err)

--- a/internal/cmd/proxy_enclave_test.go
+++ b/internal/cmd/proxy_enclave_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validEnclaveProxyPolicy = `{
+	"version": 1,
+	"profile": "issues-read-v1",
+	"audience": "gh-aw-enclave-github",
+	"workflow_run_id": "run-123",
+	"repositories": [{"repo": "assigned/private", "sensitivity": "confidential"}],
+	"public_min_integrity": "approved",
+	"allowed_operations": ["issues.get", "issues.list"],
+	"max_capability_ttl_seconds": 600
+}`
+
+func TestResolveEnclaveProxyConfig(t *testing.T) {
+	key := strings.Repeat("42", 32)
+	config, guardPolicy, enabled, err := resolveEnclaveProxyConfig(
+		validEnclaveProxyPolicy,
+		key,
+		"",
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.True(t, enabled)
+	require.NotNil(t, config)
+	assert.Equal(t, "issues-read-v1", config.Policy.Profile)
+	assert.JSONEq(t, `{
+		"allow-only": {
+			"repos": ["assigned/private", "public"],
+			"min-integrity": "approved"
+		}
+	}`, guardPolicy)
+}
+
+func TestResolveEnclaveProxyConfigRejectsIncompleteOrConflictingStartup(t *testing.T) {
+	key := strings.Repeat("42", 32)
+	secretKey := strings.Repeat("ab", 32)
+	tests := []struct {
+		name         string
+		policy       string
+		key          string
+		explicit     string
+		trustedBots  []string
+		trustedUsers []string
+		wantEnabled  bool
+		wantErr      string
+		notInError   string
+	}{
+		{name: "disabled", wantEnabled: false},
+		{name: "missing key", policy: validEnclaveProxyPolicy, wantEnabled: true, wantErr: "must be configured together"},
+		{name: "missing policy", key: key, wantEnabled: true, wantErr: "must be configured together"},
+		{name: "explicit guard policy", policy: validEnclaveProxyPolicy, key: key, explicit: `{}`, wantEnabled: true, wantErr: "cannot be combined"},
+		{name: "trusted bots", policy: validEnclaveProxyPolicy, key: key, trustedBots: []string{"bot"}, wantEnabled: true, wantErr: "not supported"},
+		{name: "trusted users", policy: validEnclaveProxyPolicy, key: key, trustedUsers: []string{"user"}, wantEnabled: true, wantErr: "not supported"},
+		{name: "invalid key", policy: validEnclaveProxyPolicy, key: secretKey + "0", wantEnabled: true, wantErr: "64 lowercase hex", notInError: secretKey},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config, guardPolicy, enabled, err := resolveEnclaveProxyConfig(
+				test.policy,
+				test.key,
+				test.explicit,
+				test.trustedBots,
+				test.trustedUsers,
+			)
+			assert.Equal(t, test.wantEnabled, enabled)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				assert.Nil(t, config)
+				assert.Empty(t, guardPolicy)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+			if test.notInError != "" {
+				assert.NotContains(t, err.Error(), test.notInError)
+			}
+			assert.Nil(t, config)
+			assert.Empty(t, guardPolicy)
+		})
+	}
+}

--- a/internal/config/config_difc_test.go
+++ b/internal/config/config_difc_test.go
@@ -478,10 +478,15 @@ func TestParseGuardPolicyJSON_UpdatedRepoRegex(t *testing.T) {
 		assert.Equal(t, IntegrityUnapproved, normalized.MinIntegrity)
 	})
 
-	t.Run("rejects dot in repo scope", func(t *testing.T) {
-		_, err := ParseGuardPolicyJSON(`{"allow-only":{"repos":["owner/repo.name"],"min-integrity":"unapproved"}}`)
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "invalid")
+	t.Run("accepts dot in repo scope", func(t *testing.T) {
+		policy, err := ParseGuardPolicyJSON(`{"allow-only":{"repos":["owner/repo.name"],"min-integrity":"unapproved"}}`)
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+
+		normalized, err := NormalizeGuardPolicy(policy)
+		require.NoError(t, err)
+		assert.Equal(t, "scoped", normalized.ScopeKind)
+		assert.Equal(t, []string{"owner/repo.name"}, normalized.ScopeValues)
 	})
 }
 

--- a/internal/config/guard_policy_test.go
+++ b/internal/config/guard_policy_test.go
@@ -146,6 +146,24 @@ func TestNormalizeGuardPolicy(t *testing.T) {
 			wantIntegrity: "approved",
 		},
 		{
+			name: "repos array combines exact repo and public",
+			policy: &GuardPolicy{AllowOnly: &AllowOnlyPolicy{
+				Repos:        []string{"myorg/repo", "public"},
+				MinIntegrity: "approved",
+			}},
+			wantScopeKind: "scoped",
+			wantScopes:    []string{"myorg/repo", "public"},
+			wantIntegrity: "approved",
+		},
+		{
+			name: "repos array rejects all composite",
+			policy: &GuardPolicy{AllowOnly: &AllowOnlyPolicy{
+				Repos:        []string{"myorg/repo", "all"},
+				MinIntegrity: "approved",
+			}},
+			wantErr: "cannot be combined",
+		},
+		{
 			name: "repos empty array",
 			policy: &GuardPolicy{AllowOnly: &AllowOnlyPolicy{
 				Repos:        []interface{}{},

--- a/internal/config/guard_policy_test.go
+++ b/internal/config/guard_policy_test.go
@@ -501,7 +501,7 @@ func TestIsValidRepoScope(t *testing.T) {
 
 		// Invalid repo
 		{"repo too long 101 chars", "owner/" + strings.Repeat("a", 101), false},
-		{"repo with dot", "owner/repo.name", false},
+		{"repo with dot", "owner/repo.name", true},
 		{"repo with uppercase", "owner/Repo", false},
 		{"repo with space", "owner/repo name", false},
 
@@ -566,7 +566,7 @@ func TestIsValidRepoName(t *testing.T) {
 		{"hyphen", "my-repo", true},
 		{"underscore", "my_repo", true},
 		{"uppercase letter", "MyRepo", false},
-		{"dot", "my.repo", false},
+		{"dot", "my.repo", true},
 		{"space", "my repo", false},
 		{"mixed valid chars", "my-repo_123", true},
 	}
@@ -608,9 +608,9 @@ func TestNormalizeAndValidateScopeArray(t *testing.T) {
 			wantErr: "repos is required",
 		},
 		{
-			name:    "invalid scope pattern",
-			scopes:  []interface{}{"owner/repo.invalid"},
-			wantErr: "is invalid",
+			name:       "scope with dotted repo",
+			scopes:     []interface{}{"owner/repo.invalid"},
+			wantResult: []string{"owner/repo.invalid"},
 		},
 		{
 			name:    "duplicate scopes",

--- a/internal/config/guard_policy_validation.go
+++ b/internal/config/guard_policy_validation.go
@@ -249,8 +249,11 @@ func normalizeAndValidateScopeArray(scopes []interface{}) ([]string, error) {
 			return nil, err
 		}
 
-		if !isValidRepoScope(scopeString) {
-			return nil, fmt.Errorf("allow-only.repos scope %q is invalid; expected owner/*, owner/repo, or owner/re*", scopeString)
+		if scopeString == "all" {
+			return nil, fmt.Errorf("allow-only.repos scope %q cannot be combined with other scopes", scopeString)
+		}
+		if scopeString != "public" && !isValidRepoScope(scopeString) {
+			return nil, fmt.Errorf("allow-only.repos scope %q is invalid; expected public, owner/*, owner/repo, or owner/re*", scopeString)
 		}
 
 		if _, exists := seen[scopeString]; exists {

--- a/internal/config/guard_policy_validation.go
+++ b/internal/config/guard_policy_validation.go
@@ -331,7 +331,15 @@ func isValidRepoOwner(owner string) bool {
 }
 
 func isValidRepoName(repo string) bool {
-	return isValidTokenString(repo, 100)
+	if len(repo) < 1 || len(repo) > 100 {
+		return false
+	}
+	for i := 0; i < len(repo); i++ {
+		if !isScopeTokenChar(repo[i]) && repo[i] != '.' {
+			return false
+		}
+	}
+	return true
 }
 
 func isScopeTokenChar(char byte) bool {

--- a/internal/difc/evaluator.go
+++ b/internal/difc/evaluator.go
@@ -164,6 +164,7 @@ type EvaluationResult struct {
 	SecrecyToAdd    []Tag  // Secrecy tags agent must add to proceed
 	IntegrityToDrop []Tag  // Integrity tags agent must drop to proceed
 	Reason          string // Human-readable reason for denial
+	hardDeny        bool
 }
 
 // IsAllowed returns true if access is allowed (either directly or with propagation)
@@ -176,9 +177,15 @@ func (e *EvaluationResult) RequiresPropagation() bool {
 	return e.Decision == AccessAllowWithPropagate
 }
 
+// MustDeny reports whether a policy boundary forbids propagation.
+func (e *EvaluationResult) MustDeny() bool {
+	return e.hardDeny
+}
+
 // Evaluator performs DIFC policy evaluation
 type Evaluator struct {
-	mode EnforcementMode
+	mode                  EnforcementMode
+	secrecyPropagationMax *SecrecyLabel
 }
 
 // NewEvaluator creates a new DIFC evaluator with strict enforcement mode
@@ -189,6 +196,15 @@ func NewEvaluator() *Evaluator {
 // NewEvaluatorWithMode creates a new DIFC evaluator with the specified enforcement mode
 func NewEvaluatorWithMode(mode EnforcementMode) *Evaluator {
 	return &Evaluator{mode: mode}
+}
+
+// WithSecrecyPropagationMax returns an evaluator that may propagate only the
+// supplied secrecy tags. Reads requiring any other secrecy tag are denied.
+func (e *Evaluator) WithSecrecyPropagationMax(tags ...Tag) *Evaluator {
+	return &Evaluator{
+		mode:                  e.mode,
+		secrecyPropagationMax: NewSecrecyLabel(tags...),
+	}
 }
 
 // SetMode sets the enforcement mode
@@ -266,6 +282,20 @@ func (e *Evaluator) evaluateRead(
 
 	// In propagate mode, reads are allowed but may require label changes
 	if e.mode == EnforcementPropagate {
+		if e.secrecyPropagationMax != nil {
+			withinMax, unauthorizedTags := resource.Secrecy.CheckFlow(e.secrecyPropagationMax)
+			if !withinMax {
+				result.Decision = AccessDeny
+				result.SecrecyToAdd = unauthorizedTags
+				result.Reason = fmt.Sprintf(
+					"Resource '%s' requires secrecy tags outside the invocation capability.",
+					resource.Description,
+				)
+				result.hardDeny = true
+				return result
+			}
+		}
+
 		// Propagate mode: allow the read and record which labels need to change
 		if !integrityOk || !secrecyOk {
 			result.Decision = AccessAllowWithPropagate

--- a/internal/difc/pipeline_decisions.go
+++ b/internal/difc/pipeline_decisions.go
@@ -35,6 +35,10 @@ func EvaluateCoarseAccess(
 		logPipeline.Printf("EvaluateCoarseAccess: outcome=allowed, operation=%s", operation)
 		return CoarseAllowed, result
 	}
+	if result.MustDeny() {
+		logPipeline.Printf("EvaluateCoarseAccess: outcome=hard-denied, operation=%s, reason=%s", operation, result.Reason)
+		return CoarseDenied, result
+	}
 	if ShouldBypassCoarseDeny(operation) {
 		logPipeline.Printf("EvaluateCoarseAccess: outcome=bypass-for-read, operation=%s", operation)
 		return CoarseBypassForRead, result

--- a/internal/difc/pipeline_decisions_test.go
+++ b/internal/difc/pipeline_decisions_test.go
@@ -98,6 +98,34 @@ func TestEvaluateCoarseAccess(t *testing.T) {
 	}
 }
 
+func TestEvaluateCoarseAccessEnforcesSecrecyPropagationMaximum(t *testing.T) {
+	t.Parallel()
+
+	evaluator := NewEvaluatorWithMode(EnforcementPropagate).
+		WithSecrecyPropagationMax("private:assigned/repo")
+	agentSecrecy := NewSecrecyLabel("private:assigned/repo")
+	agentIntegrity := NewIntegrityLabel()
+
+	assigned := NewLabeledResource("assigned repository")
+	assigned.Secrecy = *NewSecrecyLabel("private:assigned/repo")
+	outcome, result := EvaluateCoarseAccess(
+		evaluator, agentSecrecy, agentIntegrity, assigned, OperationRead,
+	)
+	assert.Equal(t, CoarseAllowed, outcome)
+	assert.False(t, result.RequiresPropagation())
+	assert.False(t, result.MustDeny())
+
+	other := NewLabeledResource("other private repository")
+	other.Secrecy = *NewSecrecyLabel("private:other/repo")
+	outcome, result = EvaluateCoarseAccess(
+		evaluator, agentSecrecy, agentIntegrity, other, OperationRead,
+	)
+	assert.Equal(t, CoarseDenied, outcome)
+	assert.False(t, result.IsAllowed())
+	assert.True(t, result.MustDeny())
+	assert.Equal(t, []Tag{"private:other/repo"}, result.SecrecyToAdd)
+}
+
 func TestShouldBypassCoarseDeny(t *testing.T) {
 	t.Parallel()
 

--- a/internal/enclavegithub/capability.go
+++ b/internal/enclavegithub/capability.go
@@ -1,0 +1,162 @@
+package enclavegithub
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	maxCapabilityTokenBytes = 16 * 1024
+	maxInvocationIDBytes    = 256
+)
+
+// Claims is the invocation-bound capability payload minted by AWF.
+type Claims struct {
+	Version    int      `json:"v"`
+	Audience   string   `json:"aud"`
+	Run        string   `json:"run"`
+	Invocation string   `json:"inv"`
+	Repo       string   `json:"repo"`
+	Profile    string   `json:"profile"`
+	Operations []string `json:"ops"`
+	NotBefore  int64    `json:"nbf"`
+	Expires    int64    `json:"exp"`
+}
+
+// AgentID returns the stable DIFC registry key for this invocation.
+func (c *Claims) AgentID() string {
+	sum := sha256.Sum256([]byte(c.Run + "\x00" + c.Invocation))
+	return "enclave:" + hex.EncodeToString(sum[:16])
+}
+
+// AllowsOperation reports whether the invocation capability permits operation.
+func (c *Claims) AllowsOperation(operation string) bool {
+	return slices.Contains(c.Operations, operation)
+}
+
+// Verifier verifies HMAC-signed invocation capabilities against one workflow policy.
+type Verifier struct {
+	key    []byte
+	policy *Policy
+}
+
+// NewVerifier creates a capability verifier from a 32-byte lowercase-hex root key.
+func NewVerifier(rootKeyHex string, policy *Policy) (*Verifier, error) {
+	if len(rootKeyHex) != 64 || strings.ToLower(rootKeyHex) != rootKeyHex {
+		return nil, fmt.Errorf("enclave capability key must be exactly 64 lowercase hex characters")
+	}
+	key, err := hex.DecodeString(rootKeyHex)
+	if err != nil || len(key) != sha256.Size {
+		return nil, fmt.Errorf("enclave capability key must be exactly 64 lowercase hex characters")
+	}
+	if err := policy.Validate(); err != nil {
+		return nil, err
+	}
+	return &Verifier{key: key, policy: policy}, nil
+}
+
+// VerifyAuthorization verifies a Bearer capability at the current time.
+func (v *Verifier) VerifyAuthorization(header string) (*Claims, error) {
+	return v.verifyAuthorizationAt(header, time.Now())
+}
+
+func (v *Verifier) verifyAuthorizationAt(header string, now time.Time) (*Claims, error) {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) || len(header) == len(prefix) ||
+		strings.ContainsAny(header[len(prefix):], " \t\r\n") {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+	return v.verifyTokenAt(header[len(prefix):], now)
+}
+
+func (v *Verifier) verifyTokenAt(token string, now time.Time) (*Claims, error) {
+	if len(token) == 0 || len(token) > maxCapabilityTokenBytes {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[0] != CapabilityPrefix {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+
+	signingInput := parts[0] + "." + parts[1]
+	providedSignature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil || len(providedSignature) != sha256.Size {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+	mac := hmac.New(sha256.New, v.key)
+	_, _ = mac.Write([]byte(signingInput))
+	expectedSignature := mac.Sum(nil)
+	if subtle.ConstantTimeCompare(providedSignature, expectedSignature) != 1 {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+	var claims Claims
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&claims); err != nil {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+	var extra interface{}
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+	if err := v.validateClaims(&claims, now); err != nil {
+		return nil, fmt.Errorf("invalid enclave capability")
+	}
+	return &claims, nil
+}
+
+func (v *Verifier) validateClaims(claims *Claims, now time.Time) error {
+	if claims.Version != 1 ||
+		claims.Audience != v.policy.Audience ||
+		claims.Run != v.policy.WorkflowRunID ||
+		claims.Profile != v.policy.Profile {
+		return fmt.Errorf("claims binding mismatch")
+	}
+	if claims.Invocation == "" || len(claims.Invocation) > maxInvocationIDBytes ||
+		!invocationPattern.MatchString(claims.Invocation) {
+		return fmt.Errorf("invalid invocation")
+	}
+	if !repositoryPattern.MatchString(claims.Repo) || !v.policy.HasRepository(claims.Repo) {
+		return fmt.Errorf("invalid assigned repository")
+	}
+	if len(claims.Operations) == 0 {
+		return fmt.Errorf("missing operations")
+	}
+	if !slices.IsSorted(claims.Operations) {
+		return fmt.Errorf("operations must be lexicographically sorted")
+	}
+	seen := make(map[string]struct{}, len(claims.Operations))
+	for _, operation := range claims.Operations {
+		if !v.policy.AllowsOperation(operation) {
+			return fmt.Errorf("operation outside policy")
+		}
+		if _, exists := seen[operation]; exists {
+			return fmt.Errorf("duplicate operation")
+		}
+		seen[operation] = struct{}{}
+	}
+	if claims.NotBefore <= 0 || claims.Expires <= claims.NotBefore ||
+		claims.Expires-claims.NotBefore > v.policy.MaxCapabilityTTLSeconds {
+		return fmt.Errorf("invalid capability lifetime")
+	}
+	nowUnix := now.Unix()
+	if nowUnix < claims.NotBefore || nowUnix >= claims.Expires {
+		return fmt.Errorf("capability outside validity window")
+	}
+	return nil
+}

--- a/internal/enclavegithub/policy.go
+++ b/internal/enclavegithub/policy.go
@@ -171,6 +171,16 @@ func (p *Policy) HasRepository(repo string) bool {
 	})
 }
 
+// RepositorySensitivity returns the configured sensitivity for repo.
+func (p *Policy) RepositorySensitivity(repo string) (string, bool) {
+	for _, candidate := range p.Repositories {
+		if candidate.Repo == repo {
+			return candidate.Sensitivity, true
+		}
+	}
+	return "", false
+}
+
 // NormalizeRepository returns a canonical lowercase owner/name repository.
 func NormalizeRepository(repo string) (string, bool) {
 	normalized := strings.ToLower(repo)

--- a/internal/enclavegithub/policy.go
+++ b/internal/enclavegithub/policy.go
@@ -1,0 +1,211 @@
+package enclavegithub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+const (
+	ProfileIssuesReadV1 = "issues-read-v1"
+	DefaultAudience     = "gh-aw-enclave-github"
+	CapabilityPrefix    = "awf-egh1"
+
+	EnvCapabilityKey = "MCP_GATEWAY_ENCLAVE_CAPABILITY_KEY"
+	EnvPolicyJSON    = "MCP_GATEWAY_ENCLAVE_POLICY_JSON"
+
+	OperationIssueCommentsList  = "issues.comments.list"
+	OperationIssuesGet          = "issues.get"
+	OperationIssuesList         = "issues.list"
+	MaxCapabilityTTLSeconds     = 600
+	maxPolicyJSONBytes          = 64 * 1024
+	maxWorkflowRunIdentityBytes = 64
+)
+
+var (
+	repositoryPattern  = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9_.-]{0,38})/[a-z0-9_.-]{1,100}$`)
+	runIdentityPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
+	invocationPattern  = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.:-]{0,255}$`)
+	validOperations    = map[string]struct{}{
+		OperationIssuesList:        {},
+		OperationIssuesGet:         {},
+		OperationIssueCommentsList: {},
+	}
+	validSensitivities = map[string]struct{}{
+		"public":       {},
+		"internal":     {},
+		"confidential": {},
+		"sealed":       {},
+	}
+	validIntegrityLevels = map[string]struct{}{
+		"none":       {},
+		"unapproved": {},
+		"approved":   {},
+		"merged":     {},
+	}
+)
+
+// RepositoryPolicy identifies a repository assignable to an enclave invocation.
+type RepositoryPolicy struct {
+	Repo        string `json:"repo"`
+	Sensitivity string `json:"sensitivity"`
+}
+
+// Policy is the compiler-owned authorization contract for one workflow run.
+type Policy struct {
+	Version                 int                `json:"version"`
+	Profile                 string             `json:"profile"`
+	Audience                string             `json:"audience"`
+	WorkflowRunID           string             `json:"workflow_run_id"`
+	Repositories            []RepositoryPolicy `json:"repositories"`
+	PublicMinIntegrity      string             `json:"public_min_integrity"`
+	AllowedOperations       []string           `json:"allowed_operations"`
+	MaxCapabilityTTLSeconds int64              `json:"max_capability_ttl_seconds"`
+}
+
+// ParsePolicy parses and validates a compiler-generated enclave policy.
+func ParsePolicy(raw string) (*Policy, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("enclave policy is required")
+	}
+	if len(raw) > maxPolicyJSONBytes {
+		return nil, fmt.Errorf("enclave policy exceeds %d bytes", maxPolicyJSONBytes)
+	}
+
+	var policy Policy
+	decoder := json.NewDecoder(bytes.NewBufferString(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&policy); err != nil {
+		return nil, fmt.Errorf("invalid enclave policy JSON: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return nil, err
+	}
+	if err := policy.Validate(); err != nil {
+		return nil, err
+	}
+	return &policy, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra interface{}
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("enclave policy must contain exactly one JSON value")
+		}
+		return fmt.Errorf("invalid enclave policy JSON: %w", err)
+	}
+	return nil
+}
+
+// Validate checks policy invariants and canonicalizes set-like fields.
+func (p *Policy) Validate() error {
+	if p == nil {
+		return fmt.Errorf("enclave policy is required")
+	}
+	if p.Version != 1 {
+		return fmt.Errorf("enclave policy version must be 1")
+	}
+	if p.Profile != ProfileIssuesReadV1 {
+		return fmt.Errorf("unsupported enclave profile %q", p.Profile)
+	}
+	if p.Audience != DefaultAudience {
+		return fmt.Errorf("unsupported enclave audience %q", p.Audience)
+	}
+	if len(p.WorkflowRunID) > maxWorkflowRunIdentityBytes ||
+		!runIdentityPattern.MatchString(p.WorkflowRunID) {
+		return fmt.Errorf("workflow_run_id must be a canonical value no longer than %d bytes", maxWorkflowRunIdentityBytes)
+	}
+	if len(p.Repositories) == 0 {
+		return fmt.Errorf("repositories must contain at least one entry")
+	}
+
+	seenRepos := make(map[string]struct{}, len(p.Repositories))
+	for i := range p.Repositories {
+		repo := &p.Repositories[i]
+		if !repositoryPattern.MatchString(repo.Repo) {
+			return fmt.Errorf("repositories[%d].repo must be canonical lowercase owner/name", i)
+		}
+		if _, exists := seenRepos[repo.Repo]; exists {
+			return fmt.Errorf("repositories must not contain duplicate repo %q", repo.Repo)
+		}
+		seenRepos[repo.Repo] = struct{}{}
+		if _, ok := validSensitivities[repo.Sensitivity]; !ok {
+			return fmt.Errorf("repositories[%d].sensitivity is invalid", i)
+		}
+	}
+
+	if _, ok := validIntegrityLevels[p.PublicMinIntegrity]; !ok {
+		return fmt.Errorf("public_min_integrity must be one of none, unapproved, approved, merged")
+	}
+	if len(p.AllowedOperations) == 0 {
+		return fmt.Errorf("allowed_operations must contain at least one operation")
+	}
+	if !slices.IsSorted(p.AllowedOperations) {
+		return fmt.Errorf("allowed_operations must be lexicographically sorted")
+	}
+	seenOps := make(map[string]struct{}, len(p.AllowedOperations))
+	for _, operation := range p.AllowedOperations {
+		if _, ok := validOperations[operation]; !ok {
+			return fmt.Errorf("unsupported allowed operation %q", operation)
+		}
+		if _, exists := seenOps[operation]; exists {
+			return fmt.Errorf("allowed_operations must not contain duplicate operation %q", operation)
+		}
+		seenOps[operation] = struct{}{}
+	}
+	if p.MaxCapabilityTTLSeconds <= 0 || p.MaxCapabilityTTLSeconds > MaxCapabilityTTLSeconds {
+		return fmt.Errorf("max_capability_ttl_seconds must be between 1 and %d", MaxCapabilityTTLSeconds)
+	}
+	return nil
+}
+
+// HasRepository reports whether repo is an assignable repository in the policy.
+func (p *Policy) HasRepository(repo string) bool {
+	return slices.ContainsFunc(p.Repositories, func(candidate RepositoryPolicy) bool {
+		return candidate.Repo == repo
+	})
+}
+
+// NormalizeRepository returns a canonical lowercase owner/name repository.
+func NormalizeRepository(repo string) (string, bool) {
+	normalized := strings.ToLower(repo)
+	return normalized, repositoryPattern.MatchString(normalized)
+}
+
+// AllowsOperation reports whether operation is enabled by the compiler policy.
+func (p *Policy) AllowsOperation(operation string) bool {
+	return slices.Contains(p.AllowedOperations, operation)
+}
+
+// GuardRepos returns exact assigned repositories followed by the public catch-all.
+func (p *Policy) GuardRepos() []string {
+	repos := make([]string, 0, len(p.Repositories)+1)
+	for _, repository := range p.Repositories {
+		repos = append(repos, repository.Repo)
+	}
+	repos = append(repos, "public")
+	return repos
+}
+
+// GuardPolicyJSON returns the internal allow-only policy for this enclave profile.
+func (p *Policy) GuardPolicyJSON() (string, error) {
+	if err := p.Validate(); err != nil {
+		return "", err
+	}
+	policy := map[string]interface{}{
+		"allow-only": map[string]interface{}{
+			"repos":         p.GuardRepos(),
+			"min-integrity": p.PublicMinIntegrity,
+		},
+	}
+	encoded, err := json.Marshal(policy)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode enclave guard policy: %w", err)
+	}
+	return string(encoded), nil
+}

--- a/internal/enclavegithub/policy_test.go
+++ b/internal/enclavegithub/policy_test.go
@@ -1,0 +1,255 @@
+package enclavegithub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validPolicyJSON() string {
+	return `{
+		"version":1,
+		"profile":"issues-read-v1",
+		"audience":"gh-aw-enclave-github",
+		"workflow_run_id":"run-123",
+		"repositories":[{"repo":"github/gh-aw","sensitivity":"confidential"}],
+		"public_min_integrity":"approved",
+		"allowed_operations":["issues.comments.list","issues.get","issues.list"],
+		"max_capability_ttl_seconds":600
+	}`
+}
+
+func TestParsePolicy(t *testing.T) {
+	policy, err := ParsePolicy(validPolicyJSON())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"github/gh-aw", "public"}, policy.GuardRepos())
+	assert.True(t, policy.HasRepository("github/gh-aw"))
+	assert.True(t, policy.AllowsOperation(OperationIssuesGet))
+}
+
+func TestParsePolicyPreservesCompilerProxyIdentity(t *testing.T) {
+	const identity = "gh-aw-egh-123456-2-abcdef123456"
+	raw := strings.Replace(validPolicyJSON(), `"run-123"`, `"`+identity+`"`, 1)
+	policy, err := ParsePolicy(raw)
+
+	require.NoError(t, err)
+	assert.Equal(t, identity, policy.WorkflowRunID)
+}
+
+func TestParsePolicyRejectsInvalidContracts(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"unknown field", `{"version":1,"extra":true}`},
+		{"uppercase repo", `{"version":1,"profile":"issues-read-v1","audience":"gh-aw-enclave-github","workflow_run_id":"r","repositories":[{"repo":"GitHub/gh-aw","sensitivity":"confidential"}],"public_min_integrity":"approved","allowed_operations":["issues.get"],"max_capability_ttl_seconds":600}`},
+		{"unknown operation", `{"version":1,"profile":"issues-read-v1","audience":"gh-aw-enclave-github","workflow_run_id":"r","repositories":[{"repo":"github/gh-aw","sensitivity":"confidential"}],"public_min_integrity":"approved","allowed_operations":["repos:get"],"max_capability_ttl_seconds":600}`},
+		{"excessive ttl", `{"version":1,"profile":"issues-read-v1","audience":"gh-aw-enclave-github","workflow_run_id":"r","repositories":[{"repo":"github/gh-aw","sensitivity":"confidential"}],"public_min_integrity":"approved","allowed_operations":["issues.get"],"max_capability_ttl_seconds":601}`},
+		{"unsorted operations", `{"version":1,"profile":"issues-read-v1","audience":"gh-aw-enclave-github","workflow_run_id":"r","repositories":[{"repo":"github/gh-aw","sensitivity":"confidential"}],"public_min_integrity":"approved","allowed_operations":["issues.list","issues.get"],"max_capability_ttl_seconds":600}`},
+		{"noncanonical run identity", `{"version":1,"profile":"issues-read-v1","audience":"gh-aw-enclave-github","workflow_run_id":"Run_123","repositories":[{"repo":"github/gh-aw","sensitivity":"confidential"}],"public_min_integrity":"approved","allowed_operations":["issues.get"],"max_capability_ttl_seconds":600}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePolicy(tt.raw)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestVerifierValidatesInvocationBinding(t *testing.T) {
+	policy, err := ParsePolicy(validPolicyJSON())
+	require.NoError(t, err)
+	keyHex := hex.EncodeToString(make([]byte, sha256.Size))
+	verifier, err := NewVerifier(keyHex, policy)
+	require.NoError(t, err)
+	now := time.Unix(1_700_000_000, 0)
+	claims := Claims{
+		Version: 1, Audience: DefaultAudience, Run: "run-123", Invocation: "inv-1",
+		Repo: "github/gh-aw", Profile: ProfileIssuesReadV1,
+		Operations: []string{OperationIssuesGet}, NotBefore: now.Unix() - 1,
+		Expires: now.Unix() + 60,
+	}
+	token := signClaims(t, make([]byte, sha256.Size), claims)
+
+	got, err := verifier.verifyAuthorizationAt("Bearer "+token, now)
+	require.NoError(t, err)
+	assert.Equal(t, claims.Repo, got.Repo)
+	assert.True(t, got.AllowsOperation(OperationIssuesGet))
+	assert.NotContains(t, got.AgentID(), claims.Invocation)
+}
+
+func TestVerifierAcceptsExactAWFPositiveVector(t *testing.T) {
+	const (
+		keyHex     = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+		payload    = `{"v":1,"aud":"gh-aw-enclave-github","run":"run-123","inv":"inv-456","repo":"octo/private","profile":"issues-read-v1","ops":["issues.comments.list","issues.get","issues.list"],"nbf":1787594400,"exp":1787594520}`
+		payloadB64 = "eyJ2IjoxLCJhdWQiOiJnaC1hdy1lbmNsYXZlLWdpdGh1YiIsInJ1biI6InJ1bi0xMjMiLCJpbnYiOiJpbnYtNDU2IiwicmVwbyI6Im9jdG8vcHJpdmF0ZSIsInByb2ZpbGUiOiJpc3N1ZXMtcmVhZC12MSIsIm9wcyI6WyJpc3N1ZXMuY29tbWVudHMubGlzdCIsImlzc3Vlcy5nZXQiLCJpc3N1ZXMubGlzdCJdLCJuYmYiOjE3ODc1OTQ0MDAsImV4cCI6MTc4NzU5NDUyMH0"
+		mac        = "6fDSD-uxmi_fCZMOFmSuckdNBGx5qcWMI1HCgoXtA3o"
+	)
+	policy, err := ParsePolicy(`{
+		"version":1,
+		"profile":"issues-read-v1",
+		"audience":"gh-aw-enclave-github",
+		"workflow_run_id":"run-123",
+		"repositories":[{"repo":"octo/private","sensitivity":"confidential"}],
+		"public_min_integrity":"approved",
+		"allowed_operations":["issues.comments.list","issues.get","issues.list"],
+		"max_capability_ttl_seconds":120
+	}`)
+	require.NoError(t, err)
+	verifier, err := NewVerifier(keyHex, policy)
+	require.NoError(t, err)
+
+	decodedPayload, err := base64.RawURLEncoding.DecodeString(payloadB64)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(decodedPayload))
+
+	token := CapabilityPrefix + "." + payloadB64 + "." + mac
+	claims, err := verifier.verifyAuthorizationAt(
+		"Bearer "+token,
+		time.Unix(1_787_594_460, 0),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "inv-456", claims.Invocation)
+	assert.Equal(t, "run-123", claims.Run)
+	assert.Equal(t, "octo/private", claims.Repo)
+	assert.Equal(t, []string{
+		OperationIssueCommentsList,
+		OperationIssuesGet,
+		OperationIssuesList,
+	}, claims.Operations)
+}
+
+func TestVerifierRejectsAWFVectorWireMutations(t *testing.T) {
+	const validToken = "awf-egh1.eyJ2IjoxLCJhdWQiOiJnaC1hdy1lbmNsYXZlLWdpdGh1YiIsInJ1biI6InJ1bi0xMjMiLCJpbnYiOiJpbnYtNDU2IiwicmVwbyI6Im9jdG8vcHJpdmF0ZSIsInByb2ZpbGUiOiJpc3N1ZXMtcmVhZC12MSIsIm9wcyI6WyJpc3N1ZXMuY29tbWVudHMubGlzdCIsImlzc3Vlcy5nZXQiLCJpc3N1ZXMubGlzdCJdLCJuYmYiOjE3ODc1OTQ0MDAsImV4cCI6MTc4NzU5NDUyMH0.6fDSD-uxmi_fCZMOFmSuckdNBGx5qcWMI1HCgoXtA3o"
+	policy, err := ParsePolicy(`{
+		"version":1,
+		"profile":"issues-read-v1",
+		"audience":"gh-aw-enclave-github",
+		"workflow_run_id":"run-123",
+		"repositories":[{"repo":"octo/private","sensitivity":"confidential"}],
+		"public_min_integrity":"approved",
+		"allowed_operations":["issues.comments.list","issues.get","issues.list"],
+		"max_capability_ttl_seconds":120
+	}`)
+	require.NoError(t, err)
+	verifier, err := NewVerifier(
+		"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+		policy,
+	)
+	require.NoError(t, err)
+
+	mutations := []string{
+		strings.Replace(validToken, CapabilityPrefix, "v1", 1),
+		strings.Replace(validToken, "eyJ2I", "eyJ3I", 1),
+		validToken[:len(validToken)-1] + "A",
+	}
+	for _, token := range mutations {
+		_, err := verifier.verifyAuthorizationAt("Bearer "+token, time.Unix(1_787_594_460, 0))
+		require.Error(t, err)
+		assert.Equal(t, "invalid enclave capability", err.Error())
+	}
+}
+
+func TestVerifierRejectsInvalidCapabilities(t *testing.T) {
+	policy, err := ParsePolicy(validPolicyJSON())
+	require.NoError(t, err)
+	key := make([]byte, sha256.Size)
+	verifier, err := NewVerifier(hex.EncodeToString(key), policy)
+	require.NoError(t, err)
+	now := time.Unix(1_700_000_000, 0)
+	base := Claims{
+		Version: 1, Audience: DefaultAudience, Run: "run-123", Invocation: "inv-1",
+		Repo: "github/gh-aw", Profile: ProfileIssuesReadV1,
+		Operations: []string{OperationIssuesGet}, NotBefore: now.Unix() - 1,
+		Expires: now.Unix() + 60,
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Claims)
+	}{
+		{"wrong version", func(c *Claims) { c.Version = 2 }},
+		{"wrong run", func(c *Claims) { c.Run = "other" }},
+		{"wrong run casing", func(c *Claims) { c.Run = "Run-123" }},
+		{"wrong repo", func(c *Claims) { c.Repo = "github/private" }},
+		{"wrong audience", func(c *Claims) { c.Audience = "other" }},
+		{"wrong profile", func(c *Claims) { c.Profile = "other" }},
+		{"wrong invocation", func(c *Claims) { c.Invocation = "" }},
+		{"expired", func(c *Claims) { c.Expires = now.Unix() }},
+		{"not yet valid", func(c *Claims) { c.NotBefore = now.Unix() + 1; c.Expires = now.Unix() + 60 }},
+		{"operation escalation", func(c *Claims) { c.Operations = []string{"repos:get"} }},
+		{"operation ordering", func(c *Claims) {
+			c.Operations = []string{OperationIssuesList, OperationIssuesGet}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := base
+			claims.Operations = append([]string(nil), base.Operations...)
+			tt.mutate(&claims)
+			_, err := verifier.verifyAuthorizationAt("Bearer "+signClaims(t, key, claims), now)
+			require.Error(t, err)
+			assert.Equal(t, "invalid enclave capability", err.Error())
+		})
+	}
+}
+
+func TestMatchRoute(t *testing.T) {
+	tests := []struct {
+		path      string
+		query     url.Values
+		operation string
+		repo      string
+	}{
+		{"/repos/github/gh-aw/issues", url.Values{"state": {"open"}, "page": {"2"}}, OperationIssuesList, "github/gh-aw"},
+		{"/repos/github/gh-aw/issues/12", nil, OperationIssuesGet, "github/gh-aw"},
+		{"/repos/github/gh-aw/issues/12/comments", url.Values{"per_page": {"100"}}, OperationIssueCommentsList, "github/gh-aw"},
+	}
+	for _, tt := range tests {
+		route, err := MatchRoute(tt.path, tt.query)
+		require.NoError(t, err)
+		assert.Equal(t, tt.operation, route.Operation)
+		assert.Equal(t, tt.repo, route.FullRepo())
+	}
+}
+
+func TestMatchRouteRejectsBroadSurface(t *testing.T) {
+	tests := []struct {
+		path  string
+		query url.Values
+	}{
+		{"/graphql", nil},
+		{"/search/issues", nil},
+		{"/repos/github/gh-aw/pulls", nil},
+		{"/repos/github/gh-aw/issues/0", nil},
+		{"/repos/github/gh-aw/issues", url.Values{"unknown": {"value"}}},
+		{"/repos/github/gh-aw/issues", url.Values{"page": {"1", "2"}}},
+		{"/repos/GitHub/gh-aw/issues", nil},
+		{"/repos/./repo/issues", nil},
+	}
+	for _, tt := range tests {
+		_, err := MatchRoute(tt.path, tt.query)
+		require.Error(t, err)
+	}
+}
+
+func signClaims(t *testing.T, key []byte, claims Claims) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	signingInput := CapabilityPrefix + "." + encoded
+	mac := hmac.New(sha256.New, key)
+	_, err = mac.Write([]byte(signingInput))
+	require.NoError(t, err)
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/internal/enclavegithub/route.go
+++ b/internal/enclavegithub/route.go
@@ -1,0 +1,69 @@
+package enclavegithub
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var (
+	issuesListPath = regexp.MustCompile(`^/repos/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/issues$`)
+	issueGetPath   = regexp.MustCompile(`^/repos/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/issues/([1-9][0-9]*)$`)
+	commentsPath   = regexp.MustCompile(`^/repos/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/issues/([1-9][0-9]*)/comments$`)
+)
+
+var allowedQueryKeys = map[string]map[string]struct{}{
+	OperationIssuesList: {
+		"milestone": {}, "state": {}, "assignee": {}, "creator": {}, "mentioned": {},
+		"labels": {}, "sort": {}, "direction": {}, "since": {}, "per_page": {}, "page": {},
+	},
+	OperationIssuesGet: {},
+	OperationIssueCommentsList: {
+		"since": {}, "per_page": {}, "page": {},
+	},
+}
+
+// Route is a validated issues-read-v1 REST request.
+type Route struct {
+	Operation string
+	Owner     string
+	Repo      string
+	Number    string
+}
+
+// FullRepo returns the canonical lowercase owner/name target.
+func (r *Route) FullRepo() string {
+	return strings.ToLower(r.Owner + "/" + r.Repo)
+}
+
+// MatchRoute matches only the versioned enclave issue-read REST surface.
+func MatchRoute(path string, query url.Values) (*Route, error) {
+	var route Route
+	switch {
+	case issuesListPath.MatchString(path):
+		match := issuesListPath.FindStringSubmatch(path)
+		route = Route{Operation: OperationIssuesList, Owner: match[1], Repo: match[2]}
+	case issueGetPath.MatchString(path):
+		match := issueGetPath.FindStringSubmatch(path)
+		route = Route{Operation: OperationIssuesGet, Owner: match[1], Repo: match[2], Number: match[3]}
+	case commentsPath.MatchString(path):
+		match := commentsPath.FindStringSubmatch(path)
+		route = Route{Operation: OperationIssueCommentsList, Owner: match[1], Repo: match[2], Number: match[3]}
+	default:
+		return nil, fmt.Errorf("unsupported enclave route")
+	}
+	fullRepo := route.Owner + "/" + route.Repo
+	normalizedRepo, valid := NormalizeRepository(fullRepo)
+	if !valid || normalizedRepo != fullRepo {
+		return nil, fmt.Errorf("unsupported enclave route")
+	}
+
+	allowed := allowedQueryKeys[route.Operation]
+	for key, values := range query {
+		if _, ok := allowed[key]; !ok || len(values) != 1 {
+			return nil, fmt.Errorf("unsupported enclave query")
+		}
+	}
+	return &route, nil
+}

--- a/internal/guard/wasm_lifecycle.go
+++ b/internal/guard/wasm_lifecycle.go
@@ -629,7 +629,7 @@ func isWasmTrap(err error) bool {
 }
 
 // callWasmGuardFunction serialises WASM access, sets the backend reference, marshals
-// inputData, logs the input, calls the named WASM export, and returns the raw result.
+// inputData, logs its size, calls the named WASM export, and returns the raw result.
 // All three public dispatch methods (LabelAgent, LabelResource, LabelResponse) share
 // this preamble; keeping it in one place ensures locking and backend-update logic
 // cannot drift between them.
@@ -644,7 +644,7 @@ func (g *WasmGuard) callWasmGuardFunction(ctx context.Context, funcName string, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal %s input: %w", funcName, err)
 	}
-	logWasm.Printf("%s input JSON (%d bytes): %s", funcName, len(inputJSON), string(inputJSON))
+	logWasm.Printf("%s input JSON: %d bytes", funcName, len(inputJSON))
 
 	return g.callWasmFunction(ctx, funcName, inputJSON)
 }

--- a/internal/guard/wasm_secret_logging_test.go
+++ b/internal/guard/wasm_secret_logging_test.go
@@ -1,0 +1,55 @@
+package guard
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/github/gh-aw-mcpg/internal/difc"
+	"github.com/github/gh-aw-mcpg/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWasmGuardLogsPayloadSizeWithoutResponseBody(t *testing.T) {
+	t.Setenv("DEBUG", "*")
+	require.NoError(t, logger.CloseAllLoggers())
+	logDir := t.TempDir()
+	logger.InitProxyLoggers(logDir)
+	t.Cleanup(func() {
+		require.NoError(t, logger.CloseAllLoggers())
+	})
+
+	guard, cleanup := setupRawWasmModule(t, labelResponseWritesEmptyObjectWasm, "secret-log-test")
+	defer cleanup()
+	const privateBodyMarker = "PRIVATE_RESPONSE_BODY_MUST_NOT_BE_LOGGED"
+	_, err := guard.LabelResponse(
+		context.Background(),
+		"issue_read",
+		map[string]interface{}{"body": privateBodyMarker},
+		nil,
+		difc.NewCapabilities(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, logger.CloseAllLoggers())
+
+	var combined strings.Builder
+	require.NoError(t, filepath.WalkDir(logDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		combined.Write(content)
+		return nil
+	}))
+	assert.NotContains(t, combined.String(), privateBodyMarker)
+}

--- a/internal/proxy/enclave.go
+++ b/internal/proxy/enclave.go
@@ -8,27 +8,35 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/github/gh-aw-mcpg/internal/difc"
 	"github.com/github/gh-aw-mcpg/internal/enclavegithub"
 	"github.com/github/gh-aw-mcpg/internal/githubhttp"
 	"github.com/github/gh-aw-mcpg/internal/httputil"
 )
 
-const maxEnclaveVisibilityResponseBytes = 1024 * 1024
+const (
+	maxEnclaveVisibilityResponseBytes    = 1024 * 1024
+	maxEnclaveVisibilityDeniedCacheItems = 1024
+	enclaveVisibilityDeniedCacheTTL      = 5 * time.Minute
+)
 
 type enclaveState struct {
 	policy   *enclavegithub.Policy
 	verifier *enclavegithub.Verifier
 
 	visibilityMu        sync.RWMutex
-	visibilityDecisions map[string]bool
+	visibilityDecisions map[string]time.Time
+	now                 func() time.Time
 }
 
 func newEnclaveState(policy *enclavegithub.Policy, verifier *enclavegithub.Verifier) *enclaveState {
 	return &enclaveState{
 		policy:              policy,
 		verifier:            verifier,
-		visibilityDecisions: make(map[string]bool),
+		visibilityDecisions: make(map[string]time.Time),
+		now:                 time.Now,
 	}
 }
 
@@ -47,11 +55,16 @@ func agentIDFromContext(ctx context.Context) string {
 }
 
 func (s *Server) enclaveRepositoryIsPublic(ctx context.Context, repo string) bool {
+	now := s.enclave.now()
+
 	s.enclave.visibilityMu.RLock()
-	decision, cached := s.enclave.visibilityDecisions[repo]
+	deniedUntil, denied := s.enclave.visibilityDecisions[repo]
 	s.enclave.visibilityMu.RUnlock()
-	if cached {
-		return decision
+	if denied {
+		if now.Before(deniedUntil) {
+			return false
+		}
+		s.clearEnclaveVisibilityDenial(repo)
 	}
 
 	resp, err := s.forwardEnclaveVisibilityLookup(ctx, repo)
@@ -96,7 +109,35 @@ func (s *Server) forwardEnclaveVisibilityLookup(ctx context.Context, repo string
 
 func (s *Server) cacheEnclaveVisibilityDenial(repo string) {
 	s.enclave.visibilityMu.Lock()
-	s.enclave.visibilityDecisions[repo] = false
+	defer s.enclave.visibilityMu.Unlock()
+
+	now := s.enclave.now()
+	for cachedRepo, deniedUntil := range s.enclave.visibilityDecisions {
+		if !now.Before(deniedUntil) {
+			delete(s.enclave.visibilityDecisions, cachedRepo)
+		}
+	}
+
+	if len(s.enclave.visibilityDecisions) >= maxEnclaveVisibilityDeniedCacheItems {
+		var oldestRepo string
+		var oldestDeniedUntil time.Time
+		for cachedRepo, deniedUntil := range s.enclave.visibilityDecisions {
+			if oldestRepo == "" || deniedUntil.Before(oldestDeniedUntil) {
+				oldestRepo = cachedRepo
+				oldestDeniedUntil = deniedUntil
+			}
+		}
+		if oldestRepo != "" {
+			delete(s.enclave.visibilityDecisions, oldestRepo)
+		}
+	}
+
+	s.enclave.visibilityDecisions[repo] = now.Add(enclaveVisibilityDeniedCacheTTL)
+}
+
+func (s *Server) clearEnclaveVisibilityDenial(repo string) {
+	s.enclave.visibilityMu.Lock()
+	delete(s.enclave.visibilityDecisions, repo)
 	s.enclave.visibilityMu.Unlock()
 }
 
@@ -175,6 +216,9 @@ func (h *proxyHandler) handleEnclaveRequest(w http.ResponseWriter, r *http.Reque
 		writeEnclaveDenied(w)
 		return
 	}
+	if targetRepo == claims.Repo {
+		h.server.seedEnclaveAssignedRepositorySecrecy(claims.AgentID(), claims.Repo)
+	}
 
 	toolName, args := enclaveToolAndArgs(route)
 	if toolName == "" {
@@ -187,4 +231,12 @@ func (h *proxyHandler) handleEnclaveRequest(w http.ResponseWriter, r *http.Reque
 	}
 	ctx := withEnclaveAgentID(r.Context(), claims.AgentID())
 	h.handleWithDIFC(w, r.WithContext(ctx), fullPath, toolName, args, nil)
+}
+
+func (s *Server) seedEnclaveAssignedRepositorySecrecy(agentID, repo string) {
+	sensitivity, ok := s.enclave.policy.RepositorySensitivity(repo)
+	if !ok || sensitivity == "public" {
+		return
+	}
+	s.AgentRegistry.GetOrCreate(agentID).AddSecrecyTag(difc.Tag("private:" + repo))
 }

--- a/internal/proxy/enclave.go
+++ b/internal/proxy/enclave.go
@@ -41,9 +41,11 @@ func newEnclaveState(policy *enclavegithub.Policy, verifier *enclavegithub.Verif
 }
 
 type enclaveAgentIDContextKey struct{}
+type enclaveAssignedRepoContextKey struct{}
 
-func withEnclaveAgentID(ctx context.Context, agentID string) context.Context {
-	return context.WithValue(ctx, enclaveAgentIDContextKey{}, agentID)
+func withEnclaveAuthorization(ctx context.Context, agentID, assignedRepo string) context.Context {
+	ctx = context.WithValue(ctx, enclaveAgentIDContextKey{}, agentID)
+	return context.WithValue(ctx, enclaveAssignedRepoContextKey{}, assignedRepo)
 }
 
 func agentIDFromContext(ctx context.Context) string {
@@ -52,6 +54,11 @@ func agentIDFromContext(ctx context.Context) string {
 		return proxyAgentID
 	}
 	return agentID
+}
+
+func enclaveAssignedRepoFromContext(ctx context.Context) string {
+	repo, _ := ctx.Value(enclaveAssignedRepoContextKey{}).(string)
+	return repo
 }
 
 func (s *Server) enclaveRepositoryIsPublic(ctx context.Context, repo string) bool {
@@ -210,16 +217,13 @@ func (h *proxyHandler) handleEnclaveRequest(w http.ResponseWriter, r *http.Reque
 		writeEnclaveDenied(w)
 		return
 	}
+	h.server.seedEnclaveAssignedRepositorySecrecy(claims.AgentID(), claims.Repo)
 
 	targetRepo := route.FullRepo()
 	if targetRepo != claims.Repo && !h.server.enclaveRepositoryIsPublic(r.Context(), targetRepo) {
 		writeEnclaveDenied(w)
 		return
 	}
-	if targetRepo == claims.Repo {
-		h.server.seedEnclaveAssignedRepositorySecrecy(claims.AgentID(), claims.Repo)
-	}
-
 	toolName, args := enclaveToolAndArgs(route)
 	if toolName == "" {
 		writeEnclaveDenied(w)
@@ -229,7 +233,7 @@ func (h *proxyHandler) handleEnclaveRequest(w http.ResponseWriter, r *http.Reque
 	if r.URL.RawQuery != "" {
 		fullPath += "?" + r.URL.RawQuery
 	}
-	ctx := withEnclaveAgentID(r.Context(), claims.AgentID())
+	ctx := withEnclaveAuthorization(r.Context(), claims.AgentID(), claims.Repo)
 	h.handleWithDIFC(w, r.WithContext(ctx), fullPath, toolName, args, nil)
 }
 

--- a/internal/proxy/enclave.go
+++ b/internal/proxy/enclave.go
@@ -1,0 +1,190 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/github/gh-aw-mcpg/internal/enclavegithub"
+	"github.com/github/gh-aw-mcpg/internal/githubhttp"
+	"github.com/github/gh-aw-mcpg/internal/httputil"
+)
+
+const maxEnclaveVisibilityResponseBytes = 1024 * 1024
+
+type enclaveState struct {
+	policy   *enclavegithub.Policy
+	verifier *enclavegithub.Verifier
+
+	visibilityMu        sync.RWMutex
+	visibilityDecisions map[string]bool
+}
+
+func newEnclaveState(policy *enclavegithub.Policy, verifier *enclavegithub.Verifier) *enclaveState {
+	return &enclaveState{
+		policy:              policy,
+		verifier:            verifier,
+		visibilityDecisions: make(map[string]bool),
+	}
+}
+
+type enclaveAgentIDContextKey struct{}
+
+func withEnclaveAgentID(ctx context.Context, agentID string) context.Context {
+	return context.WithValue(ctx, enclaveAgentIDContextKey{}, agentID)
+}
+
+func agentIDFromContext(ctx context.Context) string {
+	agentID, _ := ctx.Value(enclaveAgentIDContextKey{}).(string)
+	if agentID == "" {
+		return proxyAgentID
+	}
+	return agentID
+}
+
+func (s *Server) enclaveRepositoryIsPublic(ctx context.Context, repo string) bool {
+	s.enclave.visibilityMu.RLock()
+	decision, cached := s.enclave.visibilityDecisions[repo]
+	s.enclave.visibilityMu.RUnlock()
+	if cached {
+		return decision
+	}
+
+	resp, err := s.forwardEnclaveVisibilityLookup(ctx, repo)
+	if err != nil {
+		s.cacheEnclaveVisibilityDenial(repo)
+		return false
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		s.cacheEnclaveVisibilityDenial(repo)
+		return false
+	}
+
+	limited := io.LimitReader(resp.Body, maxEnclaveVisibilityResponseBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil || len(body) > maxEnclaveVisibilityResponseBytes {
+		s.cacheEnclaveVisibilityDenial(repo)
+		return false
+	}
+	var visibility struct {
+		Visibility string `json:"visibility"`
+	}
+	if err := json.Unmarshal(body, &visibility); err != nil || visibility.Visibility != "public" {
+		s.cacheEnclaveVisibilityDenial(repo)
+		return false
+	}
+
+	// Positive visibility is deliberately not cached because a repository can
+	// become private during a workflow run.
+	return true
+}
+
+func (s *Server) forwardEnclaveVisibilityLookup(ctx context.Context, repo string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.githubAPIURL+"/repos/"+repo, nil)
+	if err != nil {
+		return nil, err
+	}
+	githubhttp.ApplyGitHubAPIHeaders(req, "token "+s.githubToken)
+	return s.httpClient.Do(req)
+}
+
+func (s *Server) cacheEnclaveVisibilityDenial(repo string) {
+	s.enclave.visibilityMu.Lock()
+	s.enclave.visibilityDecisions[repo] = false
+	s.enclave.visibilityMu.Unlock()
+}
+
+func enclavePath(path string, rawPath string) (string, bool) {
+	if rawPath != "" {
+		return "", false
+	}
+	if path == ghHostPathPrefix {
+		return "", false
+	}
+	if strings.HasPrefix(path, ghHostPathPrefix+"/") {
+		return strings.TrimPrefix(path, ghHostPathPrefix), true
+	}
+	if strings.HasPrefix(path, ghHostPathPrefix) {
+		return "", false
+	}
+	return path, true
+}
+
+func enclaveToolAndArgs(route *enclavegithub.Route) (string, map[string]interface{}) {
+	switch route.Operation {
+	case enclavegithub.OperationIssuesList:
+		return "list_issues", repoArgs(route.Owner, route.Repo)
+	case enclavegithub.OperationIssuesGet:
+		return "issue_read", issueArgs(route.Owner, route.Repo, route.Number)
+	case enclavegithub.OperationIssueCommentsList:
+		return "issue_read", issueArgs(route.Owner, route.Repo, route.Number, "get_comments")
+	default:
+		return "", nil
+	}
+}
+
+func writeEnclaveDenied(w http.ResponseWriter) {
+	httputil.WriteErrorResponse(
+		w,
+		http.StatusForbidden,
+		"enclave_access_denied",
+		"enclave GitHub access denied",
+	)
+}
+
+func hasEnclaveGETBody(r *http.Request) bool {
+	return r.ContentLength != 0 || len(r.TransferEncoding) != 0
+}
+
+func (h *proxyHandler) handleEnclaveRequest(w http.ResponseWriter, r *http.Request) {
+	path, ok := enclavePath(r.URL.Path, r.URL.RawPath)
+	if !ok {
+		writeEnclaveDenied(w)
+		return
+	}
+
+	claims, err := h.server.enclave.verifier.VerifyAuthorization(r.Header.Get("Authorization"))
+	if err != nil {
+		writeEnclaveDenied(w)
+		return
+	}
+	if r.Method != http.MethodGet || hasEnclaveGETBody(r) {
+		writeEnclaveDenied(w)
+		return
+	}
+
+	query, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		writeEnclaveDenied(w)
+		return
+	}
+	route, err := enclavegithub.MatchRoute(path, query)
+	if err != nil || !claims.AllowsOperation(route.Operation) {
+		writeEnclaveDenied(w)
+		return
+	}
+
+	targetRepo := route.FullRepo()
+	if targetRepo != claims.Repo && !h.server.enclaveRepositoryIsPublic(r.Context(), targetRepo) {
+		writeEnclaveDenied(w)
+		return
+	}
+
+	toolName, args := enclaveToolAndArgs(route)
+	if toolName == "" {
+		writeEnclaveDenied(w)
+		return
+	}
+	fullPath := path
+	if r.URL.RawQuery != "" {
+		fullPath += "?" + r.URL.RawQuery
+	}
+	ctx := withEnclaveAgentID(r.Context(), claims.AgentID())
+	h.handleWithDIFC(w, r.WithContext(ctx), fullPath, toolName, args, nil)
+}

--- a/internal/proxy/enclave_test.go
+++ b/internal/proxy/enclave_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -191,6 +192,14 @@ func TestEnclaveAssignedAndPublicIssueReadsReplaceAuthorization(t *testing.T) {
 	}, auth)
 	assert.NotContains(t, auth, "Bearer "+capability)
 	assert.Equal(t, 1, handler.server.AgentRegistry.Count())
+
+	agentID := (&enclavegithub.Claims{
+		Run:        "run-123",
+		Invocation: "invocation-456",
+	}).AgentID()
+	labels, ok := handler.server.AgentRegistry.Get(agentID)
+	require.True(t, ok)
+	assert.Equal(t, []difc.Tag{"private:assigned/private"}, labels.GetSecrecyTags())
 }
 
 func TestEnclaveUniformlyDeniesNonPublicRepositories(t *testing.T) {
@@ -229,9 +238,44 @@ func TestEnclaveUniformlyDeniesNonPublicRepositories(t *testing.T) {
 	handler.server.enclave.visibilityMu.RLock()
 	defer handler.server.enclave.visibilityMu.RUnlock()
 	assert.Len(t, handler.server.enclave.visibilityDecisions, 5)
-	for _, decision := range handler.server.enclave.visibilityDecisions {
-		assert.False(t, decision)
+	for _, deniedUntil := range handler.server.enclave.visibilityDecisions {
+		assert.False(t, deniedUntil.IsZero())
 	}
+}
+
+func TestEnclaveVisibilityDenialCacheIsBoundedAndExpires(t *testing.T) {
+	var currentTime = time.Unix(1_800_000_000, 0)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer upstream.Close()
+
+	handler, _ := newEnclaveHandlerForTest(t, upstream.URL)
+	handler.server.enclave.now = func() time.Time { return currentTime }
+
+	for i := 0; i < maxEnclaveVisibilityDeniedCacheItems+5; i++ {
+		handler.server.cacheEnclaveVisibilityDenial(fmt.Sprintf("org/repo-%d", i))
+	}
+
+	handler.server.enclave.visibilityMu.RLock()
+	assert.Len(t, handler.server.enclave.visibilityDecisions, maxEnclaveVisibilityDeniedCacheItems)
+	handler.server.enclave.visibilityMu.RUnlock()
+
+	handler.server.cacheEnclaveVisibilityDenial("org/expiring")
+	currentTime = currentTime.Add(enclaveVisibilityDeniedCacheTTL + time.Second)
+
+	handler.server.enclave.visibilityMu.RLock()
+	_, expiredStillCached := handler.server.enclave.visibilityDecisions["org/expiring"]
+	handler.server.enclave.visibilityMu.RUnlock()
+	assert.True(t, expiredStillCached)
+
+	assert.False(t, handler.server.enclaveRepositoryIsPublic(context.Background(), "org/expiring"))
+
+	handler.server.enclave.visibilityMu.RLock()
+	refreshedDeniedUntil, refreshedCached := handler.server.enclave.visibilityDecisions["org/expiring"]
+	handler.server.enclave.visibilityMu.RUnlock()
+	assert.True(t, refreshedCached)
+	assert.True(t, refreshedDeniedUntil.After(currentTime))
 }
 
 func TestEnclaveRejectsUnsupportedAndAmbiguousRequestsBeforeUpstream(t *testing.T) {

--- a/internal/proxy/enclave_test.go
+++ b/internal/proxy/enclave_test.go
@@ -101,8 +101,10 @@ func (g *enclaveLabelGuard) LabelResource(
 ) (*difc.LabeledResource, difc.OperationType, error) {
 	resource := difc.NewLabeledResource("issue data")
 	argsMap, _ := args.(map[string]interface{})
-	if argsMap["owner"] == "assigned" && argsMap["repo"] == "private" {
-		resource.Secrecy = *difc.NewSecrecyLabel("private:assigned/private")
+	owner, _ := argsMap["owner"].(string)
+	repo, _ := argsMap["repo"].(string)
+	if owner != "public" || repo != "repo" {
+		resource.Secrecy = *difc.NewSecrecyLabel(difc.Tag("private:" + owner + "/" + repo))
 	}
 	return resource, difc.OperationRead, nil
 }
@@ -128,6 +130,7 @@ func newEnclaveHandlerForTest(
 		labelResourceOp:     difc.OperationRead,
 	}
 	server := newTestServerWithStub(t, upstreamURL, g, difc.EnforcementPropagate)
+	server.guard = &enclaveLabelGuard{}
 	server.githubToken = enclaveTestUpstreamToken
 	server.enclave = newEnclaveState(policy, verifier)
 	server.httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
@@ -219,6 +222,7 @@ func TestEnclaveUniformlyDeniesNonPublicRepositories(t *testing.T) {
 		default:
 			t.Fatalf("unexpected upstream request: %s", r.URL.Path)
 		}
+
 	}))
 	defer upstream.Close()
 
@@ -241,6 +245,53 @@ func TestEnclaveUniformlyDeniesNonPublicRepositories(t *testing.T) {
 	for _, deniedUntil := range handler.server.enclave.visibilityDecisions {
 		assert.False(t, deniedUntil.IsZero())
 	}
+}
+
+func TestEnclaveDIFCRejectsRepositoryOutsideCapabilityBeforeIssueFetch(t *testing.T) {
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer upstream.Close()
+
+	policy, verifier, _ := newEnclaveTestPolicy(t)
+	server := newTestServer(t, upstream.URL)
+	server.guard = &enclaveLabelGuard{}
+	server.Mode = difc.EnforcementPropagate
+	server.Evaluator.SetMode(difc.EnforcementPropagate)
+	server.githubToken = enclaveTestUpstreamToken
+	server.enclave = newEnclaveState(policy, verifier)
+	handler := &proxyHandler{server: server}
+	server.AgentRegistry.GetOrCreate("enclave-test-agent").
+		AddSecrecyTag("private:assigned/private")
+
+	ctx := withEnclaveAuthorization(
+		context.Background(),
+		"enclave-test-agent",
+		"assigned/private",
+	)
+	req := httptest.NewRequest(http.MethodGet, "/repos/other/private/issues", nil).
+		WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	handler.handleWithDIFC(
+		recorder,
+		req,
+		"/repos/other/private/issues",
+		"list_issues",
+		repoArgs("other", "private"),
+		nil,
+	)
+
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "enclave_access_denied")
+	assert.Zero(t, upstreamCalls, "DIFC must deny before fetching issue data")
+	assert.Equal(
+		t,
+		[]difc.Tag{"private:assigned/private"},
+		server.AgentRegistry.GetOrCreate("enclave-test-agent").GetSecrecyTags(),
+	)
 }
 
 func TestEnclaveVisibilityDenialCacheIsBoundedAndExpires(t *testing.T) {
@@ -385,5 +436,5 @@ func TestEnclaveMaintainsPerInvocationDIFCState(t *testing.T) {
 	publicLabels, ok := server.AgentRegistry.Get(publicAgentID)
 	require.True(t, ok)
 	assert.Equal(t, []difc.Tag{"private:assigned/private"}, privateLabels.GetSecrecyTags())
-	assert.Empty(t, publicLabels.GetSecrecyTags())
+	assert.Equal(t, []difc.Tag{"private:assigned/private"}, publicLabels.GetSecrecyTags())
 }

--- a/internal/proxy/enclave_test.go
+++ b/internal/proxy/enclave_test.go
@@ -1,0 +1,345 @@
+package proxy
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/github/gh-aw-mcpg/internal/difc"
+	"github.com/github/gh-aw-mcpg/internal/enclavegithub"
+	"github.com/github/gh-aw-mcpg/internal/guard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const enclaveTestUpstreamToken = "upstream-pat"
+
+func newEnclaveTestPolicy(t *testing.T) (*enclavegithub.Policy, *enclavegithub.Verifier, []byte) {
+	t.Helper()
+	policy, err := enclavegithub.ParsePolicy(`{
+		"version": 1,
+		"profile": "issues-read-v1",
+		"audience": "gh-aw-enclave-github",
+		"workflow_run_id": "run-123",
+		"repositories": [{"repo": "assigned/private", "sensitivity": "confidential"}],
+		"public_min_integrity": "approved",
+		"allowed_operations": ["issues.comments.list", "issues.get", "issues.list"],
+		"max_capability_ttl_seconds": 600
+	}`)
+	require.NoError(t, err)
+	key := make([]byte, sha256.Size)
+	for i := range key {
+		key[i] = 0x42
+	}
+	verifier, err := enclavegithub.NewVerifier(hex.EncodeToString(key), policy)
+	require.NoError(t, err)
+	return policy, verifier, key
+}
+
+func signEnclaveTestCapability(t *testing.T, key []byte, operations ...string) string {
+	return signEnclaveTestCapabilityForInvocation(t, key, "invocation-456", operations...)
+}
+
+func signEnclaveTestCapabilityForInvocation(
+	t *testing.T,
+	key []byte,
+	invocation string,
+	operations ...string,
+) string {
+	t.Helper()
+	now := time.Now()
+	claims := enclavegithub.Claims{
+		Version:    1,
+		Audience:   enclavegithub.DefaultAudience,
+		Run:        "run-123",
+		Invocation: invocation,
+		Repo:       "assigned/private",
+		Profile:    enclavegithub.ProfileIssuesReadV1,
+		Operations: operations,
+		NotBefore:  now.Add(-time.Minute).Unix(),
+		Expires:    now.Add(time.Minute).Unix(),
+	}
+
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	signingInput := enclavegithub.CapabilityPrefix + "." + encoded
+	mac := hmac.New(sha256.New, key)
+	_, err = mac.Write([]byte(signingInput))
+	require.NoError(t, err)
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+type enclaveLabelGuard struct{}
+
+func (g *enclaveLabelGuard) Name() string { return "enclave-label-test" }
+
+func (g *enclaveLabelGuard) LabelAgent(
+	_ context.Context,
+	_ interface{},
+	_ guard.BackendCaller,
+	_ *difc.Capabilities,
+) (*guard.LabelAgentResult, error) {
+	return &guard.LabelAgentResult{}, nil
+}
+
+func (g *enclaveLabelGuard) LabelResource(
+	_ context.Context,
+	_ string,
+	args interface{},
+	_ guard.BackendCaller,
+	_ *difc.Capabilities,
+) (*difc.LabeledResource, difc.OperationType, error) {
+	resource := difc.NewLabeledResource("issue data")
+	argsMap, _ := args.(map[string]interface{})
+	if argsMap["owner"] == "assigned" && argsMap["repo"] == "private" {
+		resource.Secrecy = *difc.NewSecrecyLabel("private:assigned/private")
+	}
+	return resource, difc.OperationRead, nil
+}
+
+func (g *enclaveLabelGuard) LabelResponse(
+	_ context.Context,
+	_ string,
+	_ interface{},
+	_ guard.BackendCaller,
+	_ *difc.Capabilities,
+) (difc.LabeledData, error) {
+	return nil, nil
+}
+
+func newEnclaveHandlerForTest(
+	t *testing.T,
+	upstreamURL string,
+) (*proxyHandler, string) {
+	t.Helper()
+	policy, verifier, key := newEnclaveTestPolicy(t)
+	g := &stubGuard{
+		labelResourceResult: publicResource(),
+		labelResourceOp:     difc.OperationRead,
+	}
+	server := newTestServerWithStub(t, upstreamURL, g, difc.EnforcementPropagate)
+	server.githubToken = enclaveTestUpstreamToken
+	server.enclave = newEnclaveState(policy, verifier)
+	server.httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &proxyHandler{server: server}, signEnclaveTestCapability(
+		t,
+		key,
+		enclavegithub.OperationIssueCommentsList,
+		enclavegithub.OperationIssuesGet,
+		enclavegithub.OperationIssuesList,
+	)
+}
+
+func enclaveRequest(t *testing.T, h http.Handler, method, path, capability string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	if capability != "" {
+		req.Header.Set("Authorization", "Bearer "+capability)
+	}
+	recorder := httptest.NewRecorder()
+	h.ServeHTTP(recorder, req)
+	return recorder
+}
+
+func TestEnclaveAssignedAndPublicIssueReadsReplaceAuthorization(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		requests []string
+		auth     []string
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.URL.Path)
+		auth = append(auth, r.Header.Get("Authorization"))
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/repos/public/repo" {
+			_, _ = w.Write([]byte(`{"visibility":"public"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer upstream.Close()
+
+	handler, capability := newEnclaveHandlerForTest(t, upstream.URL)
+	assigned := enclaveRequest(t, handler, http.MethodGet, "/api/v3/repos/assigned/private/issues?page=2", capability)
+	public := enclaveRequest(t, handler, http.MethodGet, "/repos/public/repo/issues", capability)
+
+	assert.Equal(t, http.StatusOK, assigned.Code)
+	assert.Equal(t, http.StatusOK, public.Code)
+	assert.Equal(t, []string{
+		"/repos/assigned/private/issues",
+		"/repos/public/repo",
+		"/repos/public/repo/issues",
+	}, requests)
+	assert.Equal(t, []string{
+		"token " + enclaveTestUpstreamToken,
+		"token " + enclaveTestUpstreamToken,
+		"token " + enclaveTestUpstreamToken,
+	}, auth)
+	assert.NotContains(t, auth, "Bearer "+capability)
+	assert.Equal(t, 1, handler.server.AgentRegistry.Count())
+}
+
+func TestEnclaveUniformlyDeniesNonPublicRepositories(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/repos/other/private":
+			_, _ = w.Write([]byte(`{"visibility":"private","secret":"must-not-leak"}`))
+		case "/repos/other/internal":
+			_, _ = w.Write([]byte(`{"visibility":"internal"}`))
+		case "/repos/other/missing":
+			http.NotFound(w, r)
+		case "/repos/other/rate-limited":
+			http.Error(w, "rate limit details", http.StatusTooManyRequests)
+		case "/repos/other/malformed":
+			_, _ = w.Write([]byte(`{"visibility":`))
+		default:
+			t.Fatalf("unexpected upstream request: %s", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	handler, capability := newEnclaveHandlerForTest(t, upstream.URL)
+	var canonicalBody string
+	for _, repo := range []string{"private", "internal", "missing", "rate-limited", "malformed"} {
+		recorder := enclaveRequest(t, handler, http.MethodGet, "/repos/other/"+repo+"/issues", capability)
+		assert.Equal(t, http.StatusForbidden, recorder.Code)
+		if canonicalBody == "" {
+			canonicalBody = recorder.Body.String()
+		}
+		assert.Equal(t, canonicalBody, recorder.Body.String())
+		assert.NotContains(t, recorder.Body.String(), repo)
+		assert.NotContains(t, recorder.Body.String(), "must-not-leak")
+	}
+
+	handler.server.enclave.visibilityMu.RLock()
+	defer handler.server.enclave.visibilityMu.RUnlock()
+	assert.Len(t, handler.server.enclave.visibilityDecisions, 5)
+	for _, decision := range handler.server.enclave.visibilityDecisions {
+		assert.False(t, decision)
+	}
+}
+
+func TestEnclaveRejectsUnsupportedAndAmbiguousRequestsBeforeUpstream(t *testing.T) {
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	handler, capability := newEnclaveHandlerForTest(t, upstream.URL)
+	tests := []struct {
+		method string
+		path   string
+		auth   string
+	}{
+		{http.MethodGet, "/graphql", capability},
+		{http.MethodGet, "/search/issues?q=x", capability},
+		{http.MethodPost, "/repos/assigned/private/issues", capability},
+		{http.MethodGet, "/repos/assigned/private/pulls", capability},
+		{http.MethodGet, "/repos/assigned/private/issues?unknown=1", capability},
+		{http.MethodGet, "/repos/assigned/private/issues?page=1&page=2", capability},
+		{http.MethodGet, "/api/v3evil/repos/assigned/private/issues", capability},
+		{http.MethodGet, "/repos/assigned%2Fprivate/issues", capability},
+		{http.MethodGet, "/repos/assigned/private/issues", ""},
+	}
+	for _, test := range tests {
+		recorder := enclaveRequest(t, handler, test.method, test.path, test.auth)
+		assert.Equal(t, http.StatusForbidden, recorder.Code, "%s %s", test.method, test.path)
+		assert.Contains(t, recorder.Body.String(), "enclave_access_denied")
+	}
+	assert.Zero(t, upstreamCalls)
+}
+
+func TestEnclaveFailsClosedOnRedirectAndNonJSONSuccess(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/assigned/private/issues/1":
+			http.Redirect(w, r, "/private-location", http.StatusFound)
+		case "/repos/assigned/private/issues/2":
+			_, _ = w.Write([]byte("private plain text"))
+		default:
+			t.Fatalf("unexpected upstream request: %s", r.URL.Path)
+		}
+
+	}))
+	defer upstream.Close()
+
+	handler, capability := newEnclaveHandlerForTest(t, upstream.URL)
+	for _, number := range []string{"1", "2"} {
+		recorder := enclaveRequest(t, handler, http.MethodGet, "/repos/assigned/private/issues/"+number, capability)
+		assert.Equal(t, http.StatusForbidden, recorder.Code)
+		assert.NotContains(t, recorder.Body.String(), "private")
+		assert.NotContains(t, recorder.Header().Get("Location"), "private-location")
+	}
+}
+
+func TestEnclaveMaintainsPerInvocationDIFCState(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/repos/public/repo" {
+			_, _ = w.Write([]byte(`{"visibility":"public"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer upstream.Close()
+
+	policy, verifier, key := newEnclaveTestPolicy(t)
+	server := newTestServer(t, upstream.URL)
+	server.guard = &enclaveLabelGuard{}
+	server.Mode = difc.EnforcementPropagate
+	server.Evaluator.SetMode(difc.EnforcementPropagate)
+	server.githubToken = enclaveTestUpstreamToken
+	server.enclave = newEnclaveState(policy, verifier)
+	handler := &proxyHandler{server: server}
+
+	privateInvocation := "private-invocation"
+	publicInvocation := "public-invocation"
+	privateCapability := signEnclaveTestCapabilityForInvocation(
+		t,
+		key,
+		privateInvocation,
+		enclavegithub.OperationIssuesList,
+	)
+	publicCapability := signEnclaveTestCapabilityForInvocation(
+		t,
+		key,
+		publicInvocation,
+		enclavegithub.OperationIssuesList,
+	)
+
+	assert.Equal(t, http.StatusOK, enclaveRequest(
+		t, handler, http.MethodGet, "/repos/assigned/private/issues", privateCapability,
+	).Code)
+	assert.Equal(t, http.StatusOK, enclaveRequest(
+		t, handler, http.MethodGet, "/repos/public/repo/issues", privateCapability,
+	).Code)
+	assert.Equal(t, http.StatusOK, enclaveRequest(
+		t, handler, http.MethodGet, "/repos/public/repo/issues", publicCapability,
+	).Code)
+
+	privateAgentID := (&enclavegithub.Claims{Run: "run-123", Invocation: privateInvocation}).AgentID()
+	publicAgentID := (&enclavegithub.Claims{Run: "run-123", Invocation: publicInvocation}).AgentID()
+	privateLabels, ok := server.AgentRegistry.Get(privateAgentID)
+	require.True(t, ok)
+	publicLabels, ok := server.AgentRegistry.Get(publicAgentID)
+	require.True(t, ok)
+	assert.Equal(t, []difc.Tag{"private:assigned/private"}, privateLabels.GetSecrecyTags())
+	assert.Empty(t, publicLabels.GetSecrecyTags())
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -200,6 +200,10 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 		clientAuth = ""
 	}
 	backend := &restBackendCaller{server: s, clientAuth: clientAuth}
+	evaluator := s.Evaluator
+	if assignedRepo := enclaveAssignedRepoFromContext(ctx); assignedRepo != "" {
+		evaluator = s.Evaluator.WithSecrecyPropagationMax(difc.Tag("private:" + assignedRepo))
+	}
 
 	// Start a DIFC pipeline span covering all phases for this request
 	ctx, difcSpan := tracing.StartDIFCPipelineSpan(ctx, h.GetTracer(), toolName, r.URL.Path)
@@ -216,7 +220,7 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 		ToolName:        toolName,
 		Args:            args,
 		Guard:           s.guard,
-		Evaluator:       s.Evaluator,
+		Evaluator:       evaluator,
 		AgentRegistry:   s.AgentRegistry,
 		Capabilities:    s.Capabilities,
 		EnforcementMode: s.Mode,
@@ -325,7 +329,7 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	var finalData interface{}
 	var useOriginalBody bool // GraphQL responses need original format preserved
 	filterResult, err := difc.FilterAndConvertLabeledData(
-		s.Evaluator,
+		pipelineIn.Evaluator,
 		pre.AgentLabels.Secrecy,
 		pre.AgentLabels.Integrity,
 		pre.Operation,

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -52,19 +52,35 @@ type proxyHandler struct {
 }
 
 func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Strip the /api/v3 prefix that GH_HOST adds
-	rawPath := StripGHHostPrefix(r.URL.Path)
+	// Avoid logging enclave paths before capability and repository authorization.
+	rawPath := r.URL.Path
+	if h.server.enclave != nil {
+		if normalizedPath, ok := enclavePath(r.URL.Path, r.URL.RawPath); ok {
+			rawPath = normalizedPath
+		}
+	} else {
+		// Strip the /api/v3 prefix that GH_HOST adds.
+		rawPath = StripGHHostPrefix(r.URL.Path)
+	}
 	// Preserve query string for upstream forwarding
 	fullPath := rawPath
 	if r.URL.RawQuery != "" {
 		fullPath = rawPath + "?" + r.URL.RawQuery
 	}
 
-	logHandler.Printf("incoming %s %s", r.Method, rawPath)
+	if h.server.enclave != nil {
+		logHandler.Printf("incoming enclave request: method=%s", r.Method)
+	} else {
+		logHandler.Printf("incoming %s %s", r.Method, rawPath)
+	}
 
 	// Health check endpoint
 	if rawPath == "/health" || rawPath == "/healthz" {
 		httputil.WriteJSONResponse(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+	if h.server.enclave != nil {
+		h.handleEnclaveRequest(w, r)
 		return
 	}
 
@@ -179,7 +195,11 @@ func (h *proxyHandler) handleUnrecognizedPassthrough(w http.ResponseWriter, r *h
 func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, path, toolName string, args map[string]interface{}, graphQLBody []byte) {
 	ctx := r.Context()
 	s := h.server
-	backend := &restBackendCaller{server: s, clientAuth: r.Header.Get("Authorization")}
+	clientAuth := r.Header.Get("Authorization")
+	if s.enclave != nil {
+		clientAuth = ""
+	}
+	backend := &restBackendCaller{server: s, clientAuth: clientAuth}
 
 	// Start a DIFC pipeline span covering all phases for this request
 	ctx, difcSpan := tracing.StartDIFCPipelineSpan(ctx, h.GetTracer(), toolName, r.URL.Path)
@@ -192,7 +212,7 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 
 	// **Phases 0–2: Get agent labels, label resource, coarse access check**
 	pipelineIn := guard.PipelineInput{
-		AgentID:         proxyAgentID,
+		AgentID:         agentIDFromContext(ctx),
 		ToolName:        toolName,
 		Args:            args,
 		Guard:           s.guard,
@@ -204,6 +224,10 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	}
 	ctx, pre, err := guard.RunPipelinePrePhases(ctx, pipelineIn)
 	if err != nil {
+		if s.enclave != nil {
+			writeEnclaveDenied(w)
+			return
+		}
 		if denied, _ := guard.HandlePrePhaseError(err); denied != nil {
 			logHandler.Printf("[DIFC] Phase 2: BLOCKED %s %s — %s", r.Method, path, denied.EvalResult.Reason)
 			deniedErr := fmt.Errorf("DIFC policy violation: %s", denied.EvalResult.Reason)
@@ -224,7 +248,6 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	}
 
 	// **Phase 3: Forward to upstream GitHub API**
-	clientAuth := r.Header.Get("Authorization")
 	var resp *http.Response
 	var respBody []byte
 
@@ -260,6 +283,10 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 
 	// For non-200 responses, pass through as-is
 	if resp.StatusCode >= 300 {
+		if s.enclave != nil && resp.StatusCode < 400 {
+			writeEnclaveDenied(w)
+			return
+		}
 		h.writeResponse(w, resp, respBody)
 		return
 	}
@@ -267,6 +294,10 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	// Parse the response as JSON for DIFC filtering
 	var responseData interface{}
 	if err := json.Unmarshal(respBody, &responseData); err != nil {
+		if s.enclave != nil {
+			writeEnclaveDenied(w)
+			return
+		}
 		// Non-JSON response — pass through
 		logHandler.Printf("[DIFC] response is not JSON, passing through")
 		h.writeResponse(w, resp, respBody)
@@ -276,6 +307,10 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	// **Phase 4: Guard labels the response**
 	labeledData, err := guard.RunPipelinePhase4(ctx, pipelineIn, pre, responseData)
 	if err != nil {
+		if s.enclave != nil {
+			writeEnclaveDenied(w)
+			return
+		}
 		logHandler.Printf("[DIFC] Phase 4 failed: %v", err)
 		// On labeling failure, fall back to coarse-grained result
 		if pre.EvalResult.IsAllowed() {
@@ -299,6 +334,10 @@ func (h *proxyHandler) handleWithDIFC(w http.ResponseWriter, r *http.Request, pa
 	)
 	if err != nil {
 		logHandler.Printf("[DIFC] Phase 5 ToResult failed: %v", err)
+		if s.enclave != nil {
+			writeEnclaveDenied(w)
+			return
+		}
 		h.writeEmptyResponse(w, resp, responseData)
 		return
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/github/gh-aw-mcpg/internal/config"
 	"github.com/github/gh-aw-mcpg/internal/difc"
+	"github.com/github/gh-aw-mcpg/internal/enclavegithub"
 	"github.com/github/gh-aw-mcpg/internal/githubhttp"
 	"github.com/github/gh-aw-mcpg/internal/guard"
 	"github.com/github/gh-aw-mcpg/internal/httputil"
@@ -53,6 +54,14 @@ type Server struct {
 
 	// guardInitialized tracks whether LabelAgent has been called
 	guardInitialized bool
+
+	enclave *enclaveState
+}
+
+// EnclaveConfig enables the fail-closed issues-read-v1 proxy profile.
+type EnclaveConfig struct {
+	Policy   *enclavegithub.Policy
+	Verifier *enclavegithub.Verifier
 }
 
 // Config holds the configuration for creating a proxy Server.
@@ -83,6 +92,9 @@ type Config struct {
 	// (writer) integrity, regardless of their author_association. These are injected
 	// into the allow-only policy's trusted-users field during LabelAgent initialization.
 	TrustedUsers []string
+
+	// Enclave enables invocation-capability enforcement for issues-read-v1.
+	Enclave *EnclaveConfig
 }
 
 // New creates a new proxy Server from the given Config.
@@ -92,6 +104,17 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 
 	if cfg.WasmPath == "" {
 		return nil, fmt.Errorf("guard WASM path is required")
+	}
+	if cfg.Enclave != nil {
+		if cfg.Enclave.Policy == nil || cfg.Enclave.Verifier == nil {
+			return nil, fmt.Errorf("enclave policy and verifier are required")
+		}
+		if err := cfg.Enclave.Policy.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid enclave policy: %w", err)
+		}
+		if cfg.GitHubToken == "" {
+			return nil, fmt.Errorf("GitHub token is required for enclave proxy mode")
+		}
 	}
 
 	apiURL := cfg.GitHubAPIURL
@@ -129,6 +152,12 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 			},
 		},
 	}
+	if cfg.Enclave != nil {
+		s.enclave = newEnclaveState(cfg.Enclave.Policy, cfg.Enclave.Verifier)
+		s.httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
 
 	// Initialize guard policy (LabelAgent)
 	if cfg.Policy != "" {
@@ -138,6 +167,18 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 		}
 	} else {
 		logProxy.Printf("No guard policy configured, running without policy enforcement")
+	}
+	if s.enclave != nil {
+		if !s.guardInitialized {
+			return nil, fmt.Errorf("guard policy is required for enclave proxy mode")
+		}
+		initialLabels, ok := s.AgentRegistry.Get(proxyAgentID)
+		if !ok {
+			return nil, fmt.Errorf("enclave guard did not initialize agent labels")
+		}
+		s.AgentRegistry.SetDefaultLabels(nil, initialLabels.GetIntegrityTags())
+		s.Mode = difc.EnforcementPropagate
+		s.Evaluator.SetMode(difc.EnforcementPropagate)
 	}
 
 	logProxy.Printf("Proxy server created successfully: mode=%s", difcComponents.Mode)
@@ -209,10 +250,14 @@ func (s *Server) initGuardPolicy(ctx context.Context, policyJSON string, trusted
 // Every request is wrapped with an OTEL "proxy.request" span so the full
 // proxy lifecycle (DIFC pipeline + GitHub API round-trip) appears in traces.
 func (s *Server) Handler() http.Handler {
-	return tracing.WrapHTTPHandler(&proxyHandler{
+	handler := &proxyHandler{
 		server:       s,
 		CachedTracer: tracing.CachedTracer{Tracer: tracing.Tracer()},
-	}, "proxy.request")
+	}
+	if s.enclave != nil {
+		return tracing.WrapHTTPHandlerWithoutPath(handler, "proxy.request")
+	}
+	return tracing.WrapHTTPHandler(handler, "proxy.request")
 }
 
 // restBackendCaller translates guard CallTool requests into GitHub REST API
@@ -253,11 +298,20 @@ func (r *restBackendCaller) CallTool(ctx context.Context, toolName string, args 
 		if query == "" {
 			return nil, fmt.Errorf("search_repositories: missing query")
 		}
-		perPage := "10"
-		if pp, ok := argsMap["perPage"].(float64); ok {
-			perPage = fmt.Sprintf("%d", int(pp))
+		if r.server.enclave != nil {
+			repoQuery, ok := strings.CutPrefix(query, "repo:")
+			repo, valid := enclavegithub.NormalizeRepository(repoQuery)
+			if !ok || !valid {
+				return nil, fmt.Errorf("search_repositories: enclave lookup must use an exact repository")
+			}
+			apiPath = "/repos/" + repo
+		} else {
+			perPage := "10"
+			if pp, ok := argsMap["perPage"].(float64); ok {
+				perPage = fmt.Sprintf("%d", int(pp))
+			}
+			apiPath = fmt.Sprintf("/search/repositories?q=%s&per_page=%s", url.QueryEscape(query), perPage)
 		}
-		apiPath = fmt.Sprintf("/search/repositories?q=%s&per_page=%s", url.QueryEscape(query), perPage)
 
 	case "get_collaborator_permission":
 		var parseErr error
@@ -368,9 +422,11 @@ func (s *Server) forwardToGitHub(ctx context.Context, method, path string, body 
 		return nil, fmt.Errorf("failed to create upstream request: %w", err)
 	}
 
-	// Prefer the client's own Authorization header; fall back to configured token.
+	// Enclave mode always replaces the invocation capability with mcpg's token.
 	var authHeader string
-	if clientAuth != "" {
+	if s.enclave != nil {
+		authHeader = "token " + s.githubToken
+	} else if clientAuth != "" {
 		authHeader = clientAuth
 	} else if s.githubToken != "" {
 		authHeader = "token " + s.githubToken

--- a/internal/tracing/http.go
+++ b/internal/tracing/http.go
@@ -45,6 +45,15 @@ type statusResponseWriter struct {
 // GitHub API proxy. Callers that need session-level attributes (e.g. session.id)
 // should add them as extra attrs or extend the context themselves.
 func WrapHTTPHandler(next http.Handler, spanName string, extraAttrs ...attribute.KeyValue) http.Handler {
+	return wrapHTTPHandler(next, spanName, true, extraAttrs...)
+}
+
+// WrapHTTPHandlerWithoutPath instruments a handler without recording request paths.
+func WrapHTTPHandlerWithoutPath(next http.Handler, spanName string, extraAttrs ...attribute.KeyValue) http.Handler {
+	return wrapHTTPHandler(next, spanName, false, extraAttrs...)
+}
+
+func wrapHTTPHandler(next http.Handler, spanName string, includePath bool, extraAttrs ...attribute.KeyValue) http.Handler {
 	logHTTP.Printf("Registering HTTP handler with OTel span: span=%s, extraAttrs=%d", spanName, len(extraAttrs))
 	t := Tracer()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +63,11 @@ func WrapHTTPHandler(next http.Handler, spanName string, extraAttrs ...attribute
 		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
 
 		hasRemoteParent := oteltrace.SpanContextFromContext(ctx).IsRemote()
-		logHTTP.Printf("Handling request: span=%s, method=%s, path=%s, remoteParent=%v", spanName, r.Method, r.URL.Path, hasRemoteParent)
+		if includePath {
+			logHTTP.Printf("Handling request: span=%s, method=%s, path=%s, remoteParent=%v", spanName, r.Method, r.URL.Path, hasRemoteParent)
+		} else {
+			logHTTP.Printf("Handling request: span=%s, method=%s, remoteParent=%v", spanName, r.Method, hasRemoteParent)
+		}
 
 		route := r.Pattern
 		if method, path, ok := strings.Cut(route, " "); ok {
@@ -66,11 +79,11 @@ func WrapHTTPHandler(next http.Handler, spanName string, extraAttrs ...attribute
 			}
 		}
 
-		attrs := append([]attribute.KeyValue{
-			HTTPRequestMethodKey.String(r.Method),
-			URLPathKey.String(r.URL.Path),
-		}, extraAttrs...)
-		if route != "" {
+		attrs := append([]attribute.KeyValue{HTTPRequestMethodKey.String(r.Method)}, extraAttrs...)
+		if includePath {
+			attrs = append(attrs, URLPathKey.String(r.URL.Path))
+		}
+		if includePath && route != "" {
 			attrs = append(attrs, HTTPRouteKey.String(route))
 		}
 

--- a/internal/tracing/http_test.go
+++ b/internal/tracing/http_test.go
@@ -119,10 +119,39 @@ func TestWrapHTTPHandler_PatternMethodMismatch_OmitsRouteAttribute(t *testing.T)
 		case HTTPRouteKey:
 			foundRoute = true
 		}
+
 	}
 	assert.True(t, foundMethod, "http.request.method attribute must be present on the span")
 	assert.True(t, foundPath, "url.path attribute must be present on the span")
 	assert.False(t, foundRoute, "http.route attribute must be omitted when the pattern method mismatches the request method")
+}
+
+func TestWrapHTTPHandlerWithoutPath_OmitsPathAndRouteAttributes(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	previousProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previousProvider)
+		require.NoError(t, tp.Shutdown(context.Background()))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/repos/private/hidden/issues", nil)
+	req.Pattern = "GET /repos/{owner}/{repo}/issues"
+	recorder := httptest.NewRecorder()
+	WrapHTTPHandlerWithoutPath(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), "test.redacted").ServeHTTP(recorder, req)
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	for _, attr := range spans[0].Attributes {
+		assert.NotEqual(t, URLPathKey, attr.Key)
+		assert.NotEqual(t, HTTPRouteKey, attr.Key)
+	}
 }
 
 func TestStatusResponseWriter_Unwrap_ExposesOptionalInterfaces(t *testing.T) {


### PR DESCRIPTION
## Summary

- verify AWF-minted `awf-egh1` capabilities against the published HMAC vector, binding audience, workflow run identity, invocation, assigned repository, profile, sorted operations, and validity window
- add the fail-closed `issues-read-v1` REST profile for issue lists, individual issues, and issue comments
- initialize each invocation agent with `private:<assigned-owner>/<assigned-repo>` and enforce the DIFC read relation `resource secrecy ⊆ agent secrecy`
- make any other private-repository tag a non-propagatable DIFC denial before issue data is fetched; public resources carry no secrecy tag
- replace every inbound bearer credential with mcpg's trusted upstream GitHub PAT
- require non-assigned repositories to be positively confirmed public, with uniform denials for private, internal, unknown, and failed visibility checks
- propagate repository secrecy and per-item integrity through the existing DIFC guard, including per-comment integrity and mixed-response aggregation
- harden logs, tracing, caches, and WASM guard diagnostics against credentials and private response-body disclosure

## Security boundaries

This deliberately does **not** authorize arbitrary `gh` commands, GraphQL, search, writes, redirects, downloads, metadata passthrough, or unrecognized REST paths. The supported client surface is `gh api --method GET` for the three repository-scoped issue routes documented in `docs/PROXY_MODE.md`. Generic proxy mode remains unchanged.

The PAT is transport authority only, not the repository boundary. The capability-bound DIFC label is the repository boundary: assigned-private and public resource labels flow to the invocation agent, while another private repository's distinct secrecy label does not. Non-assigned repositories also must be positively classified as public before issue data is fetched. Capability `run` is compared byte-for-byte with policy `workflow_run_id`, using the shared `gh-aw-egh-*` identity contract.

## Validation

- exact published positive `awf-egh1` vector plus field, ordering, wire, wrong-run, expiry, and repository mutation negatives
- explicit DIFC subset tests proving assigned-private/public labels pass and a different private-repository label hard-denies before upstream issue fetch
- proxy authorization, route/query restrictions, PAT substitution, visibility handling, uniform denials, and invocation DIFC state tests
- Go build/lint/test suite and 642 Rust guard tests via `make agent-finished`

## Dependency order

This is dependency layer 1 and should merge before the corresponding AWF and gh-aw changes.