### PR TITLE
Fix delegation control success logging

### DIFF
--- a/internal/delegation/control_handler.go
+++ b/internal/delegation/control_handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/github/gh-aw-mcpg/internal/util"
 )
 
-var log = logger.New("delegation:control_handler")
+var logControlHandler = logger.ForFile()
 
 // ControlDeps groups the delegation state a control-plane handler needs to
 // authenticate requests, mutate the in-memory store, and persist it. Both
@@ -59,17 +59,17 @@ func HandleControl(w http.ResponseWriter, r *http.Request, deps ControlDeps, log
 		}
 		result, err := deps.Store.CreateOrConfirm(request)
 		if err != nil {
-			log.Printf("create-or-confirm denied: run_hash=%s enclave_entry_id_hash=%s invocation_id_hash=%s", util.HashForLog(request.RunID, 16, ""), util.HashForLog(request.EnclaveEntryID, 16, ""), util.HashForLog(request.InvocationID, 16, ""))
+			logControlHandler.Printf("create-or-confirm denied: run_hash=%s enclave_entry_id_hash=%s invocation_id_hash=%s", util.HashForLog(request.RunID, 16, ""), util.HashForLog(request.EnclaveEntryID, 16, ""), util.HashForLog(request.InvocationID, 16, ""))
 			if !deps.persistState(w) {
 				return
 			}
 			httputil.WriteErrorResponse(w, http.StatusForbidden, "delegation_request_denied", "delegation request denied")
 			return
 		}
-		log.Printf("create-or-confirm succeeded: run_hash=%s enclave_entry_id_hash=%s handle_hash=%s", util.HashForLog(request.RunID, 16, ""), util.HashForLog(request.EnclaveEntryID, 16, ""), util.HashForLog(result.Handle, 16, ""))
 		if !deps.persistState(w) {
 			return
 		}
+		logControlHandler.Printf("create-or-confirm succeeded: run_hash=%s enclave_entry_id_hash=%s invocation_id_hash=%s handle_hash=%s", util.HashForLog(request.RunID, 16, ""), util.HashForLog(request.EnclaveEntryID, 16, ""), util.HashForLog(request.InvocationID, 16, ""), util.HashForLog(result.Handle, 16, ""))
 		httputil.WriteJSONResponse(w, http.StatusOK, result)
 	case ControlPathPrefix + "revoke":
 		var request struct {
@@ -130,11 +130,11 @@ func HandleControl(w http.ResponseWriter, r *http.Request, deps ControlDeps, log
 		// any outstanding labelled state from a prior restart, letting new
 		// dynamic admissions resume.
 		if err := deps.Store.MarkReconciledAndSaveState(deps.StatePath); err != nil {
-			log.Printf("reconcile failed: state_path=%s err=%v", deps.StatePath, err)
+			logControlHandler.Printf("reconcile failed: state_path=%s err=%v", deps.StatePath, err)
 			httputil.WriteErrorResponse(w, http.StatusInternalServerError, "delegation_state_persist_failed", "delegation state persistence failed")
 			return
 		}
-		log.Print("Reconcile succeeded, recovery-incomplete flag cleared")
+		logControlHandler.Print("Reconcile succeeded, recovery-incomplete flag cleared")
 		httputil.WriteJSONResponse(w, http.StatusOK, map[string]bool{"reconciled": true})
 	default:
 		http.NotFound(w, r)

--- a/internal/delegation/control_handler_logging_test.go
+++ b/internal/delegation/control_handler_logging_test.go
@@ -1,0 +1,95 @@
+package delegation
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/github/gh-aw-mcpg/internal/logger"
+	"github.com/github/gh-aw-mcpg/internal/util"
+)
+
+func captureControlHandlerLogs(t *testing.T, f func()) string {
+	t.Helper()
+	t.Setenv("DEBUG", "*")
+	t.Setenv("DEBUG_COLORS", "0")
+
+	previous := logControlHandler
+	logControlHandler = logger.New("delegation:control_handler")
+	require.True(t, logControlHandler.Enabled(), "the capture harness must actually enable debug logging")
+	t.Cleanup(func() { logControlHandler = previous })
+
+	original := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	var (
+		wg  sync.WaitGroup
+		buf bytes.Buffer
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, r)
+	}()
+
+	func() {
+		defer func() {
+			os.Stderr = original
+			_ = w.Close()
+		}()
+		f()
+	}()
+	wg.Wait()
+	_ = r.Close()
+	return buf.String()
+}
+
+func TestHandleControl_CreateOrConfirmSuccessLogging(t *testing.T) {
+	wire := CreateOrConfirmRequestWire{
+		RunID:               "run-123",
+		EnclaveBackend:      "awf-enclave",
+		EnclaveEntryID:      "entry-1",
+		InvocationID:        "inv-1",
+		Repository:          "github/gh-aw",
+		ToolPolicy:          ToolPolicyGitHubRepositoryReadV1,
+		SchemaHash:          "sha256:abc",
+		RequestedTTLSeconds: 60,
+		IdempotencyKey:      "idem-1",
+	}
+
+	t.Run("logs success with invocation hash after persistence succeeds", func(t *testing.T) {
+		deps, secret := newControlTestDeps(t)
+		var responseStatus int
+		logs := captureControlHandlerLogs(t, func() {
+			responseStatus = doControlRequest(t, deps, secret, ControlPathPrefix+"create-or-confirm", http.MethodPost, wire).Code
+		})
+
+		require.Equal(t, http.StatusOK, responseStatus)
+		assert.Contains(t, logs, "create-or-confirm succeeded:")
+		assert.Contains(t, logs, "invocation_id_hash="+util.HashForLog(wire.InvocationID, 16, ""))
+	})
+
+	t.Run("does not log success when persistence fails", func(t *testing.T) {
+		deps, secret := newControlTestDeps(t)
+		badDir := filepath.Join(t.TempDir(), "not-a-file")
+		require.NoError(t, os.MkdirAll(badDir, 0o755))
+		deps.StatePath = badDir
+
+		var responseStatus int
+		logs := captureControlHandlerLogs(t, func() {
+			responseStatus = doControlRequest(t, deps, secret, ControlPathPrefix+"create-or-confirm", http.MethodPost, wire).Code
+		})
+
+		require.Equal(t, http.StatusInternalServerError, responseStatus)
+		assert.NotContains(t, logs, "create-or-confirm succeeded:")
+	})
+}


### PR DESCRIPTION
## Summary

Applies the review feedback that was missed before #12908 merged:

- derive the control handler logger namespace with `logger.ForFile()`
- emit `create-or-confirm` success only after state persistence succeeds
- include the hashed invocation ID in the success event
- add regression coverage for successful and failed persistence paths

## Validation

- `make agent-finished`

Closes the unresolved review feedback from #12908.