### PR TITLE
Interpret delegation TTL wire values as seconds

### DIFF
--- a/internal/cmd/proxy.go
+++ b/internal/cmd/proxy.go
@@ -70,14 +70,18 @@ func resolveDelegationProxyConfig() (*proxy.DelegationConfig, string, error) {
 	if envelopeJSON == "" || capabilityKey == "" || statePath == "" || generationRaw == "" || controlListenAddr == "" {
 		return nil, "", fmt.Errorf("MCP_GATEWAY_DELEGATION_ENVELOPE, %s, MCP_GATEWAY_DELEGATION_STATE_PATH, %s, and MCP_GATEWAY_DELEGATION_GENERATION must be configured together", delegation.EnvControlCapabilityKey, delegation.EnvControlListenAddr)
 	}
-	var envelope delegation.Envelope
+	var envelopeWire delegation.EnvelopeWire
 	decoder := json.NewDecoder(bytes.NewReader([]byte(envelopeJSON)))
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&envelope); err != nil {
+	if err := decoder.Decode(&envelopeWire); err != nil {
 		return nil, "", fmt.Errorf("invalid delegation envelope: %w", err)
 	}
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return nil, "", fmt.Errorf("invalid delegation envelope: trailing JSON")
+	}
+	envelope, err := envelopeWire.ToEnvelope()
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid delegation envelope: %w", err)
 	}
 	generation, err := strconv.ParseUint(generationRaw, 10, 64)
 	if err != nil {
@@ -87,7 +91,7 @@ func resolveDelegationProxyConfig() (*proxy.DelegationConfig, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	store, err := delegation.LoadStore(statePath, &envelope, generation)
+	store, err := delegation.LoadStore(statePath, envelope, generation)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/cmd/proxy_test.go
+++ b/internal/cmd/proxy_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/github/gh-aw-mcpg/internal/delegation"
 	"github.com/github/gh-aw-mcpg/internal/difc"
 	"github.com/github/gh-aw-mcpg/internal/guard"
 	"github.com/spf13/cobra"
@@ -15,6 +17,45 @@ import (
 	"github.com/github/gh-aw-mcpg/internal/config"
 	"github.com/github/gh-aw-mcpg/internal/util"
 )
+
+func TestResolveDelegationProxyConfig_MaxIdentityTTLIsSeconds(t *testing.T) {
+	t.Setenv("MCP_GATEWAY_DELEGATION_ENVELOPE", `{
+		"run_id":"run-1",
+		"enclave_backend":"backend-1",
+		"allowed_repositories":["github/gh-aw"],
+		"tool_policy":"github-repository-read-v1",
+		"allowed_schema_hashes":["sha256:test"],
+		"max_identity_ttl":120,
+		"expires_at":"2030-01-01T00:00:00Z"
+	}`)
+	t.Setenv(delegation.EnvControlCapabilityKey, strings.Repeat("a", 32))
+	t.Setenv("MCP_GATEWAY_DELEGATION_STATE_PATH", filepath.Join(t.TempDir(), "state.json"))
+	t.Setenv("MCP_GATEWAY_DELEGATION_GENERATION", "1")
+	t.Setenv(delegation.EnvControlListenAddr, "127.0.0.1:0")
+
+	config, _, err := resolveDelegationProxyConfig()
+	require.NoError(t, err)
+
+	request := delegation.CreateOrConfirmRequest{
+		RunID:          "run-1",
+		EnclaveBackend: "backend-1",
+		EnclaveEntryID: "entry-1",
+		InvocationID:   "invocation-1",
+		Repository:     "github/gh-aw",
+		ToolPolicy:     delegation.ToolPolicyGitHubRepositoryReadV1,
+		SchemaHash:     "sha256:test",
+		RequestedTTL:   120 * time.Second,
+		IdempotencyKey: "key-1",
+	}
+	_, err = config.Store.CreateOrConfirm(request)
+	require.NoError(t, err)
+
+	request.InvocationID = "invocation-2"
+	request.IdempotencyKey = "key-2"
+	request.RequestedTTL = 121 * time.Second
+	_, err = config.Store.CreateOrConfirm(request)
+	assert.Error(t, err, "a requested TTL above the 120-second wire ceiling must be rejected")
+}
 
 // TestDetectGuardWasm_FileNotFound tests that detectGuardWasm returns empty string
 // when the baked-in guard at guard.ContainerGuardWasmPath does not exist and

--- a/internal/delegation/envelope.go
+++ b/internal/delegation/envelope.go
@@ -16,14 +16,14 @@ import (
 type Envelope struct {
 	// RunID is the workflow run this envelope, and every identity minted
 	// from it, is bound to.
-	RunID string `json:"run_id"`
+	RunID string
 	// EnclaveBackend is the single AWF enclave backend identities may be
 	// bound to.
-	EnclaveBackend string `json:"enclave_backend"`
+	EnclaveBackend string
 	// AllowedRepositories is the closed set of canonical owner/repo
 	// selectors the compiler admitted for this run. Selectors are compared
 	// as exact ASCII byte sequences; no normalization is performed.
-	AllowedRepositories []string `json:"allowed_repositories"`
+	AllowedRepositories []string
 	// AllowedOwners is the closed set of canonical repository owners the
 	// compiler admitted for this run's dynamic enclaves. When set, AWF may
 	// select any exact repository under an allowed owner at invocation
@@ -32,28 +32,28 @@ type Envelope struct {
 	// its owner segment is a member of AllowedOwners; one identity remains
 	// bound to exactly one repository either way. Owners are compared as
 	// exact ASCII byte sequences; no normalization is performed.
-	AllowedOwners []string `json:"allowed_owners,omitempty"`
+	AllowedOwners []string
 	// ToolPolicy is the single delegated tool policy this envelope allows.
 	// Only ToolPolicyGitHubRepositoryReadV1 is currently supported.
-	ToolPolicy string `json:"tool_policy"`
+	ToolPolicy string
 	// AllowedSchemaHashes is the closed set of finite response schema
 	// hashes the compiler approved for this run. It may be left empty to
 	// use MaxDynamicSchemaHashes' bounded runtime admission instead.
-	AllowedSchemaHashes []string `json:"allowed_schema_hashes"`
+	AllowedSchemaHashes []string
 	// MaxDynamicSchemaHashes bounds how many distinct invocation-supplied
 	// schema hashes may be admitted at runtime when AllowedSchemaHashes is
 	// empty, so a dynamic enclave can be authorized against a bounded
 	// finite-schema policy without every hash being enumerated at compile
 	// time. It has no effect when AllowedSchemaHashes is non-empty: in
 	// that case only the exact compiled hashes are ever admitted.
-	MaxDynamicSchemaHashes int `json:"max_dynamic_schema_hashes,omitempty"`
+	MaxDynamicSchemaHashes int
 	// MaxIdentityTTL bounds how long any single delegated identity may
 	// live, and therefore how long an executor bearer remains valid.
-	MaxIdentityTTL time.Duration `json:"max_identity_ttl"`
+	MaxIdentityTTL time.Duration
 	// ExpiresAt is the envelope's own absolute expiry, no later than the
 	// workflow job lifetime. No identity may be created once the envelope
 	// itself has expired.
-	ExpiresAt time.Time `json:"expires_at"`
+	ExpiresAt time.Time
 }
 
 // Validate checks the envelope's own invariants. It does not check any

--- a/internal/delegation/envelope_test.go
+++ b/internal/delegation/envelope_test.go
@@ -1,12 +1,47 @@
 package delegation
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEnvelopeWire_MaxIdentityTTLIsSeconds(t *testing.T) {
+	var wire EnvelopeWire
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"run_id":"run-123",
+		"enclave_backend":"awf-enclave",
+		"allowed_repositories":["github/gh-aw"],
+		"tool_policy":"github-repository-read-v1",
+		"allowed_schema_hashes":["sha256:abc"],
+		"max_identity_ttl":120,
+		"expires_at":"2030-01-01T00:00:00Z"
+	}`), &wire))
+
+	envelope, err := wire.ToEnvelope()
+	require.NoError(t, err)
+	assert.Equal(t, 120*time.Second, envelope.MaxIdentityTTL)
+}
+
+func TestEnvelopeWire_RejectsInvalidSeconds(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int64
+	}{
+		{name: "zero", seconds: 0},
+		{name: "negative", seconds: -1},
+		{name: "overflow", seconds: int64(^uint64(0)>>1)/int64(time.Second) + 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := (EnvelopeWire{MaxIdentityTTLSeconds: test.seconds}).ToEnvelope()
+			assert.Error(t, err)
+		})
+	}
+}
 
 func validEnvelope() *Envelope {
 	return &Envelope{

--- a/internal/delegation/identity.go
+++ b/internal/delegation/identity.go
@@ -2,41 +2,41 @@ package delegation
 
 import "time"
 
-// CreateOrConfirmRequest is an AWF-authenticated request to create or
-// confirm exactly one delegated identity. Every field must be a strict
-// subset of the compiler-installed Envelope; the Store rejects anything
-// wider than the envelope allows.
+// CreateOrConfirmRequest is the internal duration-based form of an
+// AWF-authenticated request to create or confirm exactly one delegated
+// identity. Every field must be a strict subset of the compiler-installed
+// Envelope; the Store rejects anything wider than the envelope allows.
 type CreateOrConfirmRequest struct {
 	// RunID must equal the envelope's bound workflow run.
-	RunID string `json:"run_id"`
+	RunID string
 	// EnclaveBackend must equal the envelope's single AWF enclave backend.
-	EnclaveBackend string `json:"enclave_backend"`
+	EnclaveBackend string
 	// EnclaveEntryID identifies the enclave entry (frontmatter block) this
 	// invocation belongs to.
-	EnclaveEntryID string `json:"enclave_entry_id"`
+	EnclaveEntryID string
 	// InvocationID identifies one bounded enclave invocation.
-	InvocationID string `json:"invocation_id"`
+	InvocationID string
 	// Repository is the canonical, exact-byte owner/repo selector chosen
 	// for this invocation. It must already be canonical: the Store performs
 	// no trimming, case folding, Unicode normalization, or URL decoding.
-	Repository string `json:"repository"`
+	Repository string
 	// ToolPolicy must equal ToolPolicyGitHubRepositoryReadV1.
-	ToolPolicy string `json:"tool_policy"`
+	ToolPolicy string
 	// SchemaHash is the finite response schema hash approved for this
 	// invocation; it must be a member of the envelope's allowed set.
-	SchemaHash string `json:"schema_hash"`
+	SchemaHash string
 	// AdmittedDefaultBranchSHA is the default-branch SHA AWF resolved
 	// during live-read admission, when known at request time.
-	AdmittedDefaultBranchSHA string `json:"admitted_default_branch_sha,omitempty"`
+	AdmittedDefaultBranchSHA string
 	// RequestedTTL bounds how long the identity should live; it is capped
 	// by (and must not exceed) the envelope's MaxIdentityTTL.
-	RequestedTTL time.Duration `json:"requested_ttl"`
+	RequestedTTL time.Duration
 	// InvocationExpiresAt is the absolute deadline of the invocation, when
 	// one is supplied by AWF. An identity can never outlive this deadline.
-	InvocationExpiresAt time.Time `json:"invocation_expires_at,omitempty"`
+	InvocationExpiresAt time.Time
 	// IdempotencyKey deduplicates retried create/confirm calls for the same
 	// (RunID, EnclaveEntryID, InvocationID, Repository) tuple.
-	IdempotencyKey string `json:"idempotency_key"`
+	IdempotencyKey string
 }
 
 // delegationBinding is the request/identity tuple that must remain identical

--- a/internal/delegation/identity_test.go
+++ b/internal/delegation/identity_test.go
@@ -1,12 +1,22 @@
 package delegation
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCreateOrConfirmRequestWire_RequestedTTLIsSeconds(t *testing.T) {
+	var wire CreateOrConfirmRequestWire
+	require.NoError(t, json.Unmarshal([]byte(`{"requested_ttl":120}`), &wire))
+
+	request, err := wire.ToRequest()
+	require.NoError(t, err)
+	assert.Equal(t, 120*time.Second, request.RequestedTTL)
+}
 
 func TestIdentityBindingRoundTrip(t *testing.T) {
 	req := validRequest()

--- a/internal/delegation/wire.go
+++ b/internal/delegation/wire.go
@@ -1,0 +1,89 @@
+package delegation
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// EnvelopeWire is the JSON representation installed by the workflow compiler.
+// Duration fields are whole seconds on the wire.
+type EnvelopeWire struct {
+	RunID                  string    `json:"run_id"`
+	EnclaveBackend         string    `json:"enclave_backend"`
+	AllowedRepositories    []string  `json:"allowed_repositories"`
+	AllowedOwners          []string  `json:"allowed_owners,omitempty"`
+	ToolPolicy             string    `json:"tool_policy"`
+	AllowedSchemaHashes    []string  `json:"allowed_schema_hashes"`
+	MaxDynamicSchemaHashes int       `json:"max_dynamic_schema_hashes,omitempty"`
+	MaxIdentityTTLSeconds  int64     `json:"max_identity_ttl"`
+	ExpiresAt              time.Time `json:"expires_at"`
+}
+
+// ToEnvelope validates wire-specific fields and converts them to the internal
+// duration-based representation.
+func (w EnvelopeWire) ToEnvelope() (*Envelope, error) {
+	maxIdentityTTL, err := durationFromWireSeconds("max_identity_ttl", w.MaxIdentityTTLSeconds)
+	if err != nil {
+		return nil, err
+	}
+	return &Envelope{
+		RunID:                  w.RunID,
+		EnclaveBackend:         w.EnclaveBackend,
+		AllowedRepositories:    w.AllowedRepositories,
+		AllowedOwners:          w.AllowedOwners,
+		ToolPolicy:             w.ToolPolicy,
+		AllowedSchemaHashes:    w.AllowedSchemaHashes,
+		MaxDynamicSchemaHashes: w.MaxDynamicSchemaHashes,
+		MaxIdentityTTL:         maxIdentityTTL,
+		ExpiresAt:              w.ExpiresAt,
+	}, nil
+}
+
+// CreateOrConfirmRequestWire is the JSON representation accepted by the
+// private delegation control endpoint. Duration fields are whole seconds.
+type CreateOrConfirmRequestWire struct {
+	RunID                    string    `json:"run_id"`
+	EnclaveBackend           string    `json:"enclave_backend"`
+	EnclaveEntryID           string    `json:"enclave_entry_id"`
+	InvocationID             string    `json:"invocation_id"`
+	Repository               string    `json:"repository"`
+	ToolPolicy               string    `json:"tool_policy"`
+	SchemaHash               string    `json:"schema_hash"`
+	AdmittedDefaultBranchSHA string    `json:"admitted_default_branch_sha,omitempty"`
+	RequestedTTLSeconds      int64     `json:"requested_ttl"`
+	InvocationExpiresAt      time.Time `json:"invocation_expires_at,omitempty"`
+	IdempotencyKey           string    `json:"idempotency_key"`
+}
+
+// ToRequest validates wire-specific fields and converts them to the internal
+// duration-based representation.
+func (w CreateOrConfirmRequestWire) ToRequest() (CreateOrConfirmRequest, error) {
+	requestedTTL, err := durationFromWireSeconds("requested_ttl", w.RequestedTTLSeconds)
+	if err != nil {
+		return CreateOrConfirmRequest{}, err
+	}
+	return CreateOrConfirmRequest{
+		RunID:                    w.RunID,
+		EnclaveBackend:           w.EnclaveBackend,
+		EnclaveEntryID:           w.EnclaveEntryID,
+		InvocationID:             w.InvocationID,
+		Repository:               w.Repository,
+		ToolPolicy:               w.ToolPolicy,
+		SchemaHash:               w.SchemaHash,
+		AdmittedDefaultBranchSHA: w.AdmittedDefaultBranchSHA,
+		RequestedTTL:             requestedTTL,
+		InvocationExpiresAt:      w.InvocationExpiresAt,
+		IdempotencyKey:           w.IdempotencyKey,
+	}, nil
+}
+
+func durationFromWireSeconds(field string, seconds int64) (time.Duration, error) {
+	if seconds <= 0 {
+		return 0, fmt.Errorf("%s must be a positive number of seconds", field)
+	}
+	if seconds > math.MaxInt64/int64(time.Second) {
+		return 0, fmt.Errorf("%s exceeds the maximum supported duration", field)
+	}
+	return time.Duration(seconds) * time.Second, nil
+}

--- a/internal/proxy/delegation.go
+++ b/internal/proxy/delegation.go
@@ -55,8 +55,13 @@ func (h *proxyHandler) handleDelegationControl(w http.ResponseWriter, r *http.Re
 
 	switch r.URL.Path {
 	case delegationControlPath + "create-or-confirm":
-		var request delegation.CreateOrConfirmRequest
-		if !decodeDelegationJSON(w, r, &request) {
+		var requestWire delegation.CreateOrConfirmRequestWire
+		if !decodeDelegationJSON(w, r, &requestWire) {
+			return
+		}
+		request, err := requestWire.ToRequest()
+		if err != nil {
+			httputil.WriteErrorResponse(w, http.StatusBadRequest, "invalid_delegation_request", "invalid delegation request")
 			return
 		}
 		result, err := h.server.delegation.store.CreateOrConfirm(request)

--- a/internal/proxy/delegation_control_test.go
+++ b/internal/proxy/delegation_control_test.go
@@ -24,7 +24,7 @@ func newTestDelegationHandler(t *testing.T) (*proxyHandler, string, []byte) {
 		AllowedRepositories: []string{"github/gh-aw"},
 		ToolPolicy:          delegation.ToolPolicyGitHubRepositoryReadV1,
 		AllowedSchemaHashes: []string{"sha256:test"},
-		MaxIdentityTTL:      time.Minute,
+		MaxIdentityTTL:      120 * time.Second,
 		ExpiresAt:           time.Now().Add(time.Hour),
 	}
 	store, err := delegation.NewStore(envelope, 1)
@@ -48,7 +48,7 @@ func newTestDelegationHandler(t *testing.T) (*proxyHandler, string, []byte) {
 		"repository": "github/gh-aw",
 		"tool_policy": "` + string(delegation.ToolPolicyGitHubRepositoryReadV1) + `",
 		"schema_hash": "sha256:test",
-		"requested_ttl": 60000000000,
+		"requested_ttl": 120,
 		"idempotency_key": "key-1"
 	}`)
 
@@ -97,6 +97,15 @@ func TestHandleDelegationControl_CreateOrConfirm(t *testing.T) {
 		assert.Contains(t, rec.Body.String(), "handle")
 	})
 
+	t.Run("rejects requested ttl above envelope ceiling", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		overCeiling := bytes.Replace(body, []byte(`"requested_ttl": 120`), []byte(`"requested_ttl": 121`), 1)
+		req := authedRequest(http.MethodPost, delegationControlPath+"create-or-confirm", overCeiling, capabilityKey)
+		handler.handleDelegationControl(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "delegation_request_denied")
+	})
+
 	t.Run("rejects malformed JSON body", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := authedRequest(http.MethodPost, delegationControlPath+"create-or-confirm", []byte(`{not json`), capabilityKey)
@@ -121,7 +130,7 @@ func TestHandleDelegationControl_CreateOrConfirm(t *testing.T) {
 			"repository": "github/gh-aw",
 			"tool_policy": "` + string(delegation.ToolPolicyGitHubRepositoryReadV1) + `",
 			"schema_hash": "sha256:test",
-			"requested_ttl": 60000000000,
+			"requested_ttl": 120,
 			"idempotency_key": "key-2"
 		}`)
 		req := authedRequest(http.MethodPost, delegationControlPath+"create-or-confirm", badBody, capabilityKey)
@@ -146,7 +155,7 @@ func TestHandleDelegationControl_CreateOrConfirm(t *testing.T) {
 			"repository": "github/gh-aw",
 			"tool_policy": "` + string(delegation.ToolPolicyGitHubRepositoryReadV1) + `",
 			"schema_hash": "sha256:test",
-			"requested_ttl": 60000000000,
+			"requested_ttl": 120,
 			"idempotency_key": "key-persist-fail"
 		}`)
 		req := authedRequest(http.MethodPost, delegationControlPath+"create-or-confirm", freshBody, capabilityKey)

--- a/internal/proxy/delegation_logging_test.go
+++ b/internal/proxy/delegation_logging_test.go
@@ -278,16 +278,16 @@ func TestDelegationControlLoggingRedactsPrivateSelectors(t *testing.T) {
 	}
 
 	logs := captureProxyLogs(t, func() {
-		require.Equal(t, http.StatusOK, post("create-or-confirm", delegation.CreateOrConfirmRequest{
-			RunID:          redactionRunID,
-			EnclaveBackend: "awf-enclave",
-			EnclaveEntryID: redactionEntryID,
-			InvocationID:   redactionInvID,
-			Repository:     redactionSelector,
-			ToolPolicy:     delegation.ToolPolicyGitHubRepositoryReadV1,
-			SchemaHash:     "sha256:test",
-			RequestedTTL:   time.Minute,
-			IdempotencyKey: "idem-1",
+		require.Equal(t, http.StatusOK, post("create-or-confirm", delegation.CreateOrConfirmRequestWire{
+			RunID:               redactionRunID,
+			EnclaveBackend:      "awf-enclave",
+			EnclaveEntryID:      redactionEntryID,
+			InvocationID:        redactionInvID,
+			Repository:          redactionSelector,
+			ToolPolicy:          delegation.ToolPolicyGitHubRepositoryReadV1,
+			SchemaHash:          "sha256:test",
+			RequestedTTLSeconds: 60,
+			IdempotencyKey:      "idem-1",
 		}).Code)
 
 		require.Equal(t, http.StatusOK, post("status", map[string]string{

--- a/internal/proxy/delegation_test.go
+++ b/internal/proxy/delegation_test.go
@@ -33,10 +33,10 @@ func TestDelegationControlCreateRequiresCapability(t *testing.T) {
 	require.NoError(t, err)
 	handler := &proxyHandler{server: &Server{delegation: &delegationState{store: store, capability: capability, statePath: t.TempDir() + "/state.json"}}}
 
-	body, err := json.Marshal(delegation.CreateOrConfirmRequest{
+	body, err := json.Marshal(delegation.CreateOrConfirmRequestWire{
 		RunID: "run", EnclaveBackend: "backend", EnclaveEntryID: "entry", InvocationID: "inv",
 		Repository: "github/gh-aw", ToolPolicy: delegation.ToolPolicyGitHubRepositoryReadV1,
-		SchemaHash: "sha256:test", RequestedTTL: time.Minute, IdempotencyKey: "key",
+		SchemaHash: "sha256:test", RequestedTTLSeconds: 60, IdempotencyKey: "key",
 	})
 	require.NoError(t, err)
 
@@ -68,10 +68,10 @@ func TestDelegationControlStatusAndReconcile(t *testing.T) {
 	require.NoError(t, err)
 	handler := &proxyHandler{server: &Server{delegation: &delegationState{store: store, capability: capability, statePath: t.TempDir() + "/state.json"}}}
 
-	createBody, err := json.Marshal(delegation.CreateOrConfirmRequest{
+	createBody, err := json.Marshal(delegation.CreateOrConfirmRequestWire{
 		RunID: "run", EnclaveBackend: "backend", EnclaveEntryID: "entry", InvocationID: "inv",
 		Repository: "github/gh-aw", ToolPolicy: delegation.ToolPolicyGitHubRepositoryReadV1,
-		SchemaHash: "sha256:test", RequestedTTL: time.Minute, IdempotencyKey: "key",
+		SchemaHash: "sha256:test", RequestedTTLSeconds: 60, IdempotencyKey: "key",
 	})
 	require.NoError(t, err)
 	createReq := httptest.NewRequest(http.MethodPost, delegationControlPath+"create-or-confirm", bytes.NewReader(createBody))


### PR DESCRIPTION
## Summary

- add explicit delegation envelope and create-or-confirm wire DTOs with TTL values represented as whole seconds
- validate positive, non-overflowing second values before converting them to internal `time.Duration` values
- preserve the existing duration-based store and persisted identity representation
- update control-plane and configuration tests to pin `120` on the wire as 120 seconds and reject requests above the envelope ceiling

This is the `github/gh-aw-mcpg` part of the coordinated seconds-only TTL wire contract across `github/gh-aw`, `github/gh-aw-firewall`, and `github/gh-aw-mcpg`. Companion PRs: [github/gh-aw#59292](https://github.com/github/gh-aw/pull/59292) and [github/gh-aw-firewall#8292](https://github.com/github/gh-aw-firewall/pull/8292).

## Validation

- `go test ./internal/delegation ./internal/proxy ./internal/cmd`
- `make agent-finished`