### PR TITLE
Add explicit DNS SANs to proxy TLS certificates

### DIFF
--- a/docs/PROXY_MODE.md
+++ b/docs/PROXY_MODE.md
@@ -169,6 +169,7 @@ Response schema:
 | `--github-api-url` | `https://api.github.com` | Upstream GitHub API URL |
 | `--tls` | `false` | Enable HTTPS with auto-generated self-signed certificates |
 | `--tls-dir` | `<log-dir>/proxy-tls` | Directory for generated TLS certificate files |
+| `--tls-dns-name` | *(disabled)* | Additional DNS SAN for the generated certificate; repeat the flag or use a comma-separated list |
 | `--trusted-bots` | *(disabled)* | Additional trusted bot usernames (comma-separated, extends built-in list) |
 | `--trusted-users` | *(disabled)* | User logins that receive approved integrity (comma-separated) |
 
@@ -307,7 +308,7 @@ curl -H "Authorization: token $GITHUB_TOKEN" \
 
 ## TLS Support
 
-The `gh` CLI forces HTTPS when connecting to a custom `GH_HOST`. The `--tls` flag generates a short-lived (24h) self-signed CA and server certificate at startup, enabling direct `gh` CLI integration without an external TLS terminator.
+The `gh` CLI forces HTTPS when connecting to a custom `GH_HOST`. The `--tls` flag generates a short-lived (24h) self-signed CA and server certificate at startup, enabling direct `gh` CLI integration without an external TLS terminator. When clients connect through a DNS name other than `localhost`, pass each required DNS SAN with `--tls-dns-name <name>` (repeatable and comma-separated values are both accepted). Requested names are validated as ASCII DNS hostnames, normalized to lowercase, and deduplicated in first-seen order; IP addresses and wildcards are rejected.
 
 ### Generated Files
 
@@ -316,7 +317,7 @@ When `--tls` is enabled, the proxy writes to `--tls-dir` (default: `<log-dir>/pr
 | File | Purpose |
 |------|---------|
 | `ca.crt` | CA certificate — add to client trust store |
-| `server.crt` | Server certificate (localhost, 127.0.0.1, ::1) |
+| `server.crt` | Server certificate (`localhost`, `127.0.0.1`, `::1`, and requested `--tls-dns-name` values) |
 | `server.key` | Server private key (0600 permissions) |
 
 ### Trusting the CA

--- a/internal/cmd/proxy.go
+++ b/internal/cmd/proxy.go
@@ -41,6 +41,7 @@ var (
 	proxyAPIURL          string
 	proxyTLS             bool
 	proxyTLSDir          string
+	proxyTLSDNSNames     []string
 	proxyTrustedBots     []string
 	proxyTrustedUsers    []string
 	proxyOTLPEndpoint    string
@@ -125,6 +126,7 @@ Local usage:
 	cmd.Flags().BoolVar(&proxyForcePublicRepo, "force-public-repos", envutil.GetEnvBool(config.EnvForcePublicRepos, true), "When true (default), forces repos=\"public\" at runtime if the workflow repo is public. Set to false to disable.")
 	cmd.Flags().BoolVar(&proxyTLS, "tls", false, "Enable HTTPS with auto-generated self-signed certificates")
 	cmd.Flags().StringVar(&proxyTLSDir, "tls-dir", "", "Directory for TLS certificates (default: <log-dir>/proxy-tls)")
+	cmd.Flags().StringSliceVar(&proxyTLSDNSNames, "tls-dns-name", nil, "Additional DNS name for the generated TLS certificate (repeatable or comma-separated; requires --tls)")
 	cmd.Flags().StringSliceVar(&proxyTrustedBots, "trusted-bots", nil, "Additional trusted bot usernames (comma-separated, extends built-in list)")
 	cmd.Flags().StringSliceVar(&proxyTrustedUsers, "trusted-users", nil, "User logins that receive approved integrity (comma-separated)")
 	registerTracingFlags(cmd, &proxyOTLPEndpoint, &proxyOTLPService, &proxyOTLPSampleRate,
@@ -195,6 +197,10 @@ func resolveEnclaveProxyConfig(
 func runProxy(cmd *cobra.Command, args []string) error {
 	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	if len(proxyTLSDNSNames) > 0 && !proxyTLS {
+		return fmt.Errorf("--tls-dns-name requires --tls")
+	}
 
 	enclavePolicyRaw := os.Getenv(enclavegithub.EnvPolicyJSON)
 	enclaveCapabilityKey := os.Getenv(enclavegithub.EnvCapabilityKey)
@@ -317,7 +323,7 @@ func runProxy(cmd *cobra.Command, args []string) error {
 			tlsDir = filepath.Join(proxyLogDir, "proxy-tls")
 		}
 		logProxyCmd.Printf("Generating TLS certificates in: %s", tlsDir)
-		tlsCfg, err = proxy.GenerateSelfSignedTLS(tlsDir)
+		tlsCfg, err = proxy.GenerateSelfSignedTLS(tlsDir, proxyTLSDNSNames...)
 		if err != nil {
 			return fmt.Errorf("failed to generate TLS certificates: %w", err)
 		}

--- a/internal/cmd/proxy_test.go
+++ b/internal/cmd/proxy_test.go
@@ -128,6 +128,7 @@ func TestNewProxyCmd_AllFlagsRegistered(t *testing.T) {
 		"github-api-url",
 		"tls",
 		"tls-dir",
+		"tls-dns-name",
 		"trusted-bots",
 		"trusted-users",
 		"otlp-endpoint",
@@ -157,6 +158,18 @@ func TestNewProxyCmd_CommandMetadata(t *testing.T) {
 	// Long description should mention proxy and DIFC
 	assert.Contains(t, cmd.Long, "proxy", "Long description should mention 'proxy'")
 	assert.Contains(t, cmd.Long, "DIFC", "Long description should mention 'DIFC'")
+}
+
+func TestNewProxyCmd_TLSDNSNameAcceptsRepeatedAndCommaSeparatedValues(t *testing.T) {
+	cmd := newProxyCmd()
+	require.NoError(t, cmd.Flags().Parse([]string{
+		"--tls-dns-name", "proxy.internal",
+		"--tls-dns-name", "proxy-a.internal,proxy-b.internal",
+	}))
+
+	got, err := cmd.Flags().GetStringSlice("tls-dns-name")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"proxy.internal", "proxy-a.internal", "proxy-b.internal"}, got)
 }
 
 // TestNewProxyCmd_DefaultFlagValues verifies that flags have the expected defaults
@@ -234,6 +247,15 @@ func TestNewProxyCmd_DefaultFlagValues(t *testing.T) {
 				val, err := cmd.Flags().GetString("tls-dir")
 				require.NoError(t, err)
 				assert.Equal(t, "", val, "--tls-dir default should be empty")
+			},
+		},
+		{
+			flagName: "tls-dns-name",
+			validate: func(t *testing.T, cmd *cobra.Command) {
+				t.Helper()
+				val, err := cmd.Flags().GetStringSlice("tls-dns-name")
+				require.NoError(t, err)
+				assert.Empty(t, val, "--tls-dns-name default should be empty")
 			},
 		},
 		{

--- a/internal/proxy/tls.go
+++ b/internal/proxy/tls.go
@@ -35,6 +35,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/github/gh-aw-mcpg/internal/httputil"
@@ -61,15 +62,19 @@ type TLSConfig struct {
 }
 
 // GenerateSelfSignedTLS creates a self-signed CA and server certificate for
-// localhost. All files are written to dir. The CA cert is suitable for
-// injection into client trust stores.
+// localhost and any additional DNS names. All files are written to dir. The CA
+// cert is suitable for injection into client trust stores.
 //
 // Generated files:
 //   - ca.crt    — CA certificate (share with clients)
-//   - server.crt — Server certificate (localhost + 127.0.0.1)
+//   - server.crt — Server certificate (localhost + 127.0.0.1 + ::1)
 //   - server.key — Server private key
-func GenerateSelfSignedTLS(dir string) (*TLSConfig, error) {
-	logTLS.Print("generating self-signed TLS certificates for localhost")
+func GenerateSelfSignedTLS(dir string, additionalDNSNames ...string) (*TLSConfig, error) {
+	dnsNames, err := normalizeTLSDNSNames(additionalDNSNames)
+	if err != nil {
+		return nil, err
+	}
+	logTLS.Printf("generating self-signed TLS certificates for DNS names: %v", dnsNames)
 
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create TLS directory %s: %w", dir, err)
@@ -132,7 +137,7 @@ func GenerateSelfSignedTLS(dir string) (*TLSConfig, error) {
 			Organization: []string{"MCPG Proxy"},
 			CommonName:   "localhost",
 		},
-		DNSNames:    []string{"localhost"},
+		DNSNames:    dnsNames,
 		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 		NotBefore:   time.Now().Add(-1 * time.Hour),
 		NotAfter:    time.Now().Add(24 * time.Hour),
@@ -184,6 +189,79 @@ func GenerateSelfSignedTLS(dir string) (*TLSConfig, error) {
 		KeyPath:    keyPath,
 		Config:     tlsCfg,
 	}, nil
+}
+
+func normalizeTLSDNSNames(additionalDNSNames []string) ([]string, error) {
+	dnsNames := []string{"localhost"}
+	seen := map[string]struct{}{"localhost": {}}
+
+	for _, name := range additionalDNSNames {
+		if err := validateTLSDNSName(name); err != nil {
+			return nil, fmt.Errorf("invalid TLS DNS name %q: %w", name, err)
+		}
+		normalized := strings.ToLower(name)
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		dnsNames = append(dnsNames, normalized)
+	}
+	return dnsNames, nil
+}
+
+func validateTLSDNSName(name string) error {
+	if name == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if name != strings.TrimSpace(name) {
+		return fmt.Errorf("must not contain surrounding whitespace")
+	}
+	if len(name) > 253 {
+		return fmt.Errorf("must not exceed 253 characters")
+	}
+	if strings.HasPrefix(name, ".") || strings.HasSuffix(name, ".") {
+		return fmt.Errorf("must not begin or end with a dot")
+	}
+	if net.ParseIP(name) != nil || isIPLikeTLSName(name) {
+		return fmt.Errorf("must be a DNS name, not an IP address")
+	}
+
+	hasLetter := false
+	for _, label := range strings.Split(name, ".") {
+		if len(label) == 0 || len(label) > 63 {
+			return fmt.Errorf("labels must contain 1 to 63 characters")
+		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return fmt.Errorf("labels must not begin or end with a hyphen")
+		}
+		for _, char := range label {
+			switch {
+			case char >= 'a' && char <= 'z', char >= 'A' && char <= 'Z':
+				hasLetter = true
+			case char >= '0' && char <= '9', char == '-':
+			default:
+				return fmt.Errorf("must contain only ASCII letters, digits, hyphens, and dots")
+			}
+		}
+	}
+	if !hasLetter {
+		return fmt.Errorf("must contain at least one ASCII letter")
+	}
+	return nil
+}
+
+func isIPLikeTLSName(name string) bool {
+	hasSeparator := false
+	for _, char := range name {
+		if char == '.' || char == ':' {
+			hasSeparator = true
+			continue
+		}
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return hasSeparator
 }
 
 func randomSerial() (*big.Int, error) {

--- a/internal/proxy/tls_test.go
+++ b/internal/proxy/tls_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -122,14 +123,84 @@ func TestGenerateSelfSignedTLS(t *testing.T) {
 		assert.True(t, foundLoopback6, "server cert should cover ::1")
 	})
 
-	t.Run("key files have restricted permissions", func(t *testing.T) {
+	t.Run("server cert includes requested DNS names", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			requested []string
+			want      []string
+		}{
+			{
+				name:      "one",
+				requested: []string{"awf-enclave-github-proxy"},
+				want:      []string{"localhost", "awf-enclave-github-proxy"},
+			},
+			{
+				name:      "multiple normalized and deduplicated",
+				requested: []string{"awf-enclave-github-proxy", "Proxy.Internal", "awf-enclave-github-proxy", "LOCALHOST"},
+				want:      []string{"localhost", "awf-enclave-github-proxy", "proxy.internal"},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				dir := t.TempDir()
+				tlsCfg, err := GenerateSelfSignedTLS(dir, tt.requested...)
+				require.NoError(t, err)
+
+				leaf, err := x509.ParseCertificate(tlsCfg.Config.Certificates[0].Certificate[0])
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, leaf.DNSNames)
+				assert.True(t, containsIP(leaf.IPAddresses, net.IPv4(127, 0, 0, 1)))
+				assert.True(t, containsIP(leaf.IPAddresses, net.IPv6loopback))
+			})
+		}
+	})
+
+	t.Run("invalid requested DNS names fail before writing files", func(t *testing.T) {
+		invalidNames := []string{
+			"",
+			" proxy.internal",
+			"proxy.internal ",
+			"*.internal",
+			"127.0.0.1",
+			"::1",
+			"999.1.2.3",
+			"12345",
+			".internal",
+			"internal.",
+			"proxy..internal",
+			"-proxy.internal",
+			"proxy-.internal",
+			"proxy_internal",
+			"proxy/internal",
+			"prøxy.internal",
+			strings.Repeat("a", 64) + ".internal",
+			strings.Repeat("a", 254),
+		}
+		for _, name := range invalidNames {
+			t.Run(name, func(t *testing.T) {
+				dir := filepath.Join(t.TempDir(), "tls")
+				tlsCfg, err := GenerateSelfSignedTLS(dir, name)
+				require.Error(t, err)
+				assert.Nil(t, tlsCfg)
+				assert.NoDirExists(t, dir)
+			})
+		}
+	})
+
+	t.Run("generated files preserve certificate and key permissions", func(t *testing.T) {
 		dir := t.TempDir()
 		tlsCfg, err := GenerateSelfSignedTLS(dir)
 		require.NoError(t, err)
 
-		info, err := os.Stat(tlsCfg.KeyPath)
-		require.NoError(t, err)
-		assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "private key should be owner-only")
+		for path, expected := range map[string]os.FileMode{
+			tlsCfg.CACertPath: 0644,
+			tlsCfg.CertPath:   0644,
+			tlsCfg.KeyPath:    0600,
+		} {
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			assert.Equal(t, expected, info.Mode().Perm())
+		}
 	})
 
 	t.Run("creates directory if missing", func(t *testing.T) {
@@ -196,6 +267,15 @@ func TestGenerateSelfSignedTLS(t *testing.T) {
 		require.NotEmpty(t, serverCert.Issuer.Organization)
 		assert.Equal(t, "MCPG Proxy", serverCert.Issuer.Organization[0])
 	})
+}
+
+func containsIP(ips []net.IP, target net.IP) bool {
+	for _, ip := range ips {
+		if ip.Equal(target) {
+			return true
+		}
+	}
+	return false
 }
 
 // TestWritePEM_InvalidPath verifies that writePEM returns an error when the


### PR DESCRIPTION
## Summary

- add repeatable/comma-separated `awmg proxy --tls-dns-name <name>` support
- preserve the default `localhost`, `127.0.0.1`, and `::1` SANs
- validate requested SANs as strict ASCII DNS hostnames and normalize/deduplicate them deterministically
- document the flag and cover defaults, requested names, invalid inputs, and certificate file permissions

## Validation

- `go test ./internal/proxy ./internal/cmd`
- `make agent-finished`

Fixes the TLS hostname mismatch exposed by github/gh-aw-firewall smoke run `33004295192` without weakening certificate verification or coupling mcpg to the AWF container alias.