### PR TITLE
Fix duplicate Rust guard definitions

### DIFF
--- a/guards/github-guard/rust-guard/src/labels/constants.rs
+++ b/guards/github-guard/rust-guard/src/labels/constants.rs
@@ -107,8 +107,6 @@ pub mod field_names {
     pub const AUTHOR_ASSOCIATION_CAMEL: &str = "authorAssociation";
     pub const LOGIN: &str = "login";
     pub const IS_ERROR: &str = "isError";
-    pub const AUTHOR_ASSOCIATION: &str = "author_association";
-    pub const AUTHOR_ASSOCIATION_CAMEL: &str = "authorAssociation";
 }
 
 /// Canonical repo `visibility` field string values, used to avoid silent

--- a/guards/github-guard/rust-guard/src/labels/helpers.rs
+++ b/guards/github-guard/rust-guard/src/labels/helpers.rs
@@ -1683,12 +1683,6 @@ pub(crate) fn author_association_floor_from_str(
     }
 }
 
-/// Returns `true` if `raw` (case-insensitively, after trimming) matches any of `values`.
-fn matches_any_ci(raw: &str, values: &[&str]) -> bool {
-    let raw = raw.trim();
-    values.iter().any(|value| raw.eq_ignore_ascii_case(value))
-}
-
 /// Extract the author login from an item, checking common GitHub API fields.
 /// Returns empty string if no login found.
 fn extract_author_login(item: &Value) -> &str {


### PR DESCRIPTION
## Summary

- remove duplicate author association field constants
- remove the duplicate case-insensitive matching helper
- restore Rust guard compilation in `make agent-finished`

## Verification

- `make agent-finished`
- 647 Rust guard tests passed
- no lint warnings